### PR TITLE
[GUVNOR-2991] use custom xstream-hibernate converters

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
@@ -105,7 +105,7 @@ public class JSONMarshaller implements Marshaller {
     protected DateFormat dateFormat = new SimpleDateFormat(dateFormatStr);
 
     // Optional Marshaller Extension to handle new types
-    private static List<JSONMarshallerExtension> EXTENSIONS;
+    private static final List<JSONMarshallerExtension> EXTENSIONS;
     
     // Load Marshaller Extension
     static {

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/xstream/XStreamMarshallerExtension.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/xstream/XStreamMarshallerExtension.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.api.marshalling.xstream;
+
+import com.thoughtworks.xstream.mapper.MapperWrapper;
+
+/**
+ * Represents custom extension for the XStream marshaller.
+ */
+public interface XStreamMarshallerExtension {
+
+    /**
+     * Extends the provided marshaller, with e.g. custom converters.
+     *
+     * @param xStreamMarshaller the marshaller which should be extended
+     */
+    void extend(XStreamMarshaller xStreamMarshaller);
+
+    /**
+     * Enables additional {@link MapperWrapper}s by chaining them to the provided one.
+     *
+     * Example: {@code return new HibernateWrapper(next)}
+     *   - this will add the HibernateWrapper into the chain. Note that it is important to pass the {@code next}
+     *     MapperWrapper into the constructor to make sure the chain does not get broken
+     *
+     * Default implementation: identity
+     *
+     * @param next the next {@link MapperWrapper} in the chain
+     */
+    default MapperWrapper chainMapperWrapper(MapperWrapper next) {
+        return next;
+    }
+}

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/pom.xml
@@ -31,6 +31,13 @@
     <dependency>
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-services-common</artifactId>
+      <exclusions>
+        <exclusion>
+          <!-- Collides with xml-apis:xml-apis -->
+          <groupId>javax.xml.stream</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kie.server</groupId>

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/pom.xml
@@ -35,6 +35,13 @@
     <dependency>
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-services-common</artifactId>
+      <exclusions>
+        <exclusion>
+          <!-- Collides with xml-apis:xml-apis -->
+          <groupId>javax.xml.stream</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -130,6 +137,14 @@
       <artifactId>commons-io</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream-hibernate</artifactId>
+    </dependency>
     <!-- TEST -->
     <dependency>
       <groupId>org.jbpm</groupId>
@@ -140,13 +155,6 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <!-- Collides with 'javax.xml.stream:stax-api' and is not required for the tests. -->
-          <groupId>xml-apis</groupId>
-          <artifactId>xml-apis</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.h2database</groupId>

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/xstream/HibernateXStreamMarshallerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/xstream/HibernateXStreamMarshallerExtension.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.services.jbpm.xstream;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.hibernate.converter.HibernatePersistentCollectionConverter;
+import com.thoughtworks.xstream.hibernate.converter.HibernatePersistentMapConverter;
+import com.thoughtworks.xstream.hibernate.converter.HibernatePersistentSortedMapConverter;
+import com.thoughtworks.xstream.hibernate.converter.HibernatePersistentSortedSetConverter;
+import com.thoughtworks.xstream.hibernate.converter.HibernateProxyConverter;
+import com.thoughtworks.xstream.hibernate.mapper.HibernateMapper;
+import com.thoughtworks.xstream.mapper.MapperWrapper;
+import org.kie.server.api.marshalling.xstream.XStreamMarshaller;
+import org.kie.server.api.marshalling.xstream.XStreamMarshallerExtension;
+
+public class HibernateXStreamMarshallerExtension implements XStreamMarshallerExtension {
+
+    @Override
+    public void extend(XStreamMarshaller marshaller) {
+        XStream xstream = marshaller.getXstream();
+        xstream.registerConverter(new HibernateProxyConverter());
+        xstream.registerConverter(new HibernatePersistentCollectionConverter(xstream.getMapper()));
+        xstream.registerConverter(new HibernatePersistentMapConverter(xstream.getMapper()));
+        xstream.registerConverter(new HibernatePersistentSortedMapConverter(xstream.getMapper()));
+        xstream.registerConverter(new HibernatePersistentSortedSetConverter(xstream.getMapper()));
+    }
+
+    @Override
+    public MapperWrapper chainMapperWrapper(MapperWrapper next) {
+        return new HibernateMapper(next);
+    }
+
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/resources/META-INF/services/org.kie.server.api.marshalling.xstream.XStreamMarshallerExtension
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/resources/META-INF/services/org.kie.server.api.marshalling.xstream.XStreamMarshallerExtension
@@ -1,0 +1,1 @@
+org.kie.server.services.jbpm.xstream.HibernateXStreamMarshallerExtension

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/test/java/org/kie/server/services/jbpm/xstream/HibernateXStreamMarshallerExtensionTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/test/java/org/kie/server/services/jbpm/xstream/HibernateXStreamMarshallerExtensionTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.services.jbpm.xstream;
+
+import org.hibernate.collection.internal.PersistentBag;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.junit.Assert;
+import org.junit.Test;
+import org.kie.server.api.marshalling.Marshaller;
+import org.kie.server.api.marshalling.MarshallerFactory;
+import org.kie.server.api.marshalling.MarshallingFormat;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+
+public class HibernateXStreamMarshallerExtensionTest {
+
+    @Test
+    public void testMarshallDummyHibernatePersistenceBag() {
+        SessionImplementor session = Mockito.mock(SessionImplementor.class);
+        Mockito.when(session.isOpen()).thenReturn(true);
+        Mockito.when(session.isConnected()).thenReturn(true);
+        PersistentBag bag = new PersistentBag(session, new ArrayList<String>());
+        String expectedOutput = "<list/>";
+        Marshaller marshaller = MarshallerFactory.getMarshaller(MarshallingFormat.XSTREAM, getClass().getClassLoader());
+        Assert.assertEquals(expectedOutput, marshaller.marshall(bag));
+    }
+}

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -40,7 +40,7 @@
     <kie.server.testing.kjars.build.settings.xml/>
     <org.jbpm.document.storage>${project.build.directory}/docs</org.jbpm.document.storage>
     <kie.server.router.url>http://localhost:${router.port}</kie.server.router.url>
-    <!-- This property can be overriden to exclude specific test category according to specific needs. -->
+    <!-- This property can be overridden to exclude specific test category according to specific needs. -->
     <failsafe.excluded.groups/>
     <!-- Sybase driver leaks its Timestamp implementation. To correctly handle it we need to add driver as additional test classpath. -->
     <maven.jdbc.driver.jar/>


### PR DESCRIPTION
This is needed to make sure that KIE Server is not sending away the
marshalled inernal hibernate types (like e.g. PersistentBag). Those
then can not be un-marshalled unless hibernate is on classpath.
This was an issue in workench where the hibernate was recently removed
from WEB-INF/lib.

Depends on https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/428

@mswiderski could you please take a look?