### PR TITLE
kie-server: return empty list instead of null when no containers created

### DIFF
--- a/kie-server/kie-server-api/src/main/java/org/kie/server/api/model/KieContainerResourceList.java
+++ b/kie-server/kie-server-api/src/main/java/org/kie/server/api/model/KieContainerResourceList.java
@@ -1,5 +1,6 @@
 package org.kie.server.api.model;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -17,6 +18,7 @@ public class KieContainerResourceList {
 
     public KieContainerResourceList() {
         super();
+        containers = new ArrayList<KieContainerResource>();
     }
 
     public KieContainerResourceList(List<KieContainerResource> containers) {


### PR DESCRIPTION
When there are no containers created, the kie-server-client would return null for listContainers(). This requires the caller to handle this situation. Returning empty list seems as a better choice as the caller does not need to do any special handling in that case.
