### PR TITLE
Update KSessionFactoryBean.java

### DIFF
--- a/kie-spring/src/main/java/org/kie/spring/factorybeans/KSessionFactoryBean.java
+++ b/kie-spring/src/main/java/org/kie/spring/factorybeans/KSessionFactoryBean.java
@@ -171,7 +171,7 @@ public class KSessionFactoryBean
     public Object getObject() throws Exception {
         if ("prototype".equalsIgnoreCase(scope)) {
             helper.setKieBase(kBase);
-            kSession = helper.internalNewObject();
+            Object kSession = helper.internalNewObject();
             attachLoggers((KieRuntimeEventManager) kSession);
             attachListeners((KieRuntimeEventManager) kSession);
             return kSession;


### PR DESCRIPTION
When concurrently get prototype kSession, I found sometimes there are some kSession instances are repeated. So it is not strictly prototype.  If let kSession as a local variable, I think could solve this problem.