### PR TITLE
Improve Kie Server Controller tests stability

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerSynchronization.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerSynchronization.java
@@ -17,7 +17,6 @@ package org.kie.server.integrationtests.shared;
 
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
@@ -94,21 +93,17 @@ public class KieServerSynchronization {
         });
     }
 
-    public static void waitForKieServerMessage(final KieServicesClient client, final String containerId, final String oldMessage, final String expectedMessage) throws Exception {
+    public static void waitForKieServerMessage(final KieServicesClient client, final String containerId, final String expectedMessage) throws Exception {
         waitForCondition(() -> {
             ServiceResponse<KieContainerResource> containerResponse = client.getContainerInfo(containerId);
-            if (containerResponse.getType() != ServiceResponse.ResponseType.SUCCESS) {
+            if (!containerResponse.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
                 return false;
             }
 
-            // Kie Container store only last message
+            // Kie Container store only one message
             List<Message> messagesList = containerResponse.getResult().getMessages();
             if (messagesList.size() == 1) {
-                Collection<String> messages = messagesList.get(0).getMessages();
-                String message = messages.iterator().next();
-                if (messages.size() == 1 && message.equals(oldMessage)) {
-                    return message.equals(expectedMessage);
-                }
+                return messagesList.get(0).getMessages().stream().anyMatch(n -> n.equals(expectedMessage));
             }
 
             return false;

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerSynchronization.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerSynchronization.java
@@ -17,6 +17,7 @@ package org.kie.server.integrationtests.shared;
 
 import java.util.Arrays;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BooleanSupplier;
@@ -41,6 +42,7 @@ import org.kie.server.api.model.instance.TaskInstance;
 import org.kie.server.client.JobServicesClient;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.api.exception.KieServicesException;
+import org.kie.server.api.model.Message;
 import org.kie.server.client.ProcessServicesClient;
 import org.kie.server.client.QueryServicesClient;
 import org.kie.server.client.RuleServicesClient;
@@ -88,6 +90,27 @@ public class KieServerSynchronization {
                     return true;
                 }
             }
+            return false;
+        });
+    }
+
+    public static void waitForKieServerMessage(final KieServicesClient client, final String containerId, final String oldMessage, final String expectedMessage) throws Exception {
+        waitForCondition(() -> {
+            ServiceResponse<KieContainerResource> containerResponse = client.getContainerInfo(containerId);
+            if (containerResponse.getType() != ServiceResponse.ResponseType.SUCCESS) {
+                return false;
+            }
+
+            // Kie Container store only last message
+            List<Message> messagesList = containerResponse.getResult().getMessages();
+            if (messagesList.size() == 1) {
+                Collection<String> messages = messagesList.get(0).getMessages();
+                String message = messages.iterator().next();
+                if (messages.size() == 1 && message.equals(oldMessage)) {
+                    return message.equals(expectedMessage);
+                }
+            }
+
             return false;
         });
     }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerManagementIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerManagementIntegrationTest.java
@@ -665,7 +665,7 @@ public class KieControllerManagementIntegrationTest extends KieControllerManagem
         assertEquals(releaseId, containerResponseEntity.getReleasedId());
         assertEquals(KieContainerStatus.STOPPED, containerResponseEntity.getStatus());
     }
-    
+
     @Test
     public void testUpdateContainerNonValidReleaseId() throws Exception {
         // Create kie server instance connection in controller.
@@ -689,6 +689,11 @@ public class KieControllerManagementIntegrationTest extends KieControllerManagem
         assertEquals(KieContainerStatus.STARTED, containerResource.getStatus());
         assertEquals(releaseId, containerResource.getReleaseId());
 
+        assertEquals(1, containerResource.getMessages().size());
+        Collection<String> oldMessages = containerResource.getMessages().get(0).getMessages();
+        assertEquals(1, oldMessages.size());
+        String oldMessage = oldMessages.iterator().next();
+
         // Update container
         ReleaseId nonValidReleaseId = new ReleaseId("org.kie.server.testing", "stateless-session-kjar", "2.0.0-SNAPSHOT");
         containerToDeploy.setReleasedId(nonValidReleaseId);
@@ -710,6 +715,7 @@ public class KieControllerManagementIntegrationTest extends KieControllerManagem
 
         // Check that Kie Container has message about error during updating
         // Kie Container store last message
+        KieServerSynchronization.waitForKieServerMessage(client, CONTAINER_ID, oldMessage, "Error updating releaseId for container");
         assertEquals(1, containerResource.getMessages().size());
         Collection<String> messages = containerResource.getMessages().get(0).getMessages();
         assertEquals(2, messages.size());


### PR DESCRIPTION
testUpdateContainerNonValidReleaseId() sometimes failed on Eap 7 container due race condition. Test tried to get message from controller about update, but this message was not yet in controller. For avoid this random failing is added synchronization for Messages.