### PR TITLE
JBPM-5776 - Extension mechanism for the JSON Marshaller

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshallerExtension.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshallerExtension.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.api.marshalling.json;
+
+import org.codehaus.jackson.map.ObjectMapper;
+
+public interface JSONMarshallerExtension {
+    /**
+     * Extension logic 
+     * @param marshaller
+     * @param serializer
+     * @param deserializer
+     */
+    public void extend(JSONMarshaller marshaller, ObjectMapper serializer, ObjectMapper deserializer);
+
+}

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/json/JSONMarshallerExtensionTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/json/JSONMarshallerExtensionTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package org.kie.server.api.marshalling.json;
 
 import java.text.DateFormat;

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/json/JSONMarshallerExtensionTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/json/JSONMarshallerExtensionTest.java
@@ -1,0 +1,33 @@
+package org.kie.server.api.marshalling.json;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+import org.kie.server.api.marshalling.Marshaller;
+import org.kie.server.api.marshalling.MarshallerFactory;
+import org.kie.server.api.marshalling.MarshallingFormat;
+
+import static org.junit.Assert.*;
+
+public class JSONMarshallerExtensionTest {
+    private static final DateFormat FORMATTER = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+
+    @Test
+    public void testCustomExtensionMarshaller() {
+        Set<Class<?>> extraClasses = new HashSet<Class<?>>();
+        Marshaller marshaller = MarshallerFactory.getMarshaller(extraClasses, MarshallingFormat.JSON, this.getClass().getClassLoader());
+        Calendar calendar = GregorianCalendar.getInstance();
+        
+        String marshall = marshaller.marshall(calendar);
+        assertEquals(marshall, "\""+ FORMATTER.format(calendar.getTime()) +"\"" );
+        
+        GregorianCalendar unmarshall = marshaller.unmarshall(marshall, GregorianCalendar.class);
+        assertEquals(unmarshall, calendar);
+    }
+    
+}

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/json/extension/JSONMarshallerExtensionGregorianCalendar.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/json/extension/JSONMarshallerExtensionGregorianCalendar.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package org.kie.server.api.marshalling.json.extension;
 
 import java.io.IOException;

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/json/extension/JSONMarshallerExtensionGregorianCalendar.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/json/extension/JSONMarshallerExtensionGregorianCalendar.java
@@ -1,0 +1,71 @@
+package org.kie.server.api.marshalling.json.extension;
+
+import java.io.IOException;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.JsonParser;
+import org.codehaus.jackson.JsonProcessingException;
+import org.codehaus.jackson.Version;
+import org.codehaus.jackson.map.DeserializationContext;
+import org.codehaus.jackson.map.JsonDeserializer;
+import org.codehaus.jackson.map.JsonSerializer;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.SerializerProvider;
+import org.codehaus.jackson.map.module.SimpleModule;
+import org.kie.server.api.marshalling.json.JSONMarshaller;
+import org.kie.server.api.marshalling.json.JSONMarshallerExtension;
+
+public class JSONMarshallerExtensionGregorianCalendar implements JSONMarshallerExtension {
+
+    private static final GregorianCalendarDeser DESERIALIZER = new GregorianCalendarDeser();
+    private static final GregorianCalendarSer SERIALIZER = new GregorianCalendarSer();
+    private static final DateFormat FORMATTER = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+
+
+    @Override
+    public void extend(JSONMarshaller marshaller, ObjectMapper serializer, ObjectMapper deserializer) {
+        registerModule(serializer);
+        registerModule(deserializer);
+    }
+
+    private void registerModule(ObjectMapper objectMapper) {
+        SimpleModule gregorianCalendarModule = new SimpleModule("gregoriancalendar-module", Version.unknownVersion());
+        gregorianCalendarModule.addDeserializer(GregorianCalendar.class, DESERIALIZER);
+        gregorianCalendarModule.addSerializer(GregorianCalendar.class, SERIALIZER);
+        objectMapper.registerModule(gregorianCalendarModule);
+    }
+
+    private static class GregorianCalendarDeser extends JsonDeserializer<GregorianCalendar> {
+
+        @Override
+        public GregorianCalendar deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+            GregorianCalendar gregorianCalendar = new GregorianCalendar();
+            try {
+                String text = jp.getText();
+                Date date;
+                date = FORMATTER.parse(text);
+                gregorianCalendar.setTime(date);
+            } catch (ParseException e) {
+                throw new IOException(e);
+            }
+            return gregorianCalendar;                
+        }
+    }
+
+    private static class GregorianCalendarSer extends JsonSerializer<GregorianCalendar> {
+
+        @Override
+        public void serialize(GregorianCalendar value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
+            
+            String formattedValue = FORMATTER.format(value.getTime());
+            jgen.writeString(formattedValue);
+        }
+
+    }
+
+}

--- a/kie-server-parent/kie-server-api/src/test/resources/META-INF/services/org.kie.server.api.marshalling.json.JSONMarshallerExtension
+++ b/kie-server-parent/kie-server-api/src/test/resources/META-INF/services/org.kie.server.api.marshalling.json.JSONMarshallerExtension
@@ -1,0 +1,1 @@
+org.kie.server.api.marshalling.json.extension.JSONMarshallerExtensionGregorianCalendar


### PR DESCRIPTION
It's possible to extend the JSON Marshaller providing a `JSONMarshallerExtension` implementation.
It is loaded with the service loader mechanism, adding the following file in `META-INF/services`:

`org.kie.server.api.marshalling.json.JSONMarshallerExtension`