### PR TITLE
JBPM-5946: Delete unused dependency on kie-server-rest-common

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-standalone-impl/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-standalone-impl/pom.xml
@@ -46,11 +46,6 @@
 
     <dependency>
       <groupId>org.kie.server</groupId>
-      <artifactId>kie-server-rest-common</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.kie.server</groupId>
       <artifactId>kie-server-controller-rest</artifactId>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Greatly reduces size of the controller war.