### PR TITLE
Replace uber workaround jar file by individual bundles (features)

### DIFF
--- a/drools-osgi/drools-karaf-features/pom.xml
+++ b/drools-osgi/drools-karaf-features/pom.xml
@@ -15,15 +15,17 @@
 
   <properties>
     <aries.jpa.version>1.0.1</aries.jpa.version>
-    <antlr-bundle.version>3.5_1</antlr-bundle.version>
     <jexcelapi.version>2.6.12</jexcelapi.version>
-    <quartz-bundle.version>2.1.6_1</quartz-bundle.version>
     <javax-inject.version>1.0</javax-inject.version>
-    <protobuf-google-bundle.version>2.4.1_1</protobuf-google-bundle.version>
     <eclipse-jdt.version>4.2.1</eclipse-jdt.version>
     <janino.version>2.6.1</janino.version>
-    <xstream-bundle.version>1.4.3_1</xstream-bundle.version>
-    <woodstock-bundle.version>3.2.9_3</woodstock-bundle.version>
+    <servicemix-antlr-bundle.version>3.5_1</servicemix-antlr-bundle.version>
+    <servicemix-jaxb.version>2.2.1.1_2</servicemix-jaxb.version>
+    <servicemix-jaxb-spec.version>1.9.0</servicemix-jaxb-spec.version>
+    <servicemix-quartz-bundle.version>2.1.6_1</servicemix-quartz-bundle.version>
+    <servicemix-protobuf-google-bundle.version>2.4.1_1</servicemix-protobuf-google-bundle.version>
+    <servicemix-xstream-bundle.version>1.4.3_1</servicemix-xstream-bundle.version>
+    <servicemix-woodstock-bundle.version>3.2.9_3</servicemix-woodstock-bundle.version>
   </properties>
 
   <build>

--- a/drools-osgi/drools-karaf-features/src/main/filtered-resources/repository/features.xml
+++ b/drools-osgi/drools-karaf-features/src/main/filtered-resources/repository/features.xml
@@ -8,49 +8,32 @@
   <repository>mvn:org.apache.cxf.karaf/apache-cxf/${cxf.version}/xml/features</repository>
 
   <feature name="drools-common" version="${drools.version}" description="Drools Commons">
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.protobuf-java/${protobuf-google-bundle.version}</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.antlr/${antlr-bundle.version}</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.woodstox/${woodstock-bundle.version}</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${xstream-bundle.version}</bundle>
+    <bundle>mvn:com.google.protobuf/protobuf-java/${protobuf.version}</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.antlr/${servicemix-antlr-bundle.version}</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.woodstox/${servicemix-woodstock-bundle.version}</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream/${servicemix-xstream-bundle.version}</bundle>
+    <bundle start-level='10'>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxb-api-2.2/${servicemix-jaxb-spec.version}</bundle>
+    <bundle start-level='10'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-xjc/${servicemix-jaxb.version}</bundle>
+    <bundle start-level='10'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/${servicemix-jaxb.version}</bundle>
     <bundle>mvn:org.mvel/mvel2/${mvel.dep.version}</bundle>
     <bundle>wrap:mvn:org.eclipse.jdt.core.compiler/ecj/${eclipse-jdt.version}$Bundle-SymbolicName=Eclipse-JDT-Compiler&amp;Bundle-Version=${eclipse-jdt.version}</bundle>
     <bundle>wrap:mvn:org.codehaus.janino/janino/${janino.version}$Bundle-SymbolicName=Codehaus-Janino&amp;Bundle-Version=${janino.version}</bundle>
-    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.quartz/${quartz-bundle.version}</bundle>
+    <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.quartz/${servicemix-quartz-bundle.version}</bundle>
     <bundle>mvn:org.apache.geronimo.specs/geronimo-atinject_1.0_spec/${javax-inject.version}</bundle>
     <bundle>wrap:mvn:javax.enterprise/cdi-api/1.0-SP4</bundle>
   </feature>
 
-  <feature name="drools-module" version="${drools.version}" description="Drools Module containing core, compiler &amp; KIE">
+  <feature name="drools-module" version="${drools.version}" description="Drools core">
     <feature version="${drools.version}">drools-common</feature>
-    <!-- Should be removed after refactoring of drools-spring packages -->
-    <feature version="${drools.version}">drools-spring</feature>
-    <bundle>mvn:org.drools/drools-compiler-uber-workaround/${drools.version}</bundle>
+    <feature version="${drools.version}">kie</feature>
+    <bundle>mvn:org.drools/drools-core/${drools.version}</bundle>
+    <bundle>mvn:org.drools/drools-compiler/${drools.version}</bundle>
   </feature>
 
-  <!-- DOES NOT WORK AS WE HAVE PACKAGING ISSUES WITH KIE
-  <repository name="drools-core-compiler" version="${drools.version}" description="Drools core &amp; compiler">
-      <repository version="${drools.version}">drools-common</repository>
-      <repository version="${drools.version}">drools-kie</repository>
-      <bundle>mvn:org.drools/drools-core/${drools.version}</bundle>
-      <bundle>mvn:org.drools/drools-core/${drools.version}</bundle>
-  </repository>
-
-  <repository name="drools-kie" version="${drools.version}">
-      <bundle>mvn:org.kie/kie-api/${drools.version}</bundle>
-      <bundle>mvn:org.kie/kie-internal/${drools.version}</bundle>
-  </repository>
-
-  <repository name="drools-kieuber" version="${drools.version}">
-      <bundle>mvn:org.drools/kie-internal-uber-workaround/${drools.version}</bundle>
-  </repository>
-  -->
-
-  <!-- NOT SURE THAT IT IS REQUIRED
-  <repository name="drools-knowledge" version="${drools.version}">
-      <bundle>mvn:org.kie/knowledge-api/${drools.version}</bundle>
-      <bundle>mvn:org.kie/knowledge-internal-api/${drools.version}</bundle>
-  </repository>
-  -->
+  <feature name="kie" version="${drools.version}">
+    <bundle>mvn:org.kie/kie-api/${drools.version}</bundle>
+    <bundle>mvn:org.kie/kie-internal/${drools.version}</bundle>
+  </feature>
 
   <feature name="drools-spring" version="${drools.version}" description="Drools Spring">
     <feature version="[3.0,4.0)">spring</feature>

--- a/drools-osgi/drools-osgi-examples/pom.xml
+++ b/drools-osgi/drools-osgi-examples/pom.xml
@@ -118,10 +118,9 @@
           <instructions>
             <Import-Package>
               org.apache.camel;version="[2.8,3)",
-              org.drools;version="[6.0,7)",
-              org.drools.camel.component;version="[6.0,7)",
               org.drools.core.command.runtime;version="[6.0,7)",
               org.drools.core.command.runtime.rule;version="[6.0,7)",
+              org.drools.camel.component;version="[6.0,7)",
               org.drools.container.spring;version="[6.0,7)"
             </Import-Package>
             <Export-Package>org.apache.camel.drools.example</Export-Package>


### PR DESCRIPTION
The goal of this pull request is to replace uber workaround jar file by individual bundles for OSGI platform.

The request contains : 
- Replacement of uber workaround jar file by individual bundles (core, compiler, kie-api, kie-interna) in features file used to provision Apache Karaf project, 
- Add of missing bundles required by drools (jaxb-impl, jaxb-xjc)
- Remove non required dependencies for drools-camel-example
