### PR TITLE
Fix JSONMarshaller.writeMap() check for double-wrapping for map values

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
@@ -533,7 +533,7 @@ public class JSONMarshaller implements Marshaller {
                 String jsonValue = customObjectMapper.writeValueAsString(mValue);
 
                 // don't wrap java and javax classes as they are always available, in addition avoid double wrapping
-                if (!mValueClassName.startsWith("java.") && !mValueClassName.startsWith("javax.") && !json.contains(mValueClassName)) {
+                if (!mValueClassName.startsWith("java.") && !mValueClassName.startsWith("javax.") && !jsonValue.contains(mValueClassName)) {
                     jsonValue = "{\"" + mValueClassName + "\":" + jsonValue + "}";
                 }
 


### PR DESCRIPTION
I believe this is a copy/paste typing mistake for [the analogous code at lines 521-529](https://github.com/kiegroup/droolsjbpm-integration/blob/master/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java#L521-L529) preceding this proposed correction.