### PR TITLE
Use in message for setting the result.

### DIFF
--- a/kie-camel/src/main/java/org/kie/camel/component/KieConsumer.java
+++ b/kie-camel/src/main/java/org/kie/camel/component/KieConsumer.java
@@ -28,16 +28,16 @@ import org.kie.internal.runtime.KnowledgeRuntime;
  */
 public class KieConsumer extends DefaultConsumer {
 
-    private KieEndpoint de;
+    private KieEndpoint ke;
     private KnowledgeRuntime krt;
     private String channelId;
 
     public KieConsumer(Endpoint endpoint,
                        Processor processor) {
         super( endpoint, processor );
-        de = (KieEndpoint) endpoint;
-        krt = (KnowledgeRuntime) de.getExecutor();
-        channelId = de.getChannel();
+        ke = (KieEndpoint) endpoint;
+        krt = (KnowledgeRuntime) ke.getExecutor();
+        channelId = ke.getChannel();
     }
 
     @Override
@@ -55,7 +55,7 @@ public class KieConsumer extends DefaultConsumer {
 
     class KSessionChannel implements Channel {
         public void send(Object pojo) {
-            Exchange exchange = de.createExchange( pojo );
+            Exchange exchange = ke.createExchange( pojo );
             try {
                 getProcessor().process(exchange);
             } catch (Exception e) {

--- a/kie-camel/src/main/java/org/kie/camel/component/KieExecuteProducer.java
+++ b/kie-camel/src/main/java/org/kie/camel/component/KieExecuteProducer.java
@@ -33,6 +33,7 @@ package org.kie.camel.component;
 
 import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
+import org.apache.camel.Message;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.impl.DefaultProducer;
 import org.drools.core.command.impl.GenericCommand;
@@ -51,12 +52,12 @@ public class KieExecuteProducer extends DefaultProducer {
     }
 
     public void process(Exchange exchange) throws Exception {
-        KieEndpoint de = (KieEndpoint) getEndpoint();
+        KieEndpoint ke = (KieEndpoint) getEndpoint();
 
         Command<?> cmd = exchange.getIn().getBody( Command.class );
 
         if ( cmd == null ) {
-            throw new RuntimeCamelException( "Body of in message not of the expected type 'org.kie.api.command.Command' for uri" + de.getEndpointUri() );
+            throw new RuntimeCamelException( "Body of in message not of the expected type 'org.kie.api.command.Command' for uri" + ke.getEndpointUri() );
         }
 
         if ( !(cmd instanceof BatchExecutionCommandImpl) ) {
@@ -69,7 +70,7 @@ public class KieExecuteProducer extends DefaultProducer {
         if ( droolsContext != null ) {
             exec = droolsContext.getCommandExecutor();
         } else {
-            exec = de.getExecutor();
+            exec = ke.getExecutor();
             if ( exec == null ) {
                 String lookup = exchange.getIn().getHeader( KieComponent.KIE_LOOKUP,
                                                             String.class );
@@ -78,23 +79,23 @@ public class KieExecuteProducer extends DefaultProducer {
                 }
 
                 if ( !StringUtils.isEmpty( lookup ) ) {
-                    exec = de.getComponent().getCamelContext().getRegistry().lookup( lookup,
+                    exec = ke.getComponent().getCamelContext().getRegistry().lookup( lookup,
                                                                                      CommandExecutor.class );
                     if ( exec == null ) {
-                        throw new RuntimeException( "ExecutionNode is unable to find ksession=" + lookup + " for uri" + de.getEndpointUri() );
+                        throw new RuntimeException( "ExecutionNode is unable to find ksession=" + lookup + " for uri" + ke.getEndpointUri() );
                     }
                 } else {
-                    throw new RuntimeException( "No ExecutionNode, unable to find ksession=" + lookup + " for uri" + de.getEndpointUri() );
+                    throw new RuntimeException( "No ExecutionNode, unable to find ksession=" + lookup + " for uri" + ke.getEndpointUri() );
                 }
             }
         }
 
         if ( exec == null ) {
-            throw new RuntimeException( "No defined ksession for uri " + de.getEndpointUri() );
+            throw new RuntimeException( "No defined ksession for uri " + ke.getEndpointUri() );
         }
 
-        ExecutionResults results = exec.execute( (BatchExecutionCommandImpl) cmd );;
-        exchange.getOut().setBody( results );
-        exchange.getOut().setHeaders(exchange.getIn().getHeaders());
+        ExecutionResults results = exec.execute( (BatchExecutionCommandImpl) cmd );
+
+        exchange.getIn().setBody( results );
     }
 }

--- a/kie-camel/src/main/java/org/kie/camel/component/KieInsertProducer.java
+++ b/kie-camel/src/main/java/org/kie/camel/component/KieInsertProducer.java
@@ -50,7 +50,7 @@ import org.kie.internal.runtime.StatelessKnowledgeSession;
 public class KieInsertProducer extends DefaultProducer {
 
     // the corresponding endpoint
-    private KieEndpoint de;
+    private KieEndpoint ke;
     // the actual insert is executed by a worker class that 
     // implements the GoF strategy pattern to avoid conditionals
     // at insert time and hopefully improve performance
@@ -58,11 +58,11 @@ public class KieInsertProducer extends DefaultProducer {
 
     public KieInsertProducer(Endpoint endpoint) {
         super( endpoint );
-        de = (KieEndpoint) endpoint;
+        ke = (KieEndpoint) endpoint;
 
         // Configures this Producer with the proper action
         // by composing strategy objects
-        KieEndpoint.Action action = de.getAction();
+        KieEndpoint.Action action = ke.getAction();
         Unwrapper unwrapper = null;
         switch ( action ) {
             case INSERT_BODY :
@@ -77,10 +77,10 @@ public class KieInsertProducer extends DefaultProducer {
         }
 
         // Creates the actual worker
-        CommandExecutor exec = de.getExecutor();
+        CommandExecutor exec = ke.getExecutor();
         if ( exec instanceof StatefulKnowledgeSession ) {
         	EntryPoint wmep;
-            String ep = de.getEntryPoint();
+            String ep = ke.getEntryPoint();
             if ( ep != null ) {
                 wmep = ((StatefulKnowledgeSession) exec).getEntryPoint( ep );
             } else {

--- a/kie-camel/src/main/java/org/kie/camel/component/KiePolicy.java
+++ b/kie-camel/src/main/java/org/kie/camel/component/KiePolicy.java
@@ -34,7 +34,6 @@ import org.apache.camel.model.dataformat.XStreamDataFormat;
 import org.apache.camel.spi.Policy;
 import org.apache.camel.spi.RouteContext;
 import org.drools.compiler.runtime.pipeline.impl.DroolsJaxbHelperProviderImpl;
-import org.drools.core.impl.KnowledgeBaseImpl;
 import org.drools.core.util.StringUtils;
 import org.kie.api.runtime.CommandExecutor;
 import org.kie.jax.soap.PostCxfSoapProcessor;
@@ -255,7 +254,7 @@ public class KiePolicy implements Policy {
         Processor {
 
         private String      kieUri;
-        private KieEndpoint dep;
+        private KieEndpoint ke;
         private Processor   processor;
 
         public KieProcess(String kieUri,
@@ -269,13 +268,13 @@ public class KiePolicy implements Policy {
             //I need to copy the body of the exachange because for some reason
             // the getContext().getEndpoint() erase the content/or loose the reference
             String body = exchange.getIn().getBody( String.class );
-            if ( dep == null ) {
+            if ( ke == null ) {
                 
-                this.dep = exchange.getContext().getEndpoint( this.kieUri,
+                this.ke = exchange.getContext().getEndpoint( this.kieUri,
                                                               KieEndpoint.class );
             }
 
-            if ( dep == null ) {
+            if ( ke == null ) {
                 throw new RuntimeException( "Could not find DroolsEndPoint for uri=" + this.kieUri);
             }
 
@@ -283,28 +282,28 @@ public class KiePolicy implements Policy {
             try {
                 originalClassLoader = Thread.currentThread().getContextClassLoader();
 
-                CommandExecutor exec = dep.executor;
+                CommandExecutor exec = ke.executor;
                 if ( exec == null ) {
                     String lookup = exchange.getIn().getHeader( KieComponent.KIE_LOOKUP,
                                                                 String.class );
                     if ( StringUtils.isEmpty( lookup ) ) {
                         //Bad Hack - Need to remote it and fix it in Camel (if it's a camel problem)
-                        lookup = dep.getLookup( body );
-                        //lookup = dep.getLookup( exchange.getIn().getBody( String.class ) );
+                        lookup = ke.getLookup( body );
+                        //lookup = ke.getLookup( exchange.getIn().getBody( String.class ) );
                     }
 
                     if ( StringUtils.isEmpty( lookup ) ) {
-                        throw new RuntimeException( "No Executor defined and no lookup information available for uri " + this.dep.getEndpointUri() );
+                        throw new RuntimeException( "No Executor defined and no lookup information available for uri " + this.ke.getEndpointUri() );
                     }
-                    exec = dep.getCommandExecutor( lookup );
+                    exec = ke.getCommandExecutor( lookup );
                 }
 
                 if ( exec == null ) {
-                    throw new RuntimeException( "CommandExecutor cannot be found for uri " + this.dep.getEndpointUri() );
+                    throw new RuntimeException( "CommandExecutor cannot be found for uri " + this.ke.getEndpointUri() );
                 }
-                ClassLoader localClassLoader = dep.getClassLoader( exec );
+                ClassLoader localClassLoader = ke.getClassLoader( exec );
                 if ( localClassLoader == null ) {
-                    throw new RuntimeException( "CommandExecutor Classloader cannot be null for uri " + this.dep.getEndpointUri() );
+                    throw new RuntimeException( "CommandExecutor Classloader cannot be null for uri " + this.ke.getEndpointUri() );
                 }
 
                 // Set the classloader to the one used by the CommandExecutor

--- a/kie-camel/src/main/java/org/kie/camel/component/PostCxfrs.java
+++ b/kie-camel/src/main/java/org/kie/camel/component/PostCxfrs.java
@@ -32,7 +32,7 @@ public class PostCxfrs
         if ( object instanceof Response ) {
             Response res = (Response) object;
             if ( res.getStatus() == Status.OK.getStatusCode() ) {
-                exchange.getOut().setBody( StringUtils.toString( (InputStream) ((Response) object).getEntity() ) );
+                exchange.getIn().setBody( StringUtils.toString( (InputStream) ((Response) object).getEntity() ) );
             }
         }
     }


### PR DESCRIPTION
Use in message rather than out message for setting results - http://camel.apache.org/using-getin-or-getout-methods-on-exchange.html .Otherwise headers and attachments are not propagated
Renamed variables
