### PR TITLE
RHBPMS-4636 - clean up spring context in tests properly

### DIFF
--- a/kie-spring/src/test/java/org/kie/spring/jbpm/KieSpringProcessInstanceMigrationServiceImplTest.java
+++ b/kie-spring/src/test/java/org/kie/spring/jbpm/KieSpringProcessInstanceMigrationServiceImplTest.java
@@ -55,7 +55,12 @@ public class KieSpringProcessInstanceMigrationServiceImplTest extends AbstractJb
     @After
     public void cleanup() {
         System.clearProperty("org.kie.txm.factory.class");
+        TransactionManagerFactory.resetInstance();
         EntityManagerFactoryManager.get().clear();
+        if (context != null) {
+            context.close();
+            context = null;
+        }
     }
 
     public KieSpringProcessInstanceMigrationServiceImplTest(String contextPath,


### PR DESCRIPTION
@mswiderski test was not cleaning up spring context which sometimes caused tests executed after it to fail.