### PR TITLE
Add support to evaluate a specific decision for DMN kie-server extension

### DIFF
--- a/kie-camel/src/main/java/org/kie/camel/KieConfiguration.java
+++ b/kie-camel/src/main/java/org/kie/camel/KieConfiguration.java
@@ -40,7 +40,9 @@ public class KieConfiguration implements Cloneable {
 
     private void initBodyParams() {
         setBodyParam( "process", "signal", "event" );
-        setBodyParam( "dmn", "evaluateAllDecisions", "dmnContext" );
+        setBodyParam( "dmn", "evaluateAll", "dmnContext" );
+        setBodyParam( "dmn", "evaluateDecisionByName", "dmnContext" );
+        setBodyParam( "dmn", "evaluateDecisionById", "dmnContext" );
     }
 
     public void configure(String remaining) {

--- a/kie-camel/src/test/java/org/kie/camel/KieComponentIntegrationTest.java
+++ b/kie-camel/src/test/java/org/kie/camel/KieComponentIntegrationTest.java
@@ -155,7 +155,7 @@ public class KieComponentIntegrationTest extends BaseKieComponentTest {
 
         Map<String, Object> headers = new HashMap<>();
         headers.put(KIE_CLIENT, "dmn");
-        headers.put(KIE_OPERATION, "evaluateAllDecisions");
+        headers.put(KIE_OPERATION, "evaluateAll");
         headers.put(asCamelKieName("containerId"), "containerId");
         template.sendBodyAndHeaders("direct:start", body, headers);
         assertMockEndpointsSatisfied();
@@ -249,7 +249,9 @@ public class KieComponentIntegrationTest extends BaseKieComponentTest {
         kieComponent.getConfiguration()
                     .clearBodyParams()
                     .setBodyParam( "process", "signal", "event" )
-                    .setBodyParam( "dmn", "evaluateAllDecisions", "dmnContext" );
+                    .setBodyParam( "dmn", "evaluateAll", "dmnContext" )
+                    .setBodyParam( "dmn", "evaluateDecisionByName", "dmnContext" )
+                    .setBodyParam( "dmn", "evaluateDecisionById", "dmnContext" );
         context.addComponent( "kie", kieComponent );
         return context;
     }

--- a/kie-camel/src/test/java/org/kie/camel/KieComponentOpOnUriTest.java
+++ b/kie-camel/src/test/java/org/kie/camel/KieComponentOpOnUriTest.java
@@ -127,7 +127,7 @@ public class KieComponentOpOnUriTest extends BaseKieComponentTest {
             @Override
             public void configure() {
                 from("direct:start")
-                        .to("kie:" + getAuthenticadUrl("admin", "admin") + "?client=dmn&operation=evaluateAllDecisions")
+                        .to("kie:" + getAuthenticadUrl("admin", "admin") + "?client=dmn&operation=evaluateAll")
                         .to("mock:result");
             }
         };
@@ -140,7 +140,9 @@ public class KieComponentOpOnUriTest extends BaseKieComponentTest {
         kieComponent.getConfiguration()
                     .clearBodyParams()
                     .setBodyParam( "process", "signal", "event" )
-                    .setBodyParam( "dmn", "evaluateAllDecisions", "dmnContext" );
+                    .setBodyParam( "dmn", "evaluateAll", "dmnContext" )
+                    .setBodyParam( "dmn", "evaluateDecisionByName", "dmnContext" )
+                    .setBodyParam( "dmn", "evaluateDecisionById", "dmnContext" );
         context.addComponent( "kie", kieComponent );
         return context;
     }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/dmn/DMNContextKS.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/dmn/DMNContextKS.java
@@ -45,6 +45,10 @@ public class DMNContextKS {
     @XmlElement(name="decision-name")
     @XStreamAlias("decision-name")
     private String decisionName;
+    
+    @XmlElement(name="decision-id")
+    @XStreamAlias("decision-id")
+    private String decisionId;
 
     @XmlElement(name="dmn-context")
     @XStreamAlias("dmn-context")
@@ -64,47 +68,42 @@ public class DMNContextKS {
         this.namespace = namespace;
         this.modelName = modelName;
     }
-    
-    public DMNContextKS(String namespace, String modelName, String decisionName, Map<String, Object> dmnContext) {
-        this(namespace, modelName, dmnContext);
-        this.decisionName = decisionName;
-    }
 
-    
     public String getNamespace() {
         return namespace;
     }
-
     
     public void setNamespace(String namespace) {
         this.namespace = namespace;
     }
-
     
     public String getModelName() {
         return modelName;
     }
-
     
     public void setModelName(String modelName) {
         this.modelName = modelName;
     }
 
-    
     public String getDecisionName() {
         return decisionName;
     }
-
     
     public void setDecisionName(String decisionName) {
         this.decisionName = decisionName;
     }
 
+    public String getDecisionId() {
+        return decisionId;
+    }
     
+    public void setDecisionId(String decisionId) {
+        this.decisionId = decisionId;
+    }
+
     public Map<String, Object> getDmnContext() {
         return dmnContext;
     }
-
     
     public void setDmnContext(Map<String, Object> dmnContext) {
         this.dmnContext = dmnContext;
@@ -116,6 +115,4 @@ public class DMNContextKS {
         builder.append("DMNContextKS [namespace=").append(namespace).append(", modelName=").append(modelName).append(", decisionName=").append(decisionName).append(", dmnContext=").append(dmnContext).append("]");
         return builder.toString();
     }
-    
-    
 }

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/DMNServicesClient.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/DMNServicesClient.java
@@ -21,11 +21,62 @@ import org.kie.server.api.model.ServiceResponse;
 
 public interface DMNServicesClient {
 
-    // this \/ generification below is to avoid from API client seeing the ? extends
-    <R extends DMNResult> ServiceResponse<R> evaluateAllDecisions(String containerId, DMNContext dmnContext);
-
-    <R extends DMNResult> ServiceResponse<R> evaluateAllDecisions(String containerId, String namespace, String modelName, DMNContext dmnContext);
+    /**
+     * Evaluate all decisions for the model identified by namespace and modelName, given the context dmnContext
+     *
+     * @param containerId the container id deploying the DMN model
+     * @param namespace namespace to identify the model to evaluate
+     * @param modelName model name to identify the model to evaluate
+     * @param dmnContext the context with all the input variables
+     *
+     * @return the result of the evaluation
+     */
+    ServiceResponse<DMNResult> evaluateAll(String containerId, String namespace, String modelName, DMNContext dmnContext);
     
+    /**
+     * Evaluate the decision identified by the given name and all dependent decisions for the model identified by namespace and modelName, given the context dmnContext
+     *
+     * @param containerId the container id deploying the DMN model
+     * @param namespace namespace to identify the model to evaluate
+     * @param modelName model name to identify the model to evaluate
+     * @param decisionName the root decision to evaluate, identified
+     *                     by name
+     * @param dmnContext the context with all the input variables
+     *
+     * @return the result of the evaluation
+     */
+    ServiceResponse<DMNResult> evaluateDecisionByName(String containerId, String namespace, String modelName, String decisionName, DMNContext dmnContext);
+    
+    /**
+     * Evaluate the decision identified by the given ID and all dependent decisions for the model identified by namespace and modelName, given the context dmnContext
+     *
+     * @param containerId the container id deploying the DMN model
+     * @param namespace namespace to identify the model to evaluate
+     * @param modelName model name to identify the model to evaluate
+     * @param decisionId the root decision to evaluate, identified
+     *                   by ID
+     * @param dmnContext the context with all the input variables
+     *
+     * @return the result of the evaluation
+     */
+    ServiceResponse<DMNResult> evaluateDecisionById(String containerId, String namespace, String modelName, String decisionId, DMNContext dmnContext);
+    
+    /**
+     * Creates a new empty DMNContext
+     *
+     * @return a new empty DMNContext
+     */
     DMNContext newContext();
+
+    /**
+     * Convenience method to be used if the container contains only a single DMN model, to evaluate all decisions.
+     * The method {@link DMNServicesClient#evaluateAllDecisions(String, String, String, DMNContext)} shall be used for containers deploying multiple DMN model.
+     *
+     * @param containerId the container id deploying the DMN model
+     * @param dmnContext the context with all the input variables
+     *
+     * @return the result of the evaluation, or an error if the container contains more than a single DMN model
+     */
+    ServiceResponse<DMNResult> evaluateAll(String containerId, DMNContext dmnContext);
 
 }

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-dmn/src/main/java/org/kie/server/remote/rest/dmn/ModelEvaluatorResource.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-dmn/src/main/java/org/kie/server/remote/rest/dmn/ModelEvaluatorResource.java
@@ -81,15 +81,15 @@ public class ModelEvaluatorResource {
     @POST
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    public Response evaluateAllDecisions(@javax.ws.rs.core.Context HttpHeaders headers, @PathParam(CONTAINER_ID) String containerId, String payload) {
-        LOG.debug( "About to evaluateAllDecisions on container {}", containerId );
+    public Response evaluateDecisions(@javax.ws.rs.core.Context HttpHeaders headers, @PathParam(CONTAINER_ID) String containerId, String payload) {
+        LOG.debug( "About to evaluateDecisions() on container {}", containerId );
         Variant v = getVariant( headers );
         Header conversationIdHeader = buildConversationIdHeader(containerId, modelEvaluatorService.getKieServerRegistry(), headers);
         try {
             String contentType = getContentType( headers );
             
             LOG.debug( "Payload received: {}", payload);
-            ServiceResponse<DMNResultKS> result = modelEvaluatorService.evaluateAllDecisions(containerId, payload, contentType);
+            ServiceResponse<DMNResultKS> result = modelEvaluatorService.evaluateDecisions(containerId, payload, contentType);
             if( result.getType() == ServiceResponse.ResponseType.SUCCESS ) {
                 return createCorrectVariant(marshallerHelper, containerId, result, headers, Response.Status.OK, conversationIdHeader );
             }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/java/org/kie/server/integrationtests/dmn/DMNIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/java/org/kie/server/integrationtests/dmn/DMNIntegrationTest.java
@@ -56,15 +56,15 @@ public class DMNIntegrationTest
     }
 
     @Test
-    public void test_evaluateAllDecisions() {
+    public void test_evaluateAll() {
         DMNContext dmnContext = dmnClient.newContext();
         dmnContext.set( "a", 10 );
         dmnContext.set( "b", 5 );
-        ServiceResponse<DMNResult> evaluateAllDecisions = dmnClient.evaluateAllDecisions(CONTAINER_1_ID, dmnContext);
+        ServiceResponse<DMNResult> evaluateAll = dmnClient.evaluateAll(CONTAINER_1_ID, dmnContext);
         
-        assertEquals(ResponseType.SUCCESS, evaluateAllDecisions.getType());
+        assertEquals(ResponseType.SUCCESS, evaluateAll.getType());
         
-        DMNResult dmnResult = evaluateAllDecisions.getResult();
+        DMNResult dmnResult = evaluateAll.getResult();
         
         Map<String, Object> mathInCtx = (Map<String, Object>) dmnResult.getContext().get( "Math" );
         assertThat( mathInCtx, hasEntry( "Sum", BigDecimal.valueOf( 15 ) ) );
@@ -75,17 +75,17 @@ public class DMNIntegrationTest
     
     // Using explicit namespace and model name
     @Test
-    public void test_evaluateAllDecisions2() {
+    public void test_evaluateAll2() {
         DMNContext dmnContext = dmnClient.newContext();
         dmnContext.set( "a", 10 );
         dmnContext.set( "b", 5 );
-        ServiceResponse<DMNResult> evaluateAllDecisions = dmnClient.evaluateAllDecisions(CONTAINER_1_ID,
+        ServiceResponse<DMNResult> evaluateAll = dmnClient.evaluateAll(CONTAINER_1_ID,
                 "https://www.drools.org/kie-dmn/function-definition", "function-definition",
                 dmnContext);
         
-        assertEquals(ResponseType.SUCCESS, evaluateAllDecisions.getType());
+        assertEquals(ResponseType.SUCCESS, evaluateAll.getType());
         
-        DMNResult dmnResult = evaluateAllDecisions.getResult();
+        DMNResult dmnResult = evaluateAll.getResult();
         
         Map<String, Object> mathInCtx = (Map<String, Object>) dmnResult.getContext().get( "Math" );
         assertThat( mathInCtx, hasEntry( "Sum", BigDecimal.valueOf( 15 ) ) );

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/java/org/kie/server/integrationtests/dmn/DMNTwoDMNModelsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/java/org/kie/server/integrationtests/dmn/DMNTwoDMNModelsIntegrationTest.java
@@ -57,16 +57,16 @@ public class DMNTwoDMNModelsIntegrationTest
     }
 
     @Test
-    public void test_evaluateAllDecisionsOnInputDataStringModel() {
+    public void test_evaluateAllOnInputDataStringModel() {
         DMNContext dmnContext = dmnClient.newContext();
         dmnContext.set( "Full Name", "John Doe" );
-        ServiceResponse<DMNResult> evaluateAllDecisions = dmnClient.evaluateAllDecisions(CONTAINER_1_ID, 
+        ServiceResponse<DMNResult> evaluateAll = dmnClient.evaluateAll(CONTAINER_1_ID, 
                 "https://github.com/kiegroup/kie-dmn/input-data-string", "input-data-string",
                 dmnContext);
         
-        assertEquals(ResponseType.SUCCESS, evaluateAllDecisions.getType());
+        assertEquals(ResponseType.SUCCESS, evaluateAll.getType());
         
-        DMNResult dmnResult = evaluateAllDecisions.getResult();
+        DMNResult dmnResult = evaluateAll.getResult();
         
         assertThat( dmnResult.getDecisionResults().size(), is( 1 ) );
         assertThat( dmnResult.getDecisionResultByName( "Greeting Message" ).getResult(), is( "Hello John Doe" ) );
@@ -77,17 +77,17 @@ public class DMNTwoDMNModelsIntegrationTest
     }
     
     @Test
-    public void test_evaluateAllDecisionsOnFunctionDefinitionModel() {
+    public void test_evaluateAllOnFunctionDefinitionModel() {
         DMNContext dmnContext = dmnClient.newContext();
         dmnContext.set( "a", 10 );
         dmnContext.set( "b", 5 );
-        ServiceResponse<DMNResult> evaluateAllDecisions = dmnClient.evaluateAllDecisions(CONTAINER_1_ID,
+        ServiceResponse<DMNResult> evaluateAll = dmnClient.evaluateAll(CONTAINER_1_ID,
                 "https://www.drools.org/kie-dmn/function-definition", "function-definition",
                 dmnContext);
         
-        assertEquals(ResponseType.SUCCESS, evaluateAllDecisions.getType());
+        assertEquals(ResponseType.SUCCESS, evaluateAll.getType());
         
-        DMNResult dmnResult = evaluateAllDecisions.getResult();
+        DMNResult dmnResult = evaluateAll.getResult();
         
         Map<String, Object> mathInCtx = (Map<String, Object>) dmnResult.getContext().get( "Math" );
         assertThat( mathInCtx, hasEntry( "Sum", BigDecimal.valueOf( 15 ) ) );


### PR DESCRIPTION
and API nomenclature alignments (e.g.: `evaluateAll`)