### PR TITLE
RHBPMS-4592 Fix content-type from http header

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/MarshallingFormat.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/MarshallingFormat.java
@@ -15,6 +15,9 @@
 
 package org.kie.server.api.marshalling;
 
+import static org.apache.commons.lang3.StringUtils.startsWithIgnoreCase;
+import static org.apache.commons.lang3.StringUtils.upperCase;
+
 public enum MarshallingFormat {
     XSTREAM(0, "xstream"), JAXB(1, "xml"), JSON(2, "json");
 
@@ -42,14 +45,17 @@ public enum MarshallingFormat {
     }
 
     public static MarshallingFormat fromType( String type ) {
-        if ("xstream".equalsIgnoreCase( type ) || "application/xstream".equalsIgnoreCase( type ) ) {
+        if(startsWithIgnoreCase(type, "xstream") || startsWithIgnoreCase(type, "application/xstream")) {
             return XSTREAM;
-        } else if ("xml".equalsIgnoreCase( type ) || "application/xml".equalsIgnoreCase( type ) ) {
+        } else if (startsWithIgnoreCase(type, "xml") || startsWithIgnoreCase(type, "application/xml")) {
             return JAXB;
-        } else if ("json".equalsIgnoreCase( type ) || "application/json".equalsIgnoreCase( type ) ) {
+        } else if (startsWithIgnoreCase(type, "json") || startsWithIgnoreCase(type, "application/json")) {
             return JSON;
         } else {
-            return valueOf(type);
+            try {
+                return MarshallingFormat.valueOf(upperCase(type));
+            } catch(Exception ignored) {}
+            throw new RuntimeException("Invalid marshalling format ["+type+"]");
         }
     }
 }

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/MarshallingFormatTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/MarshallingFormatTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.api.marshalling;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+
+public class MarshallingFormatTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void testEmptyMarshallingFormat() {
+        exception.expectMessage("Invalid marshalling format []");
+        MarshallingFormat.fromType("");
+    }
+
+    @Test
+    public void testNullMarshallingFormat() {
+        exception.expectMessage("Invalid marshalling format [null]");
+        MarshallingFormat.fromType(null);
+    }
+
+    @Test
+    public void testNonNullEmptyInvalidMarshallingFormat() {
+        exception.expectMessage("Invalid marshalling format [JAX]");
+        MarshallingFormat.fromType("JAX");
+    }
+
+    @Test
+    public void testExpectedMarshallingFormats() {
+        assertEquals(MarshallingFormat.JSON, MarshallingFormat.fromType("json"));
+        assertEquals(MarshallingFormat.JAXB, MarshallingFormat.fromType("xml"));
+        assertEquals(MarshallingFormat.XSTREAM, MarshallingFormat.fromType("xstream"));
+
+        assertEquals(MarshallingFormat.JSON, MarshallingFormat.fromType("application/json"));
+        assertEquals(MarshallingFormat.JAXB, MarshallingFormat.fromType("application/xml"));
+        assertEquals(MarshallingFormat.XSTREAM, MarshallingFormat.fromType("application/xstream"));
+    }
+
+    @Test
+    public void testMarshallingFormatsWithExtraneousParameters() {
+        assertEquals(MarshallingFormat.JSON, MarshallingFormat.fromType("application/json;"));
+        assertEquals(MarshallingFormat.JAXB, MarshallingFormat.fromType("application/xml;"));
+        assertEquals(MarshallingFormat.XSTREAM, MarshallingFormat.fromType("application/xstream;"));
+        assertEquals(MarshallingFormat.JSON, MarshallingFormat.fromType("application/json;encode="));
+        assertEquals(MarshallingFormat.JAXB, MarshallingFormat.fromType("application/xml;encode=utf-8"));
+        assertEquals(MarshallingFormat.XSTREAM, MarshallingFormat.fromType("application/xstream;utf-8"));
+    }
+
+    @Test
+    public void testMarshallingFormatCase() {
+        assertEquals(MarshallingFormat.JSON, MarshallingFormat.fromType("JSON"));
+    }
+
+    @Test
+    public void testEdgeCaseWithJaxb() {
+        assertEquals(MarshallingFormat.JAXB, MarshallingFormat.fromType("jaxb"));
+        assertEquals(MarshallingFormat.JAXB, MarshallingFormat.fromType("JAXB"));
+    }
+}


### PR DESCRIPTION
Accodring to rfc2616 a http media type may contain
a type/subtype followed by one or more parameters delimited by
semicolons.