### PR TITLE
changed db file path to use target directory instead of user home dir…

### DIFF
--- a/kie-osgi/kie-karaf-itests/src/test/resources/org/kie/karaf/itest/kie-beans-persistence.xml
+++ b/kie-osgi/kie-karaf-itests/src/test/resources/org/kie/karaf/itest/kie-beans-persistence.xml
@@ -18,7 +18,7 @@
 
     <bean id="jbpm-ds" class="org.springframework.jdbc.datasource.DriverManagerDataSource">
         <property name="driverClassName" value="org.h2.Driver"/>
-        <property name="url" value="jdbc:h2:tcp://localhost/~/jbpmprocess"/>
+        <property name="url" value="jdbc:h2:tcp://localhost/./jbpmprocess"/>
         <property name="username" value="sa"/>
         <property name="password" value=""/>
     </bean>


### PR DESCRIPTION
…ectory

@psiroky wdyt?

with this change the db file is stored under: kie-karaf-itests/target/paxexam/unpack/879a6f3e-fbe0-4813-8f9e-71731daa542d/
where the last directory is generated.