### PR TITLE
Re-introduce project for QE droolsjbpm-integration tests

### DIFF
--- a/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/pom.xml
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.drools.testcoverage</groupId>
+    <artifactId>kie-maven-plugin-tests-parent</artifactId>
+    <version>7.1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>kjar-with-instrumentation-wrapper</artifactId>
+  <packaging>jar</packaging>
+
+  <name>KIE Integration :: KIE Maven Plugin Instrumented kJAR Wrapper</name>
+
+  <dependencies>
+    <dependency>
+      <!-- Artificial dependency to make sure that kie-maven-plugin is always built before this
+           project - the wrapped kjar project needs the kie-maven-plugin to build.
+           Without this dependency the parallel (-T) build sometimes fails. -->
+      <groupId>org.kie</groupId>
+      <artifactId>kie-maven-plugin</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <configuration>
+          <cloneProjectsTo>${project.build.directory}/wrapped-project</cloneProjectsTo>
+          <localRepositoryPath>${settings.localRepository}</localRepositoryPath>
+          <pom>${project.basedir}/src/test/resources/kjar-with-instrumentation/pom.xml</pom>
+          <streamLogs>true</streamLogs>
+          <goals>
+            <goal>install</goal>
+          </goals>
+          <filterProperties>
+            <version.org.kie>${version.org.kie}</version.org.kie>
+          </filterProperties>
+        </configuration>
+        <executions>
+          <execution>
+            <id>generate-test-resources</id>
+            <phase>generate-test-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/src/test/resources/kjar-with-instrumentation/pom.xml
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/src/test/resources/kjar-with-instrumentation/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.drools.testcoverage</groupId>
+  <artifactId>kjar-with-instrumentation</artifactId>
+  <version>@version.org.kie@</version>
+
+  <packaging>kjar</packaging>
+
+  <name>KIE Integration :: KIE Maven Plugin Instrumented kJAR</name>
+
+  <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-maven-plugin</artifactId>
+        <version>@version.org.kie@</version>
+        <extensions>true</extensions>
+        <configuration>
+          <instrument-enabled>true</instrument-enabled>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/src/test/resources/kjar-with-instrumentation/src/main/java/org/kie/integration/testcoverage/model/instrumentation/Cat.java
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/src/test/resources/kjar-with-instrumentation/src/main/java/org/kie/integration/testcoverage/model/instrumentation/Cat.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.integration.testcoverage.model.instrumentation;
+
+/**
+ * A person's cat.
+ */
+public class Cat implements Pet {
+
+    private final String name;
+
+    private int age;
+
+    public Cat(final String name, final int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public int getAge() {
+        return this.age;
+    }
+
+    public void setAge(final int age) {
+        this.age = age;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Cat cat = (Cat) o;
+
+        if (age != cat.age) return false;
+        return name != null ? name.equals(cat.name) : cat.name == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + age;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Cat{" +
+                "name='" + name + '\'' +
+                ", age=" + age +
+                '}';
+    }
+}

--- a/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/src/test/resources/kjar-with-instrumentation/src/main/java/org/kie/integration/testcoverage/model/instrumentation/Dog.java
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/src/test/resources/kjar-with-instrumentation/src/main/java/org/kie/integration/testcoverage/model/instrumentation/Dog.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.integration.testcoverage.model.instrumentation;
+
+/**
+ * A person's dog.
+ */
+public class Dog implements Pet {
+
+    private final String name;
+
+    private int age;
+
+    public Dog(final String name, final int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public int getAge() {
+        return this.age;
+    }
+
+    public void setAge(final int age) {
+        this.age = age;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Dog dog = (Dog) o;
+
+        if (age != dog.age) return false;
+        return name != null ? name.equals(dog.name) : dog.name == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + age;
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Dog{" +
+                "name='" + name + '\'' +
+                ", age=" + age +
+                '}';
+    }
+}

--- a/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/src/test/resources/kjar-with-instrumentation/src/main/java/org/kie/integration/testcoverage/model/instrumentation/Person.java
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/src/test/resources/kjar-with-instrumentation/src/main/java/org/kie/integration/testcoverage/model/instrumentation/Person.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.integration.testcoverage.model.instrumentation;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A sample model class to be instrumented by kie-maven-plugin.
+ */
+public class Person implements Serializable {
+
+    private String name;
+
+    private Integer age;
+
+    private List<Pet> pets;
+
+    public Person(final String name, final Integer age) {
+        this.name = name;
+        this.age = age;
+        this.pets = new ArrayList<Pet>();
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public Integer getAge() {
+        return this.age;
+    }
+
+    public void setAge(final Integer age) {
+        this.age = age;
+    }
+
+    public List<Pet> getPets() {
+        return pets;
+    }
+
+    public void addPet(final Pet pet) {
+        this.pets.add(pet);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Person person = (Person) o;
+
+        if (name != null ? !name.equals(person.name) : person.name != null) return false;
+        if (age != null ? !age.equals(person.age) : person.age != null) return false;
+        return pets != null ? pets.equals(person.pets) : person.pets == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (age != null ? age.hashCode() : 0);
+        result = 31 * result + (pets != null ? pets.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Person{" +
+                "name='" + name + '\'' +
+                ", age=" + age +
+                ", pets=" + pets +
+                '}';
+    }
+}

--- a/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/src/test/resources/kjar-with-instrumentation/src/main/java/org/kie/integration/testcoverage/model/instrumentation/Pet.java
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/src/test/resources/kjar-with-instrumentation/src/main/java/org/kie/integration/testcoverage/model/instrumentation/Pet.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.integration.testcoverage.model.instrumentation;
+
+/**
+ * A person's pet.
+ */
+public interface Pet {
+
+    String getName();
+
+    int getAge();
+
+    void setAge(final int age);
+}

--- a/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/src/test/resources/kjar-with-instrumentation/src/main/resources/META-INF/kmodule.xml
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/src/test/resources/kjar-with-instrumentation/src/main/resources/META-INF/kmodule.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kmodule xmlns="http://jboss.org/kie/6.0.0/kmodule">
+  <kbase name="instrumentationKBase" default="true" packages="org.kie.integration.testcoverage.instrumentation">
+    <ksession name="instrumentationSession" default="true" type="stateful" />
+  </kbase>
+</kmodule>

--- a/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/src/test/resources/kjar-with-instrumentation/src/main/resources/org/kie/integration/testcoverage/instrumentation/rules.drl
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/src/test/resources/kjar-with-instrumentation/src/main/resources/org/kie/integration/testcoverage/instrumentation/rules.drl
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.integration.testcoverage.instrumentation;
+
+import org.kie.integration.testcoverage.model.instrumentation.Person;
+import org.kie.integration.testcoverage.model.instrumentation.Dog;
+import org.kie.integration.testcoverage.model.instrumentation.Cat;
+
+global java.util.List results
+
+rule "person's pets"
+when
+  Person( pet: /pets )
+then
+  results.add(pet.getName());
+end
+
+rule "give a dog to an adult person without a dog"
+when
+  person: Person( /age{ this >= 18 } )
+  not Person( this == person, /pets{ #Dog } )
+then
+  person.addPet(new Dog("Lassie", 1));
+end
+
+rule "give a cat to an adult person without a cat"
+when
+  person: Person( /age{ this >= 18 } )
+  not Person( this == person, /pets{ #Cat } )
+then
+  person.addPet(new Cat("The Cat", 1));
+end

--- a/kie-integration-test-coverage/kie-maven-plugin-tests/pom.xml
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.drools.testcoverage</groupId>
+    <artifactId>kie-integration-test-coverage-parent</artifactId>
+    <version>7.1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>kie-maven-plugin-tests-parent</artifactId>
+  <packaging>pom</packaging>
+
+  <name>KIE Integration :: KIE Maven Plugin Additional Test Coverage</name>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.drools.testcoverage</groupId>
+        <artifactId>kjar-with-instrumentation</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.drools.testcoverage</groupId>
+        <artifactId>kjar-with-instrumentation-wrapper</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.kie</groupId>
+          <artifactId>kie-maven-plugin</artifactId>
+          <version>${version.org.kie}</version>
+          <extensions>true</extensions>
+          <configuration>
+            <instrument-enabled>true</instrument-enabled>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <modules>
+    <module>kjar-with-instrumentation-wrapper</module>
+    <module>test-suite</module>
+  </modules>
+</project>

--- a/kie-integration-test-coverage/kie-maven-plugin-tests/test-suite/pom.xml
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/test-suite/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.drools.testcoverage</groupId>
+    <artifactId>kie-maven-plugin-tests-parent</artifactId>
+    <version>7.1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>kie-maven-plugin-test-suite</artifactId>
+
+  <name>KIE Integration :: KIE Maven Plugin Additional Tests</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-compiler</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-ci</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.drools.testcoverage</groupId>
+      <artifactId>kjar-with-instrumentation</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <!-- Artificial dependency to make sure the `kjar-with-instrumentation` is always build before the
+           test-suite. Without this dependency the parallel (-T) build sometimes fails. -->
+      <groupId>org.drools.testcoverage</groupId>
+      <artifactId>kjar-with-instrumentation-wrapper</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <testResources>
+      <testResource>
+        <filtering>false</filtering>
+        <directory>src/test/resources</directory>
+      </testResource>
+      <testResource>
+        <filtering>true</filtering>
+        <directory>src/test/filtered-resources</directory>
+      </testResource>
+    </testResources>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemProperties>
+            <kie.maven.settings.custom>${project.build.testOutputDirectory}/test-kie-maven-settings.xml</kie.maven.settings.custom>
+          </systemProperties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/kie-integration-test-coverage/kie-maven-plugin-tests/test-suite/src/test/filtered-resources/test-kie-maven-settings.xml
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/test-suite/src/test/filtered-resources/test-kie-maven-settings.xml
@@ -1,0 +1,9 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <!-- we have to use the same repo as Maven build in order to find kjar artifacts -->
+  <localRepository>${settings.localRepository}</localRepository>
+
+  <!-- no remote repositories should be declared -->
+</settings>

--- a/kie-integration-test-coverage/kie-maven-plugin-tests/test-suite/src/test/filtered-resources/test.properties
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/test-suite/src/test/filtered-resources/test.properties
@@ -1,0 +1,2 @@
+project.version=${project.version}
+kie.maven.settings.custom=${project.build.directory}/test-classes/maven-settings.xml

--- a/kie-integration-test-coverage/kie-maven-plugin-tests/test-suite/src/test/java/org/kie/integration/testcoverage/instrumentation/InstrumentationTest.java
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/test-suite/src/test/java/org/kie/integration/testcoverage/instrumentation/InstrumentationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.integration.testcoverage.instrumentation;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.runtime.KieContainer;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.rule.FactHandle;
+import org.kie.integration.testcoverage.model.instrumentation.Dog;
+import org.kie.integration.testcoverage.model.instrumentation.Person;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests using a KJAR built previously by kie-maven-plugin with instrumentation enabled.
+ */
+public class InstrumentationTest {
+
+    private static final KieServices KIE_SERVICES = KieServices.get();
+    private static final ReleaseId RELEASE_ID = KIE_SERVICES.newReleaseId("org.drools.testcoverage", "kjar-with-instrumentation", TestUtil.getProjectVersion());
+
+    private static KieContainer kieContainer;
+    private KieSession kieSession;
+    private List<String> results;
+
+    @BeforeClass
+    public static void loadKieContainer() {
+        kieContainer = KIE_SERVICES.newKieContainer(RELEASE_ID);
+    }
+
+    @Before
+    public void prepareSession() {
+        kieSession = kieContainer.newKieSession();
+        results = new ArrayList<>();
+        kieSession.setGlobal("results", results);
+    }
+
+    @After
+    public void disposeSession() {
+        if (kieSession != null) {
+            kieSession.dispose();
+        }
+        results = null;
+    }
+
+    @Test
+    public void testLoadingKJarAndFiringRules() {
+        final String dogName = "Azor";
+        final Person person = new Person("Bruno", 17);
+        person.addPet(new Dog(dogName, 2));
+
+        kieSession.insert(person);
+        kieSession.fireAllRules();
+        assertThat(results).containsExactlyInAnyOrder(dogName);
+    }
+
+    @Test
+    public void testOOPathReactivityWithInstrumentedModel() {
+        final Person person = new Person("Bruno", 17);
+
+        FactHandle fh = kieSession.insert(person);
+        kieSession.fireAllRules();
+        assertThat(results).isEmpty();
+
+        person.setAge(18);
+        kieSession.update(fh, person);
+        kieSession.fireAllRules();
+        assertThat(results).containsExactlyInAnyOrder("Lassie", "The Cat");
+    }
+
+}

--- a/kie-integration-test-coverage/kie-maven-plugin-tests/test-suite/src/test/java/org/kie/integration/testcoverage/instrumentation/TestUtil.java
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/test-suite/src/test/java/org/kie/integration/testcoverage/instrumentation/TestUtil.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.integration.testcoverage.instrumentation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+/**
+ * Generic utilities used by tests, mainly for getting current project version.
+ */
+public class TestUtil {
+
+    public static final String TEST_PROPERTIES_FILE = "/test.properties";
+
+    private static final String PROJECT_VERSION_PROPERTY = "project.version";
+
+    private static final transient Logger logger = LoggerFactory.getLogger(TestUtil.class);
+
+    private static final String PROJECT_VERSION = loadProjectVersion();
+
+    public static String getProjectVersion() {
+        return PROJECT_VERSION;
+    }
+
+    private static String loadProjectVersion() {
+        Properties testProps = new Properties();
+        try {
+            testProps.load(TestUtil.class.getResourceAsStream(TEST_PROPERTIES_FILE));
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to initialize PROJECT_VERSION property: " + e.getMessage(), e);
+        }
+
+        final String projectVersion = testProps.getProperty(PROJECT_VERSION_PROPERTY);
+        logger.info("Loaded Project Version: " + projectVersion);
+        return projectVersion;
+    }
+}

--- a/kie-integration-test-coverage/kie-maven-plugin-tests/test-suite/src/test/resources/logback-test.xml
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/test-suite/src/test/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <!-- %l lowers performance -->
+      <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
+      <pattern>%d [%t] %-5p %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.kie.maven.plugin" level="info"/>
+
+  <root level="info">
+    <appender-ref ref="consoleAppender"/>
+  </root>
+
+</configuration>
+

--- a/kie-integration-test-coverage/pom.xml
+++ b/kie-integration-test-coverage/pom.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>droolsjbpm-integration</artifactId>
+    <groupId>org.drools</groupId>
+    <version>7.1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.drools.testcoverage</groupId>
+  <artifactId>kie-integration-test-coverage-parent</artifactId>
+  <packaging>pom</packaging>
+
+  <name>KIE Integration :: Test Coverage</name>
+
+  <modules>
+    <module>kie-maven-plugin-tests</module>
+  </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     <module>kie-camel</module>
     <!-- The Android examples require Android SDK to be installed, so they are excluded from the default build -->
     <!-- <module>drools-examples-android</module> -->
+    <module>kie-integration-test-coverage</module>
   </modules>
 
   <dependencyManagement>


### PR DESCRIPTION
Creates a new project (analogy to drools/drools-test-coverage and jbpm/jbpm-test-coverage)
in droolsjbpm-integration repository.

The new project will contain more QE tests, starting with additional integration tests
of kie-maven-plugin model classes instrumentation.

Artificial dependencies on kie-maven-plugin and kjar-with-instrumentation-wrapper
have been added to make sure that the required project are built before the projects that
depend on them, even during Maven parallel build (-T).