### PR TITLE
Fix GWT compilation error

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/resources/org/kie/server/controller/api/KieServerControllerAPI.gwt.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/resources/org/kie/server/controller/api/KieServerControllerAPI.gwt.xml
@@ -7,5 +7,6 @@
 
   <source path='model'/>
   <source path='service'/>
+  <source path='storage'/>
 
 </module>


### PR DESCRIPTION
Add storage package to fix error 'No source code is available for type org.kie.server.controller.api.storage.KieServerTemplateStorage'