### PR TITLE
not-existing-dependency reproducer

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.kie.server.testing</groupId>
+  <artifactId>common-parent</artifactId>
+  <version>1.0.0.Final</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <!-- The version is set during the Maven build (this file is a filtered resource) -->
+    <version.org.kie>${version.org.kie}</version.org.kie>
+    <drools.compiler.lnglevel>1.6</drools.compiler.lnglevel>
+
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.kie</groupId>
+          <artifactId>kie-maven-plugin</artifactId>
+          <version>${version.org.kie}</version>
+          <extensions>true</extensions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <repositories>
+    <repository>
+      <!-- Needed to download the Drools/jBPM SNAPSHOTs during build -->
+      <id>jboss-public-repo</id>
+      <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <!-- Needed to download the kie-maven-plugin SNAPSHOT during build -->
+      <id>jboss-public-repo</id>
+      <url>https://repository.jboss.org/nexus/content/groups/public-jboss/</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <distributionManagement>
+    <repository>
+      <id>remote-testing-repo</id>
+      <url>${kie.server.testing.remote.repo.url}</url>
+    </repository>
+    <snapshotRepository>
+      <id>remote-testing-repo</id>
+      <url>${kie.server.testing.remote.repo.url}</url>
+    </snapshotRepository>
+  </distributionManagement>
+</project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/filtered-resources/kjars-sources/not-existing-dependency-kjar/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/filtered-resources/kjars-sources/not-existing-dependency-kjar/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.kie.server.testing</groupId>
+    <artifactId>common-parent</artifactId>
+    <version>1.0.0.Final</version>
+  </parent>
+
+  <artifactId>not-existing-dependency-kjar</artifactId>
+  <version>1.0.0</version>
+  <packaging>kjar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>really.not.existing</groupId>
+      <artifactId>dependency</artifactId>
+      <version>9999</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/filtered-resources/kjars-sources/not-existing-dependency-kjar/src/main/resources/META-INF/kmodule.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/filtered-resources/kjars-sources/not-existing-dependency-kjar/src/main/resources/META-INF/kmodule.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kmodule xmlns="http://www.drools.org/xsd/kmodule">
+</kmodule>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/filtered-resources/kjars-sources/really-not-existing/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/filtered-resources/kjars-sources/really-not-existing/pom.xml
@@ -1,0 +1,9 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>really.not.existing</groupId>
+  <artifactId>dependency</artifactId>
+  <version>9999</version>
+
+</project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerContainerNonExistingDependency.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerContainerNonExistingDependency.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.integrationtests.common;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieScannerResource;
+import org.kie.server.api.model.KieScannerStatus;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.integrationtests.shared.KieServerAssert;
+import org.kie.server.integrationtests.shared.KieServerDeployer;
+import org.kie.server.integrationtests.shared.basetests.RestJmsSharedBaseIntegrationTest;
+
+public class KieServerContainerNonExistingDependency extends RestJmsSharedBaseIntegrationTest {
+
+    private static ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "not-existing-dependency-kjar", "1.0.0");
+
+    @BeforeClass
+    public static void initialize() throws Exception {
+        // Uncomment in first run, then comment back. 
+//        KieServerDeployer.buildAndDeployCommonMavenParent();
+//        KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/really-not-existing").getFile());
+//        KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/not-existing-dependency-kjar").getFile());
+    }
+
+    @Before
+    public void setupKieServer() throws Exception {
+        disposeAllContainers();
+    }
+
+    @Test
+    public void testCreateContainerSpecial() throws Exception {
+        ServiceResponse<KieContainerResource> reply = client.createContainer("kie1", new KieContainerResource("kie1", releaseId));
+        KieServerAssert.assertSuccess(reply);
+
+        ServiceResponse<KieScannerResource> si = client.updateScanner("kie1", new KieScannerResource(KieScannerStatus.STARTED, 10000l));
+        KieServerAssert.assertSuccess(si);
+    }
+}


### PR DESCRIPTION
Steps for reproducing - easiest to reproduce in local run - TJWS embedded container :
- uncomment kjar and dependency deployment (see "Uncomment in first run, then comment back.")
- run test - will pass
- delete really.not.existing dependency from maven repo - for local run it is your general repo
- comment back dependency deployment
- run test again - will throw NPE in scanner update
