### PR TITLE
kie-server-tests: Add container config test coverage

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
@@ -94,6 +94,11 @@ public class KieServerConstants {
     public static final String KIE_SERVER_ROUTER = "org.kie.server.router";
     public static final String KIE_SERVER_ROUTER_ATTEMPT_INTERVAL = "org.kie.server.router.connect";
 
+    // ProcessConfig configuration item constants
+    public static final String PCFG_RUNTIME_STRATEGY = "RuntimeStrategy";
+    public static final String PCFG_KIE_BASE = "KBase";
+    public static final String PCFG_KIE_SESSION = "KSession";
+    public static final String PCFG_MERGE_MODE = "MergeMode";
 
     public static final String CAPABILITY_BRM = "BRM"; // Business Rules Management
     public static final String CAPABILITY_BPM = "BPM"; // Business Process Management

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerControllerImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerControllerImpl.java
@@ -31,7 +31,6 @@ import org.kie.server.api.model.Message;
 import org.kie.server.controller.api.KieServerController;
 import org.kie.server.controller.api.ModelFactory;
 import org.kie.server.controller.api.model.KieServerSetup;
-import org.kie.server.controller.api.model.KieServerStatus;
 import org.kie.server.controller.api.model.events.ServerInstanceConnected;
 import org.kie.server.controller.api.model.events.ServerInstanceDeleted;
 import org.kie.server.controller.api.model.events.ServerInstanceDisconnected;
@@ -39,16 +38,16 @@ import org.kie.server.controller.api.model.events.ServerInstanceUpdated;
 import org.kie.server.controller.api.model.events.ServerTemplateUpdated;
 import org.kie.server.controller.api.model.runtime.Container;
 import org.kie.server.controller.api.model.runtime.ServerInstance;
+import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
 import org.kie.server.controller.api.model.spec.Capability;
 import org.kie.server.controller.api.model.spec.ContainerConfig;
 import org.kie.server.controller.api.model.spec.ContainerSpec;
 import org.kie.server.controller.api.model.spec.ProcessConfig;
 import org.kie.server.controller.api.model.spec.RuleConfig;
 import org.kie.server.controller.api.model.spec.ServerConfig;
+import org.kie.server.controller.api.model.spec.ServerTemplate;
 import org.kie.server.controller.api.service.NotificationService;
 import org.kie.server.controller.api.storage.KieServerTemplateStorage;
-import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
-import org.kie.server.controller.api.model.spec.ServerTemplate;
 import org.kie.server.controller.impl.service.LoggingNotificationService;
 import org.kie.server.controller.impl.storage.InMemoryKieServerTemplateStorage;
 import org.slf4j.Logger;
@@ -110,28 +109,28 @@ public abstract class KieServerControllerImpl implements KieServerController {
 
                     KieServerConfigItem configItem = new KieServerConfigItem();
                     configItem.setType(KieServerConstants.CAPABILITY_BPM);
-                    configItem.setName("KBase");
+                    configItem.setName(KieServerConstants.PCFG_KIE_BASE);
                     configItem.setValue(processConfig.getKBase());
 
                     containerResource.addConfigItem(configItem);
 
                     configItem = new KieServerConfigItem();
                     configItem.setType(KieServerConstants.CAPABILITY_BPM);
-                    configItem.setName("KSession");
+                    configItem.setName(KieServerConstants.PCFG_KIE_SESSION);
                     configItem.setValue(processConfig.getKSession());
 
                     containerResource.addConfigItem(configItem);
 
                     configItem = new KieServerConfigItem();
                     configItem.setType(KieServerConstants.CAPABILITY_BPM);
-                    configItem.setName("MergeMode");
+                    configItem.setName(KieServerConstants.PCFG_MERGE_MODE);
                     configItem.setValue(processConfig.getMergeMode());
 
                     containerResource.addConfigItem(configItem);
 
                     configItem = new KieServerConfigItem();
                     configItem.setType(KieServerConstants.CAPABILITY_BPM);
-                    configItem.setName("RuntimeStrategy");
+                    configItem.setName(KieServerConstants.PCFG_RUNTIME_STRATEGY);
                     configItem.setValue(processConfig.getRuntimeStrategy());
 
                     containerResource.addConfigItem(configItem);

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
@@ -144,28 +144,28 @@ public class KieServerInstanceManager {
 
                         KieServerConfigItem configItem = new KieServerConfigItem();
                         configItem.setType(KieServerConstants.CAPABILITY_BPM);
-                        configItem.setName("KBase");
+                        configItem.setName(KieServerConstants.PCFG_KIE_BASE);
                         configItem.setValue(processConfig.getKBase());
 
                         containerResource.addConfigItem(configItem);
 
                         configItem = new KieServerConfigItem();
                         configItem.setType(KieServerConstants.CAPABILITY_BPM);
-                        configItem.setName("KSession");
+                        configItem.setName(KieServerConstants.PCFG_KIE_SESSION);
                         configItem.setValue(processConfig.getKSession());
 
                         containerResource.addConfigItem(configItem);
 
                         configItem = new KieServerConfigItem();
                         configItem.setType(KieServerConstants.CAPABILITY_BPM);
-                        configItem.setName("MergeMode");
+                        configItem.setName(KieServerConstants.PCFG_MERGE_MODE);
                         configItem.setValue(processConfig.getMergeMode());
 
                         containerResource.addConfigItem(configItem);
 
                         configItem = new KieServerConfigItem();
                         configItem.setType(KieServerConstants.CAPABILITY_BPM);
-                        configItem.setName("RuntimeStrategy");
+                        configItem.setName(KieServerConstants.PCFG_RUNTIME_STRATEGY);
                         configItem.setValue(processConfig.getRuntimeStrategy());
 
                         containerResource.addConfigItem(configItem);

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
@@ -352,17 +352,17 @@ public class JbpmKieServerExtension implements KieServerExtension {
             // override defaults if config options are given
             KieServerConfig config = new KieServerConfig(kieContainerInstance.getResource().getConfigItems());
 
-            String runtimeStrategy = config.getConfigItemValue("RuntimeStrategy");
+            String runtimeStrategy = config.getConfigItemValue(KieServerConstants.PCFG_RUNTIME_STRATEGY);
             if (runtimeStrategy != null && !runtimeStrategy.isEmpty()) {
                 unit.setStrategy(RuntimeStrategy.valueOf(runtimeStrategy));
             }
-            String mergeMode = config.getConfigItemValue("MergeMode");
+            String mergeMode = config.getConfigItemValue(KieServerConstants.PCFG_MERGE_MODE);
             if (mergeMode != null && !mergeMode.isEmpty()) {
                 unit.setMergeMode(MergeMode.valueOf(mergeMode));
             }
-            String ksession = config.getConfigItemValue("KSession");
+            String ksession = config.getConfigItemValue(KieServerConstants.PCFG_KIE_SESSION);
             unit.setKsessionName(ksession);
-            String kbase = config.getConfigItemValue("KBase");
+            String kbase = config.getConfigItemValue(KieServerConstants.PCFG_KIE_BASE);
             unit.setKbaseName(kbase);
 
             // reuse kieContainer to avoid unneeded bootstrap

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/ImageServiceIncludedKieBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/ImageServiceIncludedKieBaseIntegrationTest.java
@@ -17,6 +17,7 @@ package org.kie.server.integrationtests.jbpm;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.model.KieServerConfigItem;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
@@ -40,7 +41,7 @@ public class ImageServiceIncludedKieBaseIntegrationTest extends JbpmKieServerBas
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/top-level-project").getFile());
 
-        createContainer(CONTAINER_ID, releaseId, new KieServerConfigItem("KBase", "customKB", ""));
+        createContainer(CONTAINER_ID, releaseId, new KieServerConfigItem(KieServerConstants.PCFG_KIE_BASE, "customKB", ""));
     }
 
     @Test

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/filtered-resources/kjars-sources/stateless-session-kjar101/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/filtered-resources/kjars-sources/stateless-session-kjar101/pom.xml
@@ -8,7 +8,7 @@
   </parent>
 
   <artifactId>stateless-session-kjar</artifactId>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <packaging>kjar</packaging>
 
   <build>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/filtered-resources/kjars-sources/stateless-session-kjar101/src/main/resources/META-INF/kmodule.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/filtered-resources/kjars-sources/stateless-session-kjar101/src/main/resources/META-INF/kmodule.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kmodule xmlns="http://www.drools.org/xsd/kmodule">
+  <kbase name="kbase1" packages="kbase1">
+    <ksession name="kbase1.stateless" type="stateless"/>
+  </kbase>
+</kmodule>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/ContainerConfigPropagationIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/ContainerConfigPropagationIntegrationTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.integrationtests.controller;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.api.model.KieScannerStatus;
+import org.kie.server.api.model.KieServerConfigItem;
+import org.kie.server.api.model.KieServerInfo;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.controller.api.ModelFactory;
+import org.kie.server.controller.api.model.spec.Capability;
+import org.kie.server.controller.api.model.spec.ContainerConfig;
+import org.kie.server.controller.api.model.spec.ContainerSpec;
+import org.kie.server.controller.api.model.spec.ProcessConfig;
+import org.kie.server.controller.api.model.spec.RuleConfig;
+import org.kie.server.controller.api.model.spec.ServerTemplate;
+import org.kie.server.controller.impl.storage.InMemoryKieServerTemplateStorage;
+import org.kie.server.integrationtests.shared.KieServerDeployer;
+import org.kie.server.integrationtests.shared.KieServerSynchronization;
+
+public class ContainerConfigPropagationIntegrationTest extends KieControllerManagementBaseTest {
+
+    private static ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "stateless-session-kjar", "1.0.0");
+    private static ReleaseId releaseId101 = new ReleaseId("org.kie.server.testing", "stateless-session-kjar", "1.0.1");
+    private static ReleaseId releaseIdLatest = new ReleaseId("org.kie.server.testing", "stateless-session-kjar", "LATEST");
+
+    private static final String CONTAINER_ID = "kie-concurrent";
+    private static final String CONTAINER_NAME = "containerName";
+
+    private KieServerInfo kieServerInfo;
+
+    @BeforeClass
+    public static void initialize() throws Exception {
+        KieServerDeployer.buildAndDeployCommonMavenParent();
+        KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/stateless-session-kjar").getFile());
+        KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/stateless-session-kjar101").getFile());
+    }
+
+    @Before
+    public void getKieServerInfo() {
+        InMemoryKieServerTemplateStorage.getInstance().clear();
+        // Getting info from currently started kie server.
+        ServiceResponse<KieServerInfo> reply = client.getServerInfo();
+        assumeThat(reply.getType(), is(ServiceResponse.ResponseType.SUCCESS));
+        kieServerInfo = reply.getResult();
+    }
+
+    @Test
+    public void testPropagateScannerContainerConfig() throws Exception {
+        Long pollInterval = 500L;
+        ServerTemplate serverTemplate = createServerTemplate();
+
+        Map<Capability, ContainerConfig> containerConfigMap = new HashMap<>();
+
+        RuleConfig ruleConfig = new RuleConfig(pollInterval, KieScannerStatus.STARTED);
+        containerConfigMap.put(Capability.RULE, ruleConfig);
+
+        // Deploy container for kie server instance with started scanner.
+        ContainerSpec containerToDeploy = new ContainerSpec(CONTAINER_ID, CONTAINER_NAME, serverTemplate, releaseId, KieContainerStatus.STARTED, containerConfigMap);
+        mgmtControllerClient.saveContainerSpec(serverTemplate.getId(), containerToDeploy);
+
+        // Check that container is deployed in kie server.
+        KieServerSynchronization.waitForKieServerSynchronization(client, 1);
+
+        assertContainerInfoWithScanner(releaseId, pollInterval);
+
+        containerToDeploy.setReleasedId(releaseIdLatest);
+        mgmtControllerClient.updateContainerSpec(serverTemplate.getId(), containerToDeploy);
+
+        // Check that container is updated
+        KieServerSynchronization.waitForContainerWithReleaseId(client, releaseId101);
+
+        assertContainerInfoWithScanner(releaseId101, pollInterval);
+    }
+
+    @Test
+    public void testPropagateProcessContainerConfig() throws Exception {
+        ServerTemplate serverTemplate = createServerTemplate();
+
+        Map<Capability, ContainerConfig> containerConfigMap = new HashMap<>();
+
+        ProcessConfig processConfig = new ProcessConfig("PER_PROCESS_INSTANCE", "kieBase", "kieSession", "MERGE_COLLECTION");
+        containerConfigMap.put(Capability.PROCESS, processConfig);
+
+        ContainerSpec containerToDeploy = new ContainerSpec(CONTAINER_ID, CONTAINER_NAME, serverTemplate, releaseId, KieContainerStatus.STARTED, containerConfigMap);
+        mgmtControllerClient.saveContainerSpec(serverTemplate.getId(), containerToDeploy);
+
+        KieServerSynchronization.waitForKieServerSynchronization(client, 1);
+
+        ServiceResponse<KieContainerResource> containerInfo = client.getContainerInfo(CONTAINER_ID);
+        assertEquals(ServiceResponse.ResponseType.SUCCESS, containerInfo.getType());
+        assertEquals(CONTAINER_ID, containerInfo.getResult().getContainerId());
+        assertEquals(KieContainerStatus.STARTED, containerInfo.getResult().getStatus());
+
+        assertEquals(4, containerInfo.getResult().getConfigItems().size());
+        assertTrue(containsConfigItem(containerInfo.getResult(), KieServerConstants.PCFG_RUNTIME_STRATEGY, "PER_PROCESS_INSTANCE", KieServerConstants.CAPABILITY_BPM));
+        assertTrue(containsConfigItem(containerInfo.getResult(), KieServerConstants.PCFG_KIE_BASE, "kieBase", KieServerConstants.CAPABILITY_BPM));
+        assertTrue(containsConfigItem(containerInfo.getResult(), KieServerConstants.PCFG_KIE_SESSION, "kieSession", KieServerConstants.CAPABILITY_BPM));
+        assertTrue(containsConfigItem(containerInfo.getResult(), KieServerConstants.PCFG_MERGE_MODE, "MERGE_COLLECTION", KieServerConstants.CAPABILITY_BPM));
+    }
+
+    private ServerTemplate createServerTemplate() {
+        ServerTemplate serverTemplate = new ServerTemplate();
+        serverTemplate.setId(kieServerInfo.getServerId());
+        serverTemplate.setName(kieServerInfo.getName());
+
+        serverTemplate.addServerInstance(ModelFactory.newServerInstanceKey(serverTemplate.getId(), kieServerInfo.getLocation()));
+        mgmtControllerClient.saveServerTemplate(serverTemplate);
+
+        return serverTemplate;
+    }
+
+    private boolean containsConfigItem(KieContainerResource containerResource, String itemName, String itemValue, String itemType) {
+        Predicate<KieServerConfigItem> matchItem = (n -> n.getName().equals(itemName) && n.getValue().equals(itemValue) && n.getType().equals(itemType));
+        return containerResource.getConfigItems().stream().anyMatch(matchItem);
+    }
+
+    private void assertContainerInfoWithScanner(ReleaseId releaseId, Long pollInterval) {
+        ServiceResponse<KieContainerResource> containerInfo = client.getContainerInfo(CONTAINER_ID);
+        assertEquals(ServiceResponse.ResponseType.SUCCESS, containerInfo.getType());
+        assertEquals(CONTAINER_ID, containerInfo.getResult().getContainerId());
+        assertEquals(KieContainerStatus.STARTED, containerInfo.getResult().getStatus());
+        assertEquals(releaseId, containerInfo.getResult().getResolvedReleaseId());
+
+        assertEquals(pollInterval, containerInfo.getResult().getScanner().getPollInterval());
+        assertEquals(KieScannerStatus.STARTED, containerInfo.getResult().getScanner().getStatus());
+    }
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerStartupIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerStartupIntegrationTest.java
@@ -47,7 +47,7 @@ import org.kie.server.integrationtests.shared.KieServerSynchronization;
 
 public class KieControllerStartupIntegrationTest extends KieControllerManagementBaseTest {
 
-    private static ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "stateless-session-kjar", "1.0.0-SNAPSHOT");
+    private static ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "stateless-session-kjar", "1.0.0");
 
     private static final String CONTAINER_ID = "kie-concurrent";
 


### PR DESCRIPTION
Also moved ProcessConfig configuration items to constants to get rid of hardcoded values in the code.