### PR TITLE
[6.5.x] RHBPMS-4697 - Fails to start a process with CorrelationKey which is u…

### DIFF
--- a/kie-spring/src/test/resources/META-INF/orm.xml
+++ b/kie-spring/src/test/resources/META-INF/orm.xml
@@ -19,13 +19,8 @@
       key.processInstanceId
       from
       CorrelationKeyInfo key
-      left join key.properties props
       where
-      cast(:elem_count as integer) =
-      (select count(id) from CorrelationPropertyInfo cpi where cpi.correlationKey.id = key.id) and
-      props.value in :properties
-      group by key.id,key.processInstanceId
-      having count(key.id) = :elem_count
+      key.name = :ckey
     </query>
   </named-query>
   <named-query name="GetCorrelationKeysByProcessInstanceId">


### PR DESCRIPTION
…nique but includes correlation properties of an existing correlation key RHBPMS-4693 - Slow JpaProcessPersistenceContext.getProcessInstanceByCorrelationKey() with MySQL

depends on https://github.com/kiegroup/jbpm/pull/848