### PR TITLE
JBPM-5468 - Enable multiple column sorting on advanced queries

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
@@ -94,7 +94,6 @@ public class KieServerConstants {
     public static final String KIE_SERVER_ROUTER = "org.kie.server.router";
     public static final String KIE_SERVER_ROUTER_ATTEMPT_INTERVAL = "org.kie.server.router.connect";
 
-
     public static final String CAPABILITY_BRM = "BRM"; // Business Rules Management
     public static final String CAPABILITY_BPM = "BPM"; // Business Process Management
     public static final String CAPABILITY_BPM_UI = "BPM-UI"; // Business Process Management UI
@@ -118,6 +117,7 @@ public class KieServerConstants {
 
     public static final String QUERY_ORDER_BY = "q_order_by";
     public static final String QUERY_ASCENDING = "q_ascending";
+    public static final String QUERY_ORDER_BY_CLAUSE = "q_order_by_clause";
     public static final String QUERY_COLUMN_MAPPING = "q_column_mapping";
 
     public static final String CFG_KIE_SERVER_JMS_SESSION_TX = "org.kie.server.jms.session.tx";

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/definition/QueryFilterSpec.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/definition/QueryFilterSpec.java
@@ -17,6 +17,7 @@ package org.kie.server.api.model.definition;
 
 import java.util.Arrays;
 import java.util.Map;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
@@ -26,15 +27,16 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "query-filter-spec")
 public class QueryFilterSpec {
 
-    @XmlElement(name="order-by")
+    @XmlElement(name = "order-by")
     private String orderBy;
-    @XmlElement(name="order-asc")
+    @XmlElement(name = "order-asc")
     private boolean ascending;
-    @XmlElement(name="query-params")
+    @XmlElement(name = "query-params")
     private QueryParam[] parameters;
-
-    @XmlElement(name="result-column-mapping")
+    @XmlElement(name = "result-column-mapping")
     private Map<String, String> columnMapping;
+    @XmlElement(name = "order-by-clause")
+    private String orderByClause;
 
     public QueryFilterSpec() {
     }
@@ -71,12 +73,17 @@ public class QueryFilterSpec {
         this.columnMapping = columnMapping;
     }
 
+    public String getOrderByClause() {
+        return this.orderByClause;
+    }
+
+    public void setOrderByClause(String orderByClause) {
+        this.orderByClause = orderByClause;
+    }
+
     @Override
     public String toString() {
-        return "QueryFilterSpec{" +
-                "orderBy='" + orderBy + '\'' +
-                ", ascending=" + ascending +
-                ", parameters=" + Arrays.toString(parameters) +
-                '}';
+        return "QueryFilterSpec{" + "orderBy='" + orderBy + '\'' + ", ascending=" + ascending + ", parameters=" + Arrays.toString(parameters) + '}';
     }
+
 }

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/QueryServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/QueryServicesClientImpl.java
@@ -15,6 +15,38 @@
 
 package org.kie.server.client.impl;
 
+import static org.kie.server.api.rest.RestURI.CONTAINER_ID;
+import static org.kie.server.api.rest.RestURI.CORRELATION_KEY;
+import static org.kie.server.api.rest.RestURI.CREATE_QUERY_DEF_POST_URI;
+import static org.kie.server.api.rest.RestURI.DROP_QUERY_DEF_DELETE_URI;
+import static org.kie.server.api.rest.RestURI.NODE_INSTANCES_BY_INSTANCE_ID_GET_URI;
+import static org.kie.server.api.rest.RestURI.NODE_INSTANCES_BY_WORK_ITEM_ID_GET_URI;
+import static org.kie.server.api.rest.RestURI.PROCESS_DEFINITIONS_BY_CONTAINER_ID_DEF_ID_GET_URI;
+import static org.kie.server.api.rest.RestURI.PROCESS_DEFINITIONS_BY_CONTAINER_ID_GET_URI;
+import static org.kie.server.api.rest.RestURI.PROCESS_DEFINITIONS_BY_ID_GET_URI;
+import static org.kie.server.api.rest.RestURI.PROCESS_DEFINITIONS_GET_URI;
+import static org.kie.server.api.rest.RestURI.PROCESS_ID;
+import static org.kie.server.api.rest.RestURI.PROCESS_INSTANCES_BY_CONTAINER_ID_GET_URI;
+import static org.kie.server.api.rest.RestURI.PROCESS_INSTANCES_BY_CORRELATION_KEY_GET_URI;
+import static org.kie.server.api.rest.RestURI.PROCESS_INSTANCES_BY_PROCESS_ID_GET_URI;
+import static org.kie.server.api.rest.RestURI.PROCESS_INSTANCES_GET_URI;
+import static org.kie.server.api.rest.RestURI.PROCESS_INSTANCE_BY_CORRELATION_KEY_GET_URI;
+import static org.kie.server.api.rest.RestURI.PROCESS_INSTANCE_BY_INSTANCE_ID_GET_URI;
+import static org.kie.server.api.rest.RestURI.PROCESS_INSTANCE_BY_VAR_NAME_GET_URI;
+import static org.kie.server.api.rest.RestURI.PROCESS_INST_ID;
+import static org.kie.server.api.rest.RestURI.QUERY_DEF_GET_URI;
+import static org.kie.server.api.rest.RestURI.QUERY_DEF_URI;
+import static org.kie.server.api.rest.RestURI.QUERY_NAME;
+import static org.kie.server.api.rest.RestURI.QUERY_URI;
+import static org.kie.server.api.rest.RestURI.REPLACE_QUERY_DEF_PUT_URI;
+import static org.kie.server.api.rest.RestURI.RUN_FILTERED_QUERY_DEF_POST_URI;
+import static org.kie.server.api.rest.RestURI.RUN_QUERY_DEF_GET_URI;
+import static org.kie.server.api.rest.RestURI.VAR_INSTANCES_BY_INSTANCE_ID_GET_URI;
+import static org.kie.server.api.rest.RestURI.VAR_INSTANCES_BY_VAR_INSTANCE_ID_GET_URI;
+import static org.kie.server.api.rest.RestURI.VAR_NAME;
+import static org.kie.server.api.rest.RestURI.WORK_ITEM_ID;
+import static org.kie.server.api.rest.RestURI.build;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,8 +79,6 @@ import org.kie.server.api.model.instance.VariableInstanceList;
 import org.kie.server.client.KieServicesConfiguration;
 import org.kie.server.client.QueryServicesClient;
 
-import static org.kie.server.api.rest.RestURI.*;
-
 public class QueryServicesClientImpl extends AbstractKieServicesClientImpl implements QueryServicesClient {
 
     public QueryServicesClientImpl(KieServicesConfiguration config) {
@@ -62,17 +92,15 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public List<ProcessDefinition> findProcessesById(String processId) {
         ProcessDefinitionList result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(PROCESS_ID, processId);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_DEFINITIONS_BY_ID_GET_URI, valuesMap), ProcessDefinitionList.class);
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_DEFINITIONS_BY_ID_GET_URI, valuesMap), ProcessDefinitionList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessesById", new Object[]{processId}) ) );
-            ServiceResponse<ProcessDefinitionList> response = (ServiceResponse<ProcessDefinitionList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessesById", new Object[]{processId})));
+            ServiceResponse<ProcessDefinitionList> response = (ServiceResponse<ProcessDefinitionList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -105,21 +133,17 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
 
     @Override
     public ProcessDefinition findProcessByContainerIdProcessId(String containerId, String processId) {
-        ProcessDefinition  result = null;
-        if( config.isRest() ) {
+        ProcessDefinition result = null;
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(CONTAINER_ID, containerId);
             valuesMap.put(PROCESS_ID, processId);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_DEFINITIONS_BY_CONTAINER_ID_DEF_ID_GET_URI, valuesMap), ProcessDefinition.class);
-
-
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_DEFINITIONS_BY_CONTAINER_ID_DEF_ID_GET_URI, valuesMap), ProcessDefinition.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessesByDeploymentIdProcessId", new Object[]{containerId, processId}) ) );
-            ServiceResponse<ProcessDefinition> response = (ServiceResponse<ProcessDefinition>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessesByDeploymentIdProcessId", new Object[]{containerId, processId})));
+            ServiceResponse<ProcessDefinition> response = (ServiceResponse<ProcessDefinition>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -134,18 +158,16 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public List<ProcessDefinition> findProcesses(Integer page, Integer pageSize, String sort, boolean sortOrder) {
         ProcessDefinitionList result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
 
-            String queryString = getPagingQueryString("?sort="+sort+"&sortOrder="+sortOrder, page, pageSize);
+            String queryString = getPagingQueryString("?sort=" + sort + "&sortOrder=" + sortOrder, page, pageSize);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_DEFINITIONS_GET_URI, valuesMap) + queryString, ProcessDefinitionList.class);
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_DEFINITIONS_GET_URI, valuesMap) + queryString, ProcessDefinitionList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessesByFilter", new Object[]{"", page, pageSize, sort, sortOrder}) ) );
-            ServiceResponse<ProcessDefinitionList> response = (ServiceResponse<ProcessDefinitionList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessesByFilter", new Object[]{"", page, pageSize, sort, sortOrder})));
+            ServiceResponse<ProcessDefinitionList> response = (ServiceResponse<ProcessDefinitionList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -164,18 +186,16 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public List<ProcessDefinition> findProcesses(String filter, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         ProcessDefinitionList result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
 
-            String queryString = getPagingQueryString("?filter=" + filter+"&sort="+sort+"&sortOrder="+sortOrder, page, pageSize);
+            String queryString = getPagingQueryString("?filter=" + filter + "&sort=" + sort + "&sortOrder=" + sortOrder, page, pageSize);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_DEFINITIONS_GET_URI, valuesMap) + queryString, ProcessDefinitionList.class);
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_DEFINITIONS_GET_URI, valuesMap) + queryString, ProcessDefinitionList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessesByFilter", new Object[]{filter, page, pageSize, sort, sortOrder}) ) );
-            ServiceResponse<ProcessDefinitionList> response = (ServiceResponse<ProcessDefinitionList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessesByFilter", new Object[]{filter, page, pageSize, sort, sortOrder})));
+            ServiceResponse<ProcessDefinitionList> response = (ServiceResponse<ProcessDefinitionList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -194,20 +214,17 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public List<ProcessDefinition> findProcessesByContainerId(String containerId, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         ProcessDefinitionList result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(CONTAINER_ID, containerId);
 
-            String queryString = getPagingQueryString("?sort="+sort+"&sortOrder="+sortOrder, page, pageSize);
+            String queryString = getPagingQueryString("?sort=" + sort + "&sortOrder=" + sortOrder, page, pageSize);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_DEFINITIONS_BY_CONTAINER_ID_GET_URI, valuesMap) + queryString, ProcessDefinitionList.class);
-
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_DEFINITIONS_BY_CONTAINER_ID_GET_URI, valuesMap) + queryString, ProcessDefinitionList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessesByDeploymentId", new Object[]{containerId, page, pageSize, sort, sortOrder}) ) );
-            ServiceResponse<ProcessDefinitionList> response = (ServiceResponse<ProcessDefinitionList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessesByDeploymentId", new Object[]{containerId, page, pageSize, sort, sortOrder})));
+            ServiceResponse<ProcessDefinitionList> response = (ServiceResponse<ProcessDefinitionList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -271,18 +288,16 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public List<ProcessInstance> findProcessInstances(Integer page, Integer pageSize, String sort, boolean sortOrder) {
         ProcessInstanceList result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
 
-            String queryString = getPagingQueryString("?sort="+sort+"&sortOrder="+sortOrder, page, pageSize);
+            String queryString = getPagingQueryString("?sort=" + sort + "&sortOrder=" + sortOrder, page, pageSize);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCES_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCES_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessInstances", new Object[]{new ArrayList(), "", "", page, pageSize, sort, sortOrder}) ) );
-            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessInstances", new Object[]{new ArrayList(), "", "", page, pageSize, sort, sortOrder})));
+            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -290,7 +305,6 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             }
             result = response.getResult();
         }
-
 
         if (result != null && result.getProcessInstances() != null) {
             return Arrays.asList(result.getProcessInstances());
@@ -302,19 +316,17 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public List<ProcessInstance> findProcessInstancesByCorrelationKey(CorrelationKey correlationKey, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         ProcessInstanceList result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(CORRELATION_KEY, correlationKey.toExternalForm());
 
-            String queryString = getPagingQueryString("?sort="+sort+"&sortOrder="+sortOrder, page, pageSize);
+            String queryString = getPagingQueryString("?sort=" + sort + "&sortOrder=" + sortOrder, page, pageSize);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCES_BY_CORRELATION_KEY_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCES_BY_CORRELATION_KEY_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessInstancesByCorrelationKey", new Object[]{correlationKey.toExternalForm(), page, pageSize, sort, sortOrder}) ) );
-            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessInstancesByCorrelationKey", new Object[]{correlationKey.toExternalForm(), page, pageSize, sort, sortOrder})));
+            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -333,20 +345,18 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public List<ProcessInstance> findProcessInstancesByProcessId(String processId, List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         ProcessInstanceList result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(PROCESS_ID, processId);
 
-            String statusQueryString = getAdditionalParams("?sort="+sort+"&sortOrder="+sortOrder, "status", status);
+            String statusQueryString = getAdditionalParams("?sort=" + sort + "&sortOrder=" + sortOrder, "status", status);
             String queryString = getPagingQueryString(statusQueryString, page, pageSize);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCES_BY_PROCESS_ID_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCES_BY_PROCESS_ID_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessInstancesByProcessId", new Object[]{processId, safeList(status), "", page, pageSize, sort, sortOrder}) ) );
-            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessInstancesByProcessId", new Object[]{processId, safeList(status), "", page, pageSize, sort, sortOrder})));
+            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -354,7 +364,6 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             }
             result = response.getResult();
         }
-
 
         if (result != null && result.getProcessInstances() != null) {
             return Arrays.asList(result.getProcessInstances());
@@ -366,19 +375,17 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public List<ProcessInstance> findProcessInstancesByProcessName(String processName, List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         ProcessInstanceList result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
 
-            String statusQueryString = getAdditionalParams("?processName=" + processName+"&sort="+sort+"&sortOrder="+sortOrder, "status", status);
+            String statusQueryString = getAdditionalParams("?processName=" + processName + "&sort=" + sort + "&sortOrder=" + sortOrder, "status", status);
             String queryString = getPagingQueryString(statusQueryString, page, pageSize);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCES_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCES_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessInstances", new Object[]{safeList(status), "", processName, page, pageSize, sort, sortOrder}) ) );
-            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessInstances", new Object[]{safeList(status), "", processName, page, pageSize, sort, sortOrder})));
+            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -386,7 +393,6 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             }
             result = response.getResult();
         }
-
 
         if (result != null && result.getProcessInstances() != null) {
             return Arrays.asList(result.getProcessInstances());
@@ -398,20 +404,18 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public List<ProcessInstance> findProcessInstancesByContainerId(String containerId, List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         ProcessInstanceList result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(CONTAINER_ID, containerId);
 
-            String statusQueryString = getAdditionalParams("?sort="+sort+"&sortOrder="+sortOrder, "status", status);
+            String statusQueryString = getAdditionalParams("?sort=" + sort + "&sortOrder=" + sortOrder, "status", status);
             String queryString = getPagingQueryString(statusQueryString, page, pageSize);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCES_BY_CONTAINER_ID_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCES_BY_CONTAINER_ID_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessInstancesByDeploymentId", new Object[]{containerId, safeList(status), page, pageSize, sort, sortOrder}) ) );
-            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessInstancesByDeploymentId", new Object[]{containerId, safeList(status), page, pageSize, sort, sortOrder})));
+            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -419,7 +423,6 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             }
             result = response.getResult();
         }
-
 
         if (result != null && result.getProcessInstances() != null) {
             return Arrays.asList(result.getProcessInstances());
@@ -431,18 +434,16 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public List<ProcessInstance> findProcessInstancesByStatus(List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         ProcessInstanceList result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
 
-            String statusQueryString = getAdditionalParams("?sort="+sort+"&sortOrder="+sortOrder, "status", status);
+            String statusQueryString = getAdditionalParams("?sort=" + sort + "&sortOrder=" + sortOrder, "status", status);
             String queryString = getPagingQueryString(statusQueryString, page, pageSize);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCES_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCES_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessInstances", new Object[]{safeList(status), "", "", page, pageSize, sort, sortOrder}) ) );
-            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessInstances", new Object[]{safeList(status), "", "", page, pageSize, sort, sortOrder})));
+            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -450,7 +451,6 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             }
             result = response.getResult();
         }
-
 
         if (result != null && result.getProcessInstances() != null) {
             return Arrays.asList(result.getProcessInstances());
@@ -462,20 +462,17 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public List<ProcessInstance> findProcessInstancesByInitiator(String initiator, List<Integer> status, Integer page, Integer pageSize, String sort, boolean sortOrder) {
         ProcessInstanceList result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
 
-            String statusQueryString = getAdditionalParams("?initiator=" + initiator+"&sort="+sort+"&sortOrder="+sortOrder, "status", status);
+            String statusQueryString = getAdditionalParams("?initiator=" + initiator + "&sort=" + sort + "&sortOrder=" + sortOrder, "status", status);
             String queryString = getPagingQueryString(statusQueryString, page, pageSize);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCES_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
-
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCES_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessInstances", new Object[]{safeList(status), initiator, "", page, pageSize, sort, sortOrder}) ) );
-            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessInstances", new Object[]{safeList(status), initiator, "", page, pageSize, sort, sortOrder})));
+            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -483,7 +480,6 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             }
             result = response.getResult();
         }
-
 
         if (result != null && result.getProcessInstances() != null) {
             return Arrays.asList(result.getProcessInstances());
@@ -499,17 +495,14 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(VAR_NAME, variableName);
 
-            String statusQueryString = getAdditionalParams("?sort="+sort+"&sortOrder="+sortOrder, "status", status);
+            String statusQueryString = getAdditionalParams("?sort=" + sort + "&sortOrder=" + sortOrder, "status", status);
             String queryString = getPagingQueryString(statusQueryString, page, pageSize);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCE_BY_VAR_NAME_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
-
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCE_BY_VAR_NAME_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessInstanceByVariables", new Object[]{variableName, "", safeList(status), page, pageSize, sort, sortOrder}) ) );
-            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessInstanceByVariables", new Object[]{variableName, "", safeList(status), page, pageSize, sort, sortOrder})));
+            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -532,18 +525,14 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(VAR_NAME, variableName);
 
-            String statusQueryString = getAdditionalParams("?varValue=" + variableValue+"&sort="+sort+"&sortOrder="+sortOrder, "status", status);
+            String statusQueryString = getAdditionalParams("?varValue=" + variableValue + "&sort=" + sort + "&sortOrder=" + sortOrder, "status", status);
             String queryString = getPagingQueryString(statusQueryString, page, pageSize);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCE_BY_VAR_NAME_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
-
-
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCE_BY_VAR_NAME_GET_URI, valuesMap) + queryString, ProcessInstanceList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessInstanceByVariables", new Object[]{variableName, variableValue, safeList(status), page, pageSize, sort, sortOrder}) ) );
-            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessInstanceByVariables", new Object[]{variableName, variableValue, safeList(status), page, pageSize, sort, sortOrder})));
+            ServiceResponse<ProcessInstanceList> response = (ServiceResponse<ProcessInstanceList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -562,17 +551,15 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public ProcessInstance findProcessInstanceById(Long processInstanceId) {
         ProcessInstance result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(PROCESS_INST_ID, processInstanceId);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCE_BY_INSTANCE_ID_GET_URI, valuesMap), ProcessInstance.class);
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCE_BY_INSTANCE_ID_GET_URI, valuesMap), ProcessInstance.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessInstanceById", new Object[]{processInstanceId}) ) );
-            ServiceResponse<ProcessInstance> response = (ServiceResponse<ProcessInstance>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessInstanceById", new Object[]{processInstanceId})));
+            ServiceResponse<ProcessInstance> response = (ServiceResponse<ProcessInstance>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -587,17 +574,15 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public ProcessInstance findProcessInstanceById(Long processInstanceId, boolean withVars) {
         ProcessInstance result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(PROCESS_INST_ID, processInstanceId);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCE_BY_INSTANCE_ID_GET_URI, valuesMap) + "?withVars=" + withVars, ProcessInstance.class);
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCE_BY_INSTANCE_ID_GET_URI, valuesMap) + "?withVars=" + withVars, ProcessInstance.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessInstanceById", new Object[]{processInstanceId, withVars}) ) );
-            ServiceResponse<ProcessInstance> response = (ServiceResponse<ProcessInstance>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessInstanceById", new Object[]{processInstanceId, withVars})));
+            ServiceResponse<ProcessInstance> response = (ServiceResponse<ProcessInstance>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -612,17 +597,15 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public ProcessInstance findProcessInstanceByCorrelationKey(CorrelationKey correlationKey) {
         ProcessInstance result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(CORRELATION_KEY, correlationKey.toExternalForm());
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCE_BY_CORRELATION_KEY_GET_URI, valuesMap), ProcessInstance.class);
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_INSTANCE_BY_CORRELATION_KEY_GET_URI, valuesMap), ProcessInstance.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessInstanceByCorrelationKey", new Object[]{correlationKey.toExternalForm()}) ) );
-            ServiceResponse<ProcessInstance> response = (ServiceResponse<ProcessInstance>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessInstanceByCorrelationKey", new Object[]{correlationKey.toExternalForm()})));
+            ServiceResponse<ProcessInstance> response = (ServiceResponse<ProcessInstance>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -637,18 +620,16 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public NodeInstance findNodeInstanceByWorkItemId(Long processInstanceId, Long workItemId) {
         NodeInstance result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(PROCESS_INST_ID, processInstanceId);
             valuesMap.put(WORK_ITEM_ID, workItemId);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + NODE_INSTANCES_BY_WORK_ITEM_ID_GET_URI, valuesMap), NodeInstance.class);
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + NODE_INSTANCES_BY_WORK_ITEM_ID_GET_URI, valuesMap), NodeInstance.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getNodeInstanceForWorkItem", new Object[]{processInstanceId, workItemId}) ) );
-            ServiceResponse<NodeInstance> response = (ServiceResponse<NodeInstance>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getNodeInstanceForWorkItem", new Object[]{processInstanceId, workItemId})));
+            ServiceResponse<NodeInstance> response = (ServiceResponse<NodeInstance>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -664,20 +645,17 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     public List<NodeInstance> findActiveNodeInstances(Long processInstanceId, Integer page, Integer pageSize) {
         NodeInstanceList result = null;
 
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(PROCESS_INST_ID, processInstanceId);
 
             String queryString = getPagingQueryString("?activeOnly=true", page, pageSize);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + NODE_INSTANCES_BY_INSTANCE_ID_GET_URI, valuesMap) + queryString, NodeInstanceList.class);
-
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + NODE_INSTANCES_BY_INSTANCE_ID_GET_URI, valuesMap) + queryString, NodeInstanceList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessInstanceHistory", new Object[]{processInstanceId, true, false, page, pageSize}) ) );
-            ServiceResponse<NodeInstanceList> response = (ServiceResponse<NodeInstanceList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessInstanceHistory", new Object[]{processInstanceId, true, false, page, pageSize})));
+            ServiceResponse<NodeInstanceList> response = (ServiceResponse<NodeInstanceList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -696,20 +674,17 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public List<NodeInstance> findCompletedNodeInstances(Long processInstanceId, Integer page, Integer pageSize) {
         NodeInstanceList result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(PROCESS_INST_ID, processInstanceId);
 
             String queryString = getPagingQueryString("?completedOnly=true", page, pageSize);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + NODE_INSTANCES_BY_INSTANCE_ID_GET_URI, valuesMap) + queryString, NodeInstanceList.class);
-
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + NODE_INSTANCES_BY_INSTANCE_ID_GET_URI, valuesMap) + queryString, NodeInstanceList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessInstanceHistory", new Object[]{processInstanceId, false, true, page, pageSize}) ) );
-            ServiceResponse<NodeInstanceList> response = (ServiceResponse<NodeInstanceList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessInstanceHistory", new Object[]{processInstanceId, false, true, page, pageSize})));
+            ServiceResponse<NodeInstanceList> response = (ServiceResponse<NodeInstanceList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -717,7 +692,6 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             }
             result = response.getResult();
         }
-
 
         if (result != null && result.getNodeInstances() != null) {
             return Arrays.asList(result.getNodeInstances());
@@ -729,20 +703,17 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public List<NodeInstance> findNodeInstances(Long processInstanceId, Integer page, Integer pageSize) {
         NodeInstanceList result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(PROCESS_INST_ID, processInstanceId);
 
             String queryString = getPagingQueryString("", page, pageSize);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + NODE_INSTANCES_BY_INSTANCE_ID_GET_URI, valuesMap) + queryString, NodeInstanceList.class);
-
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + NODE_INSTANCES_BY_INSTANCE_ID_GET_URI, valuesMap) + queryString, NodeInstanceList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getProcessInstanceHistory", new Object[]{processInstanceId, true, true, page, pageSize}) ) );
-            ServiceResponse<NodeInstanceList> response = (ServiceResponse<NodeInstanceList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessInstanceHistory", new Object[]{processInstanceId, true, true, page, pageSize})));
+            ServiceResponse<NodeInstanceList> response = (ServiceResponse<NodeInstanceList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -762,19 +733,15 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     public List<VariableInstance> findVariablesCurrentState(Long processInstanceId) {
         VariableInstanceList result = null;
 
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(PROCESS_INST_ID, processInstanceId);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + VAR_INSTANCES_BY_INSTANCE_ID_GET_URI, valuesMap), VariableInstanceList.class);
-
-
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + VAR_INSTANCES_BY_INSTANCE_ID_GET_URI, valuesMap), VariableInstanceList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getVariablesCurrentState", new Object[]{processInstanceId}) ) );
-            ServiceResponse<VariableInstanceList> response = (ServiceResponse<VariableInstanceList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getVariablesCurrentState", new Object[]{processInstanceId})));
+            ServiceResponse<VariableInstanceList> response = (ServiceResponse<VariableInstanceList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -794,21 +761,18 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     public List<VariableInstance> findVariableHistory(Long processInstanceId, String variableName, Integer page, Integer pageSize) {
         VariableInstanceList result = null;
 
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(PROCESS_INST_ID, processInstanceId);
             valuesMap.put(VAR_NAME, variableName);
 
             String queryString = getPagingQueryString("", page, pageSize);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_URI + "/" + VAR_INSTANCES_BY_VAR_INSTANCE_ID_GET_URI, valuesMap) + queryString, VariableInstanceList.class);
-
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + VAR_INSTANCES_BY_VAR_INSTANCE_ID_GET_URI, valuesMap) + queryString, VariableInstanceList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryService", "getVariableHistory", new Object[]{processInstanceId, variableName, page, pageSize}) ) );
-            ServiceResponse<VariableInstanceList> response = (ServiceResponse<VariableInstanceList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getVariableHistory", new Object[]{processInstanceId, variableName, page, pageSize})));
+            ServiceResponse<VariableInstanceList> response = (ServiceResponse<VariableInstanceList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -816,7 +780,6 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             }
             result = response.getResult();
         }
-
 
         if (result != null && result.getVariableInstances() != null) {
             return Arrays.asList(result.getVariableInstances());
@@ -828,19 +791,16 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     // QueryDataService related
     @Override
     public void registerQuery(QueryDefinition queryDefinition) {
-        if( config.isRest() ) {
+        if (config.isRest()) {
 
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(QUERY_NAME, queryDefinition.getName());
 
-            makeHttpPostRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_DEF_URI + "/" + CREATE_QUERY_DEF_POST_URI, valuesMap), queryDefinition,
-                    Object.class);
+            makeHttpPostRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_DEF_URI + "/" + CREATE_QUERY_DEF_POST_URI, valuesMap), queryDefinition, Object.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList(
-                    (KieServerCommand) new DescriptorCommand( "QueryDataService", "registerQuery", serialize(queryDefinition), marshaller.getFormat().getType(), new Object[]{queryDefinition.getName()}) ) );
-            ServiceResponse<String> response = (ServiceResponse<String>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryDataService", "registerQuery", serialize(queryDefinition), marshaller.getFormat().getType(), new Object[]{queryDefinition.getName()})));
+            ServiceResponse<String> response = (ServiceResponse<String>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
         }
@@ -848,19 +808,16 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
 
     @Override
     public void replaceQuery(QueryDefinition queryDefinition) {
-        if( config.isRest() ) {
+        if (config.isRest()) {
 
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(QUERY_NAME, queryDefinition.getName());
 
-            makeHttpPutRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_DEF_URI + "/" + REPLACE_QUERY_DEF_PUT_URI, valuesMap), queryDefinition,
-                    Object.class, new HashMap<String, String>());
+            makeHttpPutRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_DEF_URI + "/" + REPLACE_QUERY_DEF_PUT_URI, valuesMap), queryDefinition, Object.class, new HashMap<String, String>());
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList(
-                    (KieServerCommand) new DescriptorCommand( "QueryDataService", "replaceQuery", serialize(queryDefinition), marshaller.getFormat().getType(), new Object[]{queryDefinition.getName()}) ) );
-            ServiceResponse<String> response = (ServiceResponse<String>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryDataService", "replaceQuery", serialize(queryDefinition), marshaller.getFormat().getType(), new Object[]{queryDefinition.getName()})));
+            ServiceResponse<String> response = (ServiceResponse<String>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
         }
@@ -868,18 +825,15 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
 
     @Override
     public void unregisterQuery(String queryName) {
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(QUERY_NAME, queryName);
 
-            makeHttpDeleteRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_DEF_URI + "/" + DROP_QUERY_DEF_DELETE_URI, valuesMap),
-                    null);
+            makeHttpDeleteRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_DEF_URI + "/" + DROP_QUERY_DEF_DELETE_URI, valuesMap), null);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList(
-                    (KieServerCommand) new DescriptorCommand( "QueryDataService", "unregisterQuery", new Object[]{queryName})));
-            ServiceResponse<?> response = (ServiceResponse<?>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryDataService", "unregisterQuery", new Object[]{queryName})));
+            ServiceResponse<?> response = (ServiceResponse<?>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
             throwExceptionOnFailure(response);
         }
     }
@@ -887,18 +841,15 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public QueryDefinition getQuery(String queryName) {
         QueryDefinition result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(QUERY_NAME, queryName);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_DEF_URI + "/" + QUERY_DEF_GET_URI, valuesMap), QueryDefinition.class);
-
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_DEF_URI + "/" + QUERY_DEF_GET_URI, valuesMap), QueryDefinition.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryDataService", "getQuery", new Object[]{queryName}) ) );
-            ServiceResponse<QueryDefinition> response = (ServiceResponse<QueryDefinition>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryDataService", "getQuery", new Object[]{queryName})));
+            ServiceResponse<QueryDefinition> response = (ServiceResponse<QueryDefinition>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -913,19 +864,16 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     @Override
     public List<QueryDefinition> getQueries(Integer page, Integer pageSize) {
         QueryDefinitionList result = null;
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
 
             String queryString = getPagingQueryString("", page, pageSize);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_DEF_URI, valuesMap) + queryString, QueryDefinitionList.class);
-
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_DEF_URI, valuesMap) + queryString, QueryDefinitionList.class);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryDataService", "getQueries", new Object[]{page, pageSize}) ) );
-            ServiceResponse<QueryDefinitionList> response = (ServiceResponse<QueryDefinitionList>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryDataService", "getQueries", new Object[]{page, pageSize})));
+            ServiceResponse<QueryDefinitionList> response = (ServiceResponse<QueryDefinitionList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -933,7 +881,6 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             }
             result = response.getResult();
         }
-
 
         if (result != null && result.getQueries() != null) {
             return Arrays.asList(result.getQueries());
@@ -946,20 +893,17 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     public <T> List<T> query(String queryName, String mapper, String orderBy, Integer page, Integer pageSize, Class<T> resultType) {
         Object result = null;
         Class<?> resultTypeList = getResultTypeList(resultType);
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(QUERY_NAME, queryName);
 
-            String queryString = getPagingQueryString("?mapper="+mapper+"&orderBy="+orderBy, page, pageSize);
-
-            result = makeHttpGetRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_DEF_URI + "/" + RUN_QUERY_DEF_GET_URI, valuesMap) + queryString, resultTypeList);
-
+            String queryString = getPagingQueryString("?mapper=" + mapper + "&orderBy=" + orderBy, page, pageSize);
+            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_DEF_URI + "/" + RUN_QUERY_DEF_GET_URI, valuesMap) + queryString, resultTypeList);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryDataService", "query", new Object[]{queryName, mapper, orderBy, page, pageSize}) ) );
-            ServiceResponse<Object> response = (ServiceResponse<Object>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryDataService", "query", new Object[]{queryName, mapper, orderBy, page, pageSize})));
+            ServiceResponse<Object> response = (ServiceResponse<Object>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -968,7 +912,6 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             result = response.getResult();
         }
 
-
         if (result != null) {
 
             if (result instanceof ItemList) {
@@ -976,7 +919,7 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             } else if (result instanceof List) {
                 return (List) result;
             } else if (result instanceof Wrapped) {
-                return (List)((Wrapped) result).unwrap();
+                return (List) ((Wrapped) result).unwrap();
             }
         }
 
@@ -993,20 +936,17 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     public <T> List<T> query(String queryName, String mapper, QueryFilterSpec filterSpec, Integer page, Integer pageSize, Class<T> resultType) {
         Object result = null;
         Class<?> resultTypeList = getResultTypeList(resultType);
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(QUERY_NAME, queryName);
 
-            String queryString = getPagingQueryString("?mapper="+mapper, page, pageSize);
+            String queryString = getPagingQueryString("?mapper=" + mapper, page, pageSize);
 
-            result = makeHttpPostRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_DEF_URI + "/" + RUN_FILTERED_QUERY_DEF_POST_URI, valuesMap) + queryString, filterSpec, resultTypeList);
-
+            result = makeHttpPostRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_DEF_URI + "/" + RUN_FILTERED_QUERY_DEF_POST_URI, valuesMap) + queryString, filterSpec, resultTypeList);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryDataService", "queryFiltered", serialize(filterSpec), marshaller.getFormat().getType(), new Object[]{queryName, mapper, page, pageSize}) ) );
-            ServiceResponse<Object> response = (ServiceResponse<Object>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryDataService", "queryFiltered", serialize(filterSpec), marshaller.getFormat().getType(), new Object[]{queryName, mapper, page, pageSize})));
+            ServiceResponse<Object> response = (ServiceResponse<Object>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -1015,7 +955,6 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             result = response.getResult();
         }
 
-
         if (result != null) {
 
             if (result instanceof ItemList) {
@@ -1023,7 +962,7 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             } else if (result instanceof List) {
                 return (List) result;
             } else if (result instanceof Wrapped) {
-                return (List)((Wrapped) result).unwrap();
+                return (List) ((Wrapped) result).unwrap();
             }
         }
 
@@ -1034,21 +973,17 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
     public <T> List<T> query(String queryName, String mapper, String builder, Map<String, Object> parameters, Integer page, Integer pageSize, Class<T> resultType) {
         Object result = null;
         Class<?> resultTypeList = getResultTypeList(resultType);
-        if( config.isRest() ) {
+        if (config.isRest()) {
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(QUERY_NAME, queryName);
 
-            String queryString = getPagingQueryString("?mapper="+mapper+"&builder="+builder, page, pageSize);
+            String queryString = getPagingQueryString("?mapper=" + mapper + "&builder=" + builder, page, pageSize);
 
-            result = makeHttpPostRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), QUERY_DEF_URI + "/" + RUN_FILTERED_QUERY_DEF_POST_URI, valuesMap) + queryString, parameters, resultTypeList);
-
+            result = makeHttpPostRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_DEF_URI + "/" + RUN_FILTERED_QUERY_DEF_POST_URI, valuesMap) + queryString, parameters, resultTypeList);
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand)
-                    new DescriptorCommand( "QueryDataService", "queryFilteredWithBuilder", serialize(safeMap(parameters)),
-                            marshaller.getFormat().getType(), new Object[]{queryName, mapper, builder, page, pageSize}) ) );
-            ServiceResponse<Object> response = (ServiceResponse<Object>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM" ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryDataService", "queryFilteredWithBuilder", serialize(safeMap(parameters)), marshaller.getFormat().getType(), new Object[]{queryName, mapper, builder, page, pageSize})));
+            ServiceResponse<Object> response = (ServiceResponse<Object>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {
@@ -1057,7 +992,6 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             result = response.getResult();
         }
 
-
         if (result != null) {
 
             if (result instanceof ItemList) {
@@ -1065,7 +999,7 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             } else if (result instanceof List) {
                 return (List) result;
             } else if (result instanceof Wrapped) {
-                return (List)((Wrapped) result).unwrap();
+                return (List) ((Wrapped) result).unwrap();
             }
         }
 

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/build/revapi-config.json
@@ -165,6 +165,17 @@
           "methodName": "getRequestsByCommand",
           "elementKind": "method",
           "justification": "Added support for job status filter"
+        },
+		{
+          "code": "java.annotation.attributeValueChanged",
+          "old": "parameter javax.ws.rs.core.Response org.kie.server.remote.rest.jbpm.QueryDataResource::runQuery(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String, ===java.lang.String===, java.lang.Integer, java.lang.Integer)",
+          "new": "parameter javax.ws.rs.core.Response org.kie.server.remote.rest.jbpm.QueryDataResource::runQuery(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String, ===java.lang.String===, java.lang.Integer, java.lang.Integer)",
+          "attribute": "value",
+          "oldValue": "\"sortBy\"",
+          "newValue": "\"orderBy\"",
+          "annotationType": "javax.ws.rs.QueryParam",
+          "elementKind": "annotation",
+          "justification": "Name of query param needs to be named orderBy as  calls by QueryServiceClient use orderBy, not sortBy"
         }
       ]
     }

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/main/java/org/kie/server/remote/rest/jbpm/QueryDataResource.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/main/java/org/kie/server/remote/rest/jbpm/QueryDataResource.java
@@ -15,7 +15,28 @@
 
 package org.kie.server.remote.rest.jbpm;
 
+import static org.kie.server.api.rest.RestURI.CREATE_QUERY_DEF_POST_URI;
+import static org.kie.server.api.rest.RestURI.DROP_QUERY_DEF_DELETE_URI;
+import static org.kie.server.api.rest.RestURI.QUERY_DEF_GET_URI;
+import static org.kie.server.api.rest.RestURI.QUERY_DEF_URI;
+import static org.kie.server.api.rest.RestURI.REPLACE_QUERY_DEF_PUT_URI;
+import static org.kie.server.api.rest.RestURI.RUN_FILTERED_QUERY_DEF_POST_URI;
+import static org.kie.server.api.rest.RestURI.RUN_QUERY_DEF_GET_URI;
+import static org.kie.server.remote.rest.common.util.RestUtils.alreadyExists;
+import static org.kie.server.remote.rest.common.util.RestUtils.buildConversationIdHeader;
+import static org.kie.server.remote.rest.common.util.RestUtils.createCorrectVariant;
+import static org.kie.server.remote.rest.common.util.RestUtils.createResponse;
+import static org.kie.server.remote.rest.common.util.RestUtils.getContentType;
+import static org.kie.server.remote.rest.common.util.RestUtils.getVariant;
+import static org.kie.server.remote.rest.common.util.RestUtils.internalServerError;
+import static org.kie.server.remote.rest.common.util.RestUtils.noContent;
+import static org.kie.server.remote.rest.common.util.RestUtils.notFound;
+import static org.kie.server.remote.rest.jbpm.resources.Messages.QUERY_ALREADY_EXISTS;
+import static org.kie.server.remote.rest.jbpm.resources.Messages.QUERY_NOT_FOUND;
+import static org.kie.server.remote.rest.jbpm.resources.Messages.UNEXPECTED_ERROR;
+
 import java.text.MessageFormat;
+
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -41,10 +62,6 @@ import org.kie.server.services.jbpm.QueryDataServiceBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.kie.server.api.rest.RestURI.*;
-import static org.kie.server.remote.rest.common.util.RestUtils.*;
-import static org.kie.server.remote.rest.jbpm.resources.Messages.*;
-
 @Path("server/" + QUERY_DEF_URI)
 public class QueryDataResource {
 
@@ -64,8 +81,7 @@ public class QueryDataResource {
 
     @GET
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    public Response getQueries(@Context HttpHeaders headers,
-            @QueryParam("page") @DefaultValue("0") Integer page, @QueryParam("pageSize") @DefaultValue("10") Integer pageSize) {
+    public Response getQueries(@Context HttpHeaders headers, @QueryParam("page") @DefaultValue("0") Integer page, @QueryParam("pageSize") @DefaultValue("10") Integer pageSize) {
         // no container id available so only used to transfer conversation id if given by client
         Header conversationIdHeader = buildConversationIdHeader("", context, headers);
         QueryDefinitionList result = queryDataServiceBase.getQueries(page, pageSize);
@@ -154,9 +170,7 @@ public class QueryDataResource {
     @GET
     @Path(RUN_QUERY_DEF_GET_URI)
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    public Response runQuery(@Context HttpHeaders headers,
-            @PathParam("queryName") String queryName, @QueryParam("mapper") String mapper, @QueryParam("sortBy") String orderBy,
-            @QueryParam("page") @DefaultValue("0") Integer page, @QueryParam("pageSize") @DefaultValue("10") Integer pageSize) {
+    public Response runQuery(@Context HttpHeaders headers, @PathParam("queryName") String queryName, @QueryParam("mapper") String mapper, @QueryParam("orderBy") String orderBy, @QueryParam("page") @DefaultValue("0") Integer page, @QueryParam("pageSize") @DefaultValue("10") Integer pageSize) {
 
         // no container id available so only used to transfer conversation id if given by client
         Header conversationIdHeader = buildConversationIdHeader("", context, headers);
@@ -170,9 +184,7 @@ public class QueryDataResource {
     @POST
     @Path(RUN_FILTERED_QUERY_DEF_POST_URI)
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
-    public Response runQueryFiltered(@Context HttpHeaders headers,
-            @PathParam("queryName") String queryName, @QueryParam("mapper") String mapper, @QueryParam("builder") String builder,
-            @QueryParam("page") @DefaultValue("0") Integer page, @QueryParam("pageSize") @DefaultValue("10") Integer pageSize, String payload) {
+    public Response runQueryFiltered(@Context HttpHeaders headers, @PathParam("queryName") String queryName, @QueryParam("mapper") String mapper, @QueryParam("builder") String builder, @QueryParam("page") @DefaultValue("0") Integer page, @QueryParam("pageSize") @DefaultValue("10") Integer pageSize, String payload) {
 
         String type = getContentType(headers);
         // no container id available so only used to transfer conversation id if given by client


### PR DESCRIPTION
Enhancing the advanced queries provided by REST and JMS to support a full SQL ORDER BY clause. This ensures the sort order can be selected per column of ordering.