### PR TITLE
[7.0.x] JBPM-5897 - Fails to start a process with CorrelationKey which is uni…

### DIFF
--- a/kie-spring/src/test/resources/META-INF/orm.xml
+++ b/kie-spring/src/test/resources/META-INF/orm.xml
@@ -19,13 +19,8 @@
       key.processInstanceId
       from
       CorrelationKeyInfo key
-      left join key.properties props
       where
-      cast(:elem_count as integer) =
-      (select count(id) from CorrelationPropertyInfo cpi where cpi.correlationKey.id = key.id) and
-      props.value in :properties
-      group by key.id,key.processInstanceId
-      having count(key.id) = :elem_count
+      key.name = :ckey
     </query>
   </named-query>
   <named-query name="GetCorrelationKeysByProcessInstanceId">


### PR DESCRIPTION
…que but includes correlation properties of an existing correlation key