### PR TITLE
JBPM-5887: Add support for WebSphere 9

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-test-war/src/main/assembly/assembly-ee7-container.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-test-war/src/main/assembly/assembly-ee7-container.xml
@@ -51,6 +51,7 @@
 
         <include>com.sun.xml.bind:jaxb-impl</include>
         <include>com.sun.xml.bind:jaxb-core</include>
+        <include>org.slf4j:slf4j-api</include>
       </includes>
       <outputDirectory>WEB-INF/lib</outputDirectory>
       <useTransitiveFiltering>true</useTransitiveFiltering>

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -253,7 +253,7 @@
               </goals>
               <configuration>
                 <excludedGroups>${failsafe.excluded.groups}</excludedGroups>
-                <additionalClasspathElements>
+                <additionalClasspathElements combine.children="append">
                   <additionalClasspathElement>${maven.jdbc.driver.jar}</additionalClasspathElement>
                 </additionalClasspathElements>
               </configuration>
@@ -862,7 +862,7 @@
       </dependencies>
     </profile>
     <profile>
-      <id>was85x</id>
+      <id>websphere9</id>
       <properties>
         <container.port>9080</container.port>
         <kie.server.remoting.url>iiop://${container.hostname}:2809</kie.server.remoting.url>
@@ -871,7 +871,7 @@
         <kie.server.jndi.response.queue>jms/KIE.SERVER.RESPONSE</kie.server.jndi.response.queue>
         <kie.server.connection.factory>jms/cf/KIE.SERVER.REQUEST</kie.server.connection.factory>
         <org.kie.server.persistence.ds>jdbc/jbpm</org.kie.server.persistence.ds>
-        <kie.server.classifier>ee6</kie.server.classifier>
+        <kie.server.classifier>ee7</kie.server.classifier>
         <cargo.container.id>websphere85x</cargo.container.id>
         <failsafe.excluded.groups>org.kie.server.integrationtests.category.Email,org.kie.server.integrationtests.category.RemotelyControlled,org.kie.server.integrationtests.category.Transactional</failsafe.excluded.groups>
       </properties>
@@ -887,6 +887,7 @@
                   <home>${websphere.home}</home>
                   <timeout>240000</timeout>
                   <systemProperties>
+                    <!-- JtaPlatform doesn't work for new version of Hibernate, user needs to provide own implementation, see https://hibernate.atlassian.net/browse/HHH-11606 . -->
                     <org.kie.server.persistence.tm>org.hibernate.service.jta.platform.internal.WebSphereExtendedJtaPlatform</org.kie.server.persistence.tm>
                     <org.kie.server.persistence.ds>jdbc/jbpm</org.kie.server.persistence.ds>
                     <org.kie.server.domain>WSLogin</org.kie.server.domain>
@@ -896,6 +897,13 @@
                     <!-- disable JMS support for executor to use same tests for all containers for jbpm excutor -->
                     <org.kie.executor.jms>false</org.kie.executor.jms>
                     <org.kie.server.sync.deploy>true</org.kie.server.sync.deploy>
+                    <!-- Disable CDI to speed up Kie server startup -->
+                    <com.ibm.ws.cdi.enableImplicitBeanArchives>false</com.ibm.ws.cdi.enableImplicitBeanArchives>
+                    <com.ibm.ws.cdi.enableCDI>false</com.ibm.ws.cdi.enableCDI>
+                    <!-- Needed by WebSphere to trust JBoss Nexus -->
+                    <javax.net.ssl.trustStore>${java.home}/lib/security/cacerts</javax.net.ssl.trustStore>
+                    <javax.net.ssl.trustStorePassword>changeit</javax.net.ssl.trustStorePassword>
+                    <javax.net.ssl.trustStoreType>JKS</javax.net.ssl.trustStoreType>
                   </systemProperties>
                   <dependencies>
                     <dependency>
@@ -908,7 +916,7 @@
                   <type>standalone</type>
                   <properties>
                     <cargo.websphere.profile>${project.artifactId}</cargo.websphere.profile>
-                    <cargo.jvmargs>-Xms2g -Xmx2g</cargo.jvmargs>
+                    <cargo.jvmargs>-Xms1g -Xmx2g</cargo.jvmargs>
                     <cargo.websphere.classloader.mode>PARENT_LAST</cargo.websphere.classloader.mode>
                     <cargo.websphere.war.classloader.policy>SINGLE</cargo.websphere.war.classloader.policy>
                     <!-- CFs -->
@@ -969,9 +977,9 @@
               <artifactId>maven-failsafe-plugin</artifactId>
               <configuration>
                 <additionalClasspathElements>
-                  <additionalClasspathElement>${websphere.home}/runtimes/com.ibm.ws.ejb.thinclient_8.5.0.jar</additionalClasspathElement>
-                  <additionalClasspathElement>${websphere.home}/runtimes/com.ibm.ws.sib.client.thin.jms_8.5.0.jar</additionalClasspathElement>
-                  <additionalClasspathElement>${websphere.home}/runtimes/com.ibm.ws.orb_8.5.0.jar</additionalClasspathElement>
+                  <additionalClasspathElement>${websphere.home}/runtimes/com.ibm.ws.ejb.thinclient_9.0.jar</additionalClasspathElement>
+                  <additionalClasspathElement>${websphere.home}/runtimes/com.ibm.ws.sib.client.thin.jms_9.0.jar</additionalClasspathElement>
+                  <additionalClasspathElement>${websphere.home}/runtimes/com.ibm.ws.orb_9.0.jar</additionalClasspathElement>
                 </additionalClasspathElements>
               </configuration>
             </plugin>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee7-container.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee7-container.xml
@@ -84,6 +84,7 @@
         <exclude>org.jboss.spec.javax.annotation:*</exclude>
         <exclude>org.jboss.spec.javax.ejb:*</exclude>
         <exclude>org.jboss.spec.javax.interceptor:*</exclude>
+        <exclude>org.jboss.spec.javax.transaction:*</exclude>
         <exclude>org.jboss.spec.javax.ws.rs:*</exclude>
         <exclude>javax.enterprise:cdi-api</exclude>
         <exclude>javax.inject:javax.inject</exclude>
@@ -93,6 +94,7 @@
         <exclude>org.hibernate.javax.persistence:hibernate-jpa-2.1-api</exclude>
         <exclude>xml-apis:xml-apis</exclude>
         <exclude>javax.mail:mail</exclude>
+        <exclude>org.apache.cxf:cxf-rt-ws-policy</exclude>
       </excludes>
       <outputDirectory>WEB-INF/lib</outputDirectory>
       <useTransitiveFiltering>true</useTransitiveFiltering>


### PR DESCRIPTION
Initial implementation, to be discussed.

Contains own WebSphere platform implementation as implementation provided by Hibernate doesn't work - throwing UnsupportedOperationException.

Transaction API exclusion - will check if this works with WildFly/WLS.
cxf-rt-ws-policy - was causing issues with WebSphere's own cxf.  It is brought by jbpm-workitems, I am not sure what functionality depends on it.
