### PR TITLE
Change revapi-config.json comment to be more general

### DIFF
--- a/kie-server-parent/kie-server-api/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-api/src/build/revapi-config.json
@@ -16,7 +16,7 @@
   },
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "_comment": "Changes between 6.5.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
       "ignore": [
         {
           "code": "java.method.returnTypeChanged",

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/build/revapi-config.json
@@ -17,7 +17,7 @@
 
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "_comment": "Changes between 6.5.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
       "ignore": [
         {
           "code": "java.class.removed",

--- a/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/build/revapi-config.json
@@ -24,7 +24,7 @@
 
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "_comment": "Changes between 6.5.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
       "ignore": [
         {
           "code": "java.class.removed",

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/build/revapi-config.json
@@ -40,7 +40,7 @@
   },
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "_comment": "Changes between 6.5.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
       "ignore": [
         {
           "code": "java.method.addedToInterface",

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-case-mgmt/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-case-mgmt/src/build/revapi-config.json
@@ -21,7 +21,7 @@
 
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "_comment": "Changes between 6.5.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
       "ignore": []
     }
   }

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/build/revapi-config.json
@@ -30,7 +30,7 @@
 
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "_comment": "Changes between 6.5.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
       "ignore": []
     }
   }

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-drools/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-drools/src/build/revapi-config.json
@@ -25,7 +25,7 @@
 
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "_comment": "Changes between 6.5.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
       "ignore": []
     }
   }

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm-ui/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm-ui/src/build/revapi-config.json
@@ -25,7 +25,7 @@
 
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "_comment": "Changes between 6.5.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
       "ignore": [
         {
           "code": "java.method.numberOfParametersChanged",

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/build/revapi-config.json
@@ -28,7 +28,7 @@
 
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "_comment": "Changes between 6.5.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
       "ignore": [
         {
           "code": "java.field.visibilityReduced",

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-optaplanner/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-optaplanner/src/build/revapi-config.json
@@ -25,9 +25,10 @@
       }
     }
   },
+
   "ignores": {
     "revapi": {
-      "_comment": "Changes between 6.5.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+      "_comment": "Changes between 6.5.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
       "ignore": [
         {
           "code": "java.annotation.attributeValueChanged",


### PR DESCRIPTION
Hi, @mswiderski,

this is only a minor change to the revapi-config.json file, since these files are no more only on master branch, but on 7.0.x as well.

Marian
