### PR TITLE
kie-server-tests: Stabilize UserTaskEscalationIntegrationTest

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/definition-project/src/main/resources/humanTaskEscalation.bpmn2
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/definition-project/src/main/resources/humanTaskEscalation.bpmn2
@@ -76,14 +76,14 @@
       <bpmn2:dataInputAssociation id="_jwTnOqL0EeOIL6YyOM8POA">
         <bpmn2:targetRef>_4_NotStartedReassignInputX</bpmn2:targetRef>
         <bpmn2:assignment id="_jwTnO6L0EeOIL6YyOM8POA">
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_jwTnPKL0EeOIL6YyOM8POA"><![CDATA[[users:#{reassignTo}]@[1s]]]></bpmn2:from>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_jwTnPKL0EeOIL6YyOM8POA"><![CDATA[[users:#{reassignTo}]@[3s]]]></bpmn2:from>
           <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_jwTnPaL0EeOIL6YyOM8POA">_4_NotStartedReassignInputX</bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>
       <bpmn2:dataInputAssociation id="_jwTnPqL0EeOIL6YyOM8POA">
         <bpmn2:targetRef>_4_NotCompletedNotifyInputX</bpmn2:targetRef>
         <bpmn2:assignment id="_jwTnP6L0EeOIL6YyOM8POA">
-          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_jwTnQKL0EeOIL6YyOM8POA"><![CDATA[[tousers:#{escUser}|subject:Escalation|body:#{escalation}]@[2s]]]></bpmn2:from>
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_jwTnQKL0EeOIL6YyOM8POA"><![CDATA[[tousers:#{escUser}|subject:Escalation|body:#{escalation}]@[6s]]]></bpmn2:from>
           <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_jwTnQaL0EeOIL6YyOM8POA">_4_NotCompletedNotifyInputX</bpmn2:to>
         </bpmn2:assignment>
       </bpmn2:dataInputAssociation>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskEscalationIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskEscalationIntegrationTest.java
@@ -16,7 +16,10 @@
 package org.kie.server.integrationtests.jbpm;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,10 +36,13 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runners.Parameterized;
+import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.api.model.instance.TaskInstance;
 import org.kie.server.api.model.instance.TaskSummary;
+import org.kie.server.client.KieServicesConfiguration;
 import org.kie.server.integrationtests.category.Email;
 import org.kie.server.integrationtests.category.Unstable;
 import org.kie.server.integrationtests.config.TestConfig;
@@ -68,6 +74,18 @@ public class UserTaskEscalationIntegrationTest extends JbpmKieServerBaseIntegrat
     }
 
     private Wiser wiser;
+
+    @Parameterized.Parameters(name = "{index}: {0} {1}")
+    public static Collection<Object[]> data() {
+        KieServicesConfiguration configuration = createKieServicesRestConfiguration();
+
+        Collection<Object[]> parameterData = new ArrayList<Object[]>(Arrays.asList(new Object[][] {
+                                {MarshallingFormat.JAXB, configuration}
+                        }
+        ));
+
+        return parameterData;
+    }
 
     @Before
     public void startWiser() {
@@ -165,8 +183,8 @@ public class UserTaskEscalationIntegrationTest extends JbpmKieServerBaseIntegrat
 
         KieServerAssert.assertNullOrEmpty("Email recieved!", wiser.getMessages());
 
-        //wait while, cause email is sended 2s after task start
-        Thread.sleep(3000l);
+        //wait while, cause email is sent 6s after task start
+        Thread.sleep(8000l);
         KieServerAssert.assertNullOrEmpty("Email recieved!", wiser.getMessages());
     }
 


### PR DESCRIPTION
Also UserTaskEscalationIntegrationTest will run now just with REST/JAXB combination to compensate longer test run. There is no need to test different transport/marshalling protocols as tested functionality use standard responses, they are covered by other tests.