### PR TITLE
kie-spring: add reproducer for not configuring KieSession clock type

### DIFF
--- a/kie-spring/src/test/java/org/kie/spring/tests/KieSpringKieSessionAttributesTest.java
+++ b/kie-spring/src/test/java/org/kie/spring/tests/KieSpringKieSessionAttributesTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.spring.tests;
+
+import org.drools.core.time.SessionPseudoClock;
+import org.drools.core.time.impl.JDKTimerService;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.conf.ClockTypeOption;
+import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class KieSpringKieSessionAttributesTest {
+
+    private static AbstractApplicationContext context = null;
+
+    @BeforeClass
+    public static void setup() {
+        context = new ClassPathXmlApplicationContext("org/kie/spring/kiesession-attributes.xml");
+    }
+
+    @Test
+    public void testContext() throws Exception {
+        assertNotNull(context);
+    }
+
+    @Test
+    public void testStatefulRealTimeClockKieSession() throws Exception {
+        KieSession ksession = context.getBean("statefulSessionRealTime", KieSession.class);
+        assertNotNull(ksession);
+        assertEquals("Session has configured different clock type", ClockTypeOption.get("realtime"), ksession.getSessionConfiguration().getOption(ClockTypeOption.class));
+        assertTrue(String.format("Session clock not an instance of '~s', but: '~s'.", JDKTimerService.class.getSimpleName(), ksession.getSessionClock().getClass().getSimpleName()),
+                   ksession.getSessionClock() instanceof JDKTimerService);
+    }
+
+    @Test
+    public void testStatefulPseudoClockKieSession() throws Exception {
+        KieSession ksession = context.getBean("statefulSessionPseudo", KieSession.class);
+        assertNotNull(ksession);
+        assertEquals("Session has configured different clock type", ClockTypeOption.get("pseudo"), ksession.getSessionConfiguration().getOption(ClockTypeOption.class));
+        assertTrue(String.format("Session clock not an instance of '~s', but '~s'.", SessionPseudoClock.class.getSimpleName(), ksession.getSessionClock().getClass().getSimpleName()),
+                ksession.getSessionClock() instanceof SessionPseudoClock);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        context.destroy();
+    }
+
+}

--- a/kie-spring/src/test/resources/org/kie/spring/kiesession-attributes.xml
+++ b/kie-spring/src/test/resources/org/kie/spring/kiesession-attributes.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:kie="http://drools.org/schema/kie-spring"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+                          http://drools.org/schema/kie-spring http://drools.org/schema/kie-spring.xsd">
+
+  <kie:kmodule id="kiesession_module">
+
+    <kie:kbase name="drl_kiesample" packages="drl_kiesample">
+
+      <kie:ksession name="statefulSessionRealTime" type="stateful" clockType="realtime"/>
+      <kie:ksession name="statefulSessionPseudo" type="stateful" clockType="pseudo"/>
+      <!-- Configuring SessionClock for stateless session is not supported. -->
+    </kie:kbase>
+
+  </kie:kmodule>
+
+  <bean id="kiePostProcessor" class="org.kie.spring.KModuleBeanFactoryPostProcessor"/>
+
+</beans>


### PR DESCRIPTION
Added reproducer for problem reported by @agiertli (BZ 1334321) - KIE-Spring does not properly configure `clockType` on a KieSession defined using Spring XML, such as:

```
<kie:kmodule id="kiesession_module">
  <kie:kbase name="drl_kiesample" packages="drl_kiesample">
    <kie:ksession name="statefulSessionPseudo" type="stateful" clockType="pseudo"/>
  </kie:kbase>
</kie:kmodule>
```
