### PR TITLE
JBRULES-2960: ClassPathResource fails to get last version if the underlying ClassLoader uses a cache.

### DIFF
--- a/drools-container/drools-spring/src/main/java/org/drools/container/spring/beans/DroolsResourceAdapter.java
+++ b/drools-container/drools-spring/src/main/java/org/drools/container/spring/beans/DroolsResourceAdapter.java
@@ -13,98 +13,94 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.drools.container.spring.beans;
 
 import org.drools.builder.ResourceConfiguration;
 import org.drools.builder.ResourceType;
 import org.drools.io.Resource;
 import org.drools.io.impl.ClassPathResource;
-import org.drools.io.impl.URLClassPathResource;
 import org.drools.io.impl.UrlResource;
 import org.springframework.beans.factory.InitializingBean;
 
 public class DroolsResourceAdapter
-    implements
-    InitializingBean {
-    private Resource              resource;
-    private ResourceType          resourceType;
+        implements
+        InitializingBean {
+
+    private Resource resource;
+    private ResourceType resourceType;
     private ResourceConfiguration resourceConfiguration;
 
     public DroolsResourceAdapter() {
-
     }
 
     public DroolsResourceAdapter(String resource,
-                                 ResourceType resourceType,
-                                 ResourceConfiguration resourceConfiguration) {
+            ResourceType resourceType,
+            ResourceConfiguration resourceConfiguration) {
         super();
-        setResource( resource );
+        setResource(resource);
         this.resourceType = resourceType;
         this.resourceConfiguration = resourceConfiguration;
     }
 
     public void setResource(String resource) {
-        if ( resource.trim().startsWith( "classpath:" ) ) {
-            this.resource = new ClassPathResource( resource.substring( resource.indexOf( ':' ) + 1 ),
-                                                   ClassPathResource.class.getClassLoader() );
-        } else if (resource.trim().startsWith( "URLClasspath:" )){
-            this.resource = new URLClassPathResource( resource.substring( resource.indexOf( ':' ) + 1 ) );
+        if (resource.trim().startsWith("classpath:")) {
+            this.resource = new ClassPathResource(resource.substring(resource.indexOf(':') + 1),
+                    ClassPathResource.class.getClassLoader());
         } else {
-            this.resource = new UrlResource( resource );
+            this.resource = new UrlResource(resource);
         }
     }
 
     public void setBasicAuthenticationEnabled(Boolean enabled) {
-        if ( enabled && !(this.resource instanceof UrlResource) ) {
-            throw new IllegalArgumentException( "Authentication Attributes are only valid for URL Resources" );
+        if (enabled && !(this.resource instanceof UrlResource)) {
+            throw new IllegalArgumentException("Authentication Attributes are only valid for URL Resources");
         }
 
-        if ( this.resource instanceof UrlResource ) {
-            ((UrlResource) this.resource).setBasicAuthentication( enabled ? "enabled" : "disabled" );
+        if (this.resource instanceof UrlResource) {
+            ((UrlResource) this.resource).setBasicAuthentication(enabled ? "enabled" : "disabled");
         }
     }
 
     public void setBasicAuthenticationUsername(String username) {
-        if ( !(this.resource instanceof UrlResource) ) {
-            throw new IllegalArgumentException( "Authentication Attributes are only valid for URL Resources" );
+        if (!(this.resource instanceof UrlResource)) {
+            throw new IllegalArgumentException("Authentication Attributes are only valid for URL Resources");
         }
-        ((UrlResource) this.resource).setUsername( username );
+        ((UrlResource) this.resource).setUsername(username);
     }
 
     public void setBasicAuthenticationPassword(String password) {
-        if ( !(this.resource instanceof UrlResource) ) {
-            throw new IllegalArgumentException( "Authentication Attributes are only valid for URL Resources" );
+        if (!(this.resource instanceof UrlResource)) {
+            throw new IllegalArgumentException("Authentication Attributes are only valid for URL Resources");
         }
-        ((UrlResource) this.resource).setPassword( password );
+        ((UrlResource) this.resource).setPassword(password);
     }
 
     public DroolsResourceAdapter(String resource,
-                                 ResourceType resourceType) {
-        this( resource,
-              resourceType,
-              null );
+            ResourceType resourceType) {
+        this(resource,
+                resourceType,
+                null);
     }
 
     public DroolsResourceAdapter(String resource) {
-        this( resource,
-              ResourceType.DRL,
-              null );
+        this(resource,
+                ResourceType.DRL,
+                null);
     }
 
     public DroolsResourceAdapter(String resource,
-                                 String resourceType,
-                                 ResourceConfiguration resourceConfiguration) {
-        this( resource,
-              ResourceType.getResourceType( resourceType ),
-              resourceConfiguration );
+            String resourceType,
+            ResourceConfiguration resourceConfiguration) {
+        this(resource,
+                ResourceType.getResourceType(resourceType),
+                resourceConfiguration);
     }
 
     public DroolsResourceAdapter(String resource,
-                                 String resourceType) {
-        this( resource,
-              resourceType,
-              null );
+            String resourceType) {
+        this(resource,
+                resourceType,
+                null);
     }
 
     public Resource getDroolsResource() {
@@ -128,14 +124,14 @@ public class DroolsResourceAdapter
     }
 
     public void afterPropertiesSet() throws Exception {
-        if ( resource == null ) {
-            throw new IllegalArgumentException( "resource property is mandatory" );
+        if (resource == null) {
+            throw new IllegalArgumentException("resource property is mandatory");
         }
-        if ( resourceType == null ) {
-            throw new IllegalArgumentException( "resourceType property is mandatory" );
+        if (resourceType == null) {
+            throw new IllegalArgumentException("resourceType property is mandatory");
         }
-        if ( resourceConfiguration != null && !(ResourceType.DTABLE.equals( resourceType ) || ResourceType.XSD.equals( resourceType )) ) {
-            throw new IllegalArgumentException( "Only Decision Tables or XSD resources can have configuration" );
+        if (resourceConfiguration != null && !(ResourceType.DTABLE.equals(resourceType) || ResourceType.XSD.equals(resourceType))) {
+            throw new IllegalArgumentException("Only Decision Tables or XSD resources can have configuration");
         }
     }
 }

--- a/drools-container/drools-spring/src/main/java/org/drools/container/spring/beans/ResourceBeanFactory.java
+++ b/drools-container/drools-spring/src/main/java/org/drools/container/spring/beans/ResourceBeanFactory.java
@@ -18,7 +18,6 @@ package org.drools.container.spring.beans;
 
 import org.drools.io.Resource;
 import org.drools.io.impl.ClassPathResource;
-import org.drools.io.impl.URLClassPathResource;
 import org.drools.io.impl.UrlResource;
 import org.springframework.beans.factory.FactoryBean;
 
@@ -32,8 +31,6 @@ public class ResourceBeanFactory
         if ( source.trim().startsWith( "classpath:" ) ) {
             resource = new ClassPathResource( source.substring( source.indexOf( ':' ) + 1 ),
                                               ClassPathResource.class.getClassLoader() );
-        } else if (source.trim().startsWith( "URLClasspath:" )){
-            resource = new URLClassPathResource( source.substring( source.indexOf( ':' ) + 1 ) );
         } else {
             resource = new UrlResource( source );
         }

--- a/drools-container/drools-spring/src/test/java/org/drools/container/spring/SpringDroolsTest.java
+++ b/drools-container/drools-spring/src/test/java/org/drools/container/spring/SpringDroolsTest.java
@@ -39,7 +39,6 @@ import org.drools.impl.StatelessKnowledgeSessionImpl;
 import org.drools.io.Resource;
 import org.drools.io.ResourceFactory;
 import org.drools.io.impl.ResourceChangeScannerImpl;
-import org.drools.io.impl.URLClassPathResource;
 import org.drools.io.impl.UrlResource;
 import org.drools.runtime.StatefulKnowledgeSession;
 import org.drools.runtime.StatelessKnowledgeSession;
@@ -283,15 +282,4 @@ public class SpringDroolsTest {
                       ur.getPassword() );
     }
     
-    @Test
-    public void testURLClasspathResource(){
-        ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext( "org/drools/container/spring/beans.xml" );
-        DroolsResourceAdapter resourceAdapter = (DroolsResourceAdapter) context.getBean("UCPresource");
-        
-        assertNotNull( resourceAdapter );
-
-        Resource resource = resourceAdapter.getDroolsResource();
-        assertTrue( resource instanceof URLClassPathResource );
-        
-    }
 }

--- a/drools-container/drools-spring/src/test/resources/org/drools/container/spring/beans.xml
+++ b/drools-container/drools-spring/src/test/resources/org/drools/container/spring/beans.xml
@@ -19,8 +19,6 @@
    <drools:resource id="secureResource" basic-authentication="enabled" username="someUser" password="somePassword" type="DRL" source="http://someHost:1234/someDRLResource.drl"/>
    <drools:resource id="insecureResource" type="DRL" source="http://someHost:1234/someOtherDRLResource.drl"/>
    
-  <drools:resource id="UCPresource" type="DRL" source="URLClasspath:org/drools/container/spring/testSpring.drl"/>
-
   <drools:kbase id="kbase1" node="node1">
       <drools:resources>
       <drools:resource source="classpath:org/drools/container/spring/IntegrationExampleTest.xls" type="DTABLE">


### PR DESCRIPTION
```
- Added spring support for "URLClasspath:" resource
- Added test scenario
```
