### PR TITLE
kie-server-tests: fix ErrorsQueryDefinition in QueryDataServiceIntegr…

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
@@ -761,7 +761,7 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
         QueryDefinition query = new QueryDefinition();
         query.setName("unAckErrors");
         query.setSource(System.getProperty("org.kie.server.persistence.ds", "jdbc/jbpm-ds"));
-        query.setExpression("select * from ExecutionErrorInfo where ERROR_ACK = 0");
+        query.setExpression("select * from ExecutionErrorInfo where ERROR_ACK = '0'");
         query.setTarget("CUSTOM");
         return query;
     }


### PR DESCRIPTION
…ationTest

Test testErrorHandlingFailedToSignal in QueryDataServiceIntegrationTest on PostgreSQL databases failed. This was caused by: org.postgresql.util.PSQLException: ERROR: operator does not exist: boolean = integer. On other databases this tests scenario run fine. Now on all DBs this test scenario pass. 