### PR TITLE
JBPM-5336 Add test coverage for container aliases

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/kjars-sources/definition-project-101/src/main/resources/hiring-taskform.form
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/kjars-sources/definition-project-101/src/main/resources/hiring-taskform.form
@@ -11,7 +11,7 @@
 <property name="groupWithPrevious" value="false"/>
 <property name="labelCSSClass" value=""/>
 <property name="labelCSSStyle" value=""/>
-<property name="label" value="quot;SSClassquot;,quot;quot;quot;SSStylequot;,quot;quot;quot;enquot;,quot;Candidate First Name And Surenamequot;quot;esquot;,quot;quot;"/>
+<property name="label" value="quot;SSClassquot;,quot;quot;quot;SSStylequot;,quot;quot;quot;enquot;,quot;Candidate First Name And Surnamequot;quot;esquot;,quot;quot;"/>
 <property name="errorMessage" value="quot;enquot;,quot;quot;quot;esquot;,quot;quot;"/>
 <property name="title" value="quot;enquot;,quot;quot;quot;esquot;,quot;quot;"/>
 <property name="disabled" value="false"/>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/ContainerUpdateUiIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/ContainerUpdateUiIntegrationTest.java
@@ -65,7 +65,7 @@ public class ContainerUpdateUiIntegrationTest extends JbpmKieServerBaseIntegrati
 
         result = uiServicesClient.getProcessForm(CONTAINER_ID, HIRING_PROCESS_ID, "en");
         assertNotNull(result);
-        assertTrue("Form doesn't contain updated label!", result.contains("Candidate First Name And Surename"));
+        assertTrue("Form doesn't contain updated label!", result.contains("Candidate First Name And Surname"));
     }
 
     @Test

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/FormServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/FormServiceIntegrationTest.java
@@ -15,18 +15,20 @@
 
 package org.kie.server.integrationtests.jbpm;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.kie.server.api.model.ReleaseId;
-import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.api.exception.KieServicesException;
-
-import static org.junit.Assert.*;
-
+import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.instance.ProcessInstance;
+import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.client.UIServicesClient;
 import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
@@ -35,8 +37,13 @@ public class FormServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
 
     private static ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "definition-project",
             "1.0.0.Final");
+    private static final ReleaseId releaseId101 = new ReleaseId("org.kie.server.testing", "definition-project",
+            "1.0.1.Final");
 
+    protected static final String CONTAINER_ALIAS = "project";
     private static final String CONTAINER_ID = "definition-project";
+    protected static final String CONTAINER_ID_101 = "definition-project-101";
+
     private static final String HIRING_PROCESS_ID = "hiring";
     private static final String HIRING_2_PROCESS_ID = "hiring2";
     private static final String HIRING_SUBFORM_PROCESS_ID = "hiringSubform";
@@ -46,16 +53,28 @@ public class FormServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
 
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
+        KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project-101").getFile());
 
-        createContainer(CONTAINER_ID, releaseId);
+        createContainer(CONTAINER_ID, releaseId, CONTAINER_ALIAS);
+    }
+
+    @After
+    public void removeExtraContainer() {
+        abortAllProcesses();
+        client.disposeContainer(CONTAINER_ID_101);
+    }
+
+    protected void createExtraContainer() {
+        KieContainerResource containerResource = new KieContainerResource(CONTAINER_ID_101, releaseId101);
+        containerResource.setContainerAlias(CONTAINER_ALIAS);
+        client.createContainer(CONTAINER_ID_101, containerResource);
     }
 
     @Test
     public void testGetProcessFormViaUIClientTest() throws Exception {
         String result = uiServicesClient.getProcessForm(CONTAINER_ID, HIRING_PROCESS_ID, "en");
         logger.debug("Form content is '{}'", result);
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
+        assertThat(result).isNotNull().isNotEmpty();
     }
 
     @Test(expected = KieServicesException.class)
@@ -78,8 +97,7 @@ public class FormServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
     public void testGetProcessFormInPackageViaUIClientTest() throws Exception {
         String result = uiServicesClient.getProcessForm(CONTAINER_ID, HIRING_2_PROCESS_ID, "en");
         logger.debug("Form content is '{}'", result);
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
+        assertThat(result).isNotNull().isNotEmpty();
     }
 
     @Test
@@ -89,18 +107,16 @@ public class FormServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
     }
 
     protected void runGetTaskFormTest( long processInstanceId ) {
-        assertTrue(processInstanceId > 0);
+        assertThat(processInstanceId).isGreaterThan(0);
         try {
             List<TaskSummary> tasks = taskClient.findTasksByStatusByProcessInstanceId(processInstanceId, null, 0, 10);
-            assertNotNull(tasks);
-            assertEquals(1, tasks.size());
+            assertThat(tasks).isNotNull().hasSize(1);
 
             Long taskId = tasks.get(0).getId();
 
             String result = uiServicesClient.getTaskForm(CONTAINER_ID, taskId, "en");
             logger.debug("Form content is '{}'", result);
-            assertNotNull(result);
-            assertFalse(result.isEmpty());
+            assertThat(result).isNotNull().isNotEmpty();
         } finally {
             processClient.abortProcessInstance(CONTAINER_ID, processInstanceId);
         }
@@ -109,18 +125,16 @@ public class FormServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
     @Test
     public void testGetTaskRawFormViaUIClient() throws Exception {
         long processInstanceId = processClient.startProcess(CONTAINER_ID, HIRING_2_PROCESS_ID);
-        assertTrue(processInstanceId > 0);
+        assertThat(processInstanceId).isGreaterThan(0);
         try {
             List<TaskSummary> tasks = taskClient.findTasksByStatusByProcessInstanceId(processInstanceId, null, 0, 10);
-            assertNotNull(tasks);
-            assertEquals(1, tasks.size());
+            assertThat(tasks).isNotNull().hasSize(1);
 
             Long taskId = tasks.get(0).getId();
 
             String result = uiServicesClient.getTaskRawForm( CONTAINER_ID, taskId );
             logger.debug("Form content is '{}'", result);
-            assertNotNull(result);
-            assertFalse(result.isEmpty());
+            assertThat(result).isNotNull().isNotEmpty();
         } finally {
             processClient.abortProcessInstance(CONTAINER_ID, processInstanceId);
         }
@@ -130,17 +144,15 @@ public class FormServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
     public void testGetProcessFormViaUIClientTestByType() throws Exception {
         String result = uiServicesClient.getProcessFormByType(CONTAINER_ID, HIRING_PROCESS_ID, "en", UIServicesClient.FORM_TYPE);
         logger.debug("Form content is '{}'", result);
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
-        assertTrue(result.contains("hiring-taskform.frm"));
+        assertThat(result).isNotNull().isNotEmpty();
+        assertThat(result).contains("hiring-taskform.frm");
     }
 
     @Test
     public void testGetProcessRawFormViaUIClient() throws Exception {
         String result = uiServicesClient.getProcessRawForm( CONTAINER_ID, HIRING_PROCESS_ID );
         logger.debug("Form content is '{}'", result);
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
+        assertThat(result).isNotNull().isNotEmpty();
     }
 
     @Test
@@ -151,46 +163,40 @@ public class FormServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
         parameters.put("age", 33);
         parameters.put("mail", "john@doe.org");
         long processInstanceId = processClient.startProcess(CONTAINER_ID, HIRING_2_PROCESS_ID, parameters);
-        assertTrue(processInstanceId > 0);
+        assertThat(processInstanceId).isGreaterThan(0);
         try {
             List<TaskSummary> tasks = taskClient.findTasksByStatusByProcessInstanceId(processInstanceId, null, 0, 10);
-            assertNotNull(tasks);
-            assertEquals(1, tasks.size());
+            assertThat(tasks).isNotNull().hasSize(1);
 
             Long taskId = tasks.get(0).getId();
 
             String result = uiServicesClient.getTaskFormByType(CONTAINER_ID, taskId, "en", UIServicesClient.FORM_MODELLER_TYPE);
             logger.debug("Form content is '{}'", result);
-            assertNotNull(result);
-            assertFalse(result.isEmpty());
+            assertThat(result).isNotNull().isNotEmpty();
 
             parameters.put("out_age", 33);
             parameters.put("out_mail", "john@doe.org");
             taskClient.completeAutoProgress(CONTAINER_ID, taskId, USER_JOHN, parameters);
 
             tasks = taskClient.findTasksByStatusByProcessInstanceId(processInstanceId, null, 0, 10);
-            assertNotNull(tasks);
-            assertEquals(1, tasks.size());
+            assertThat(tasks).isNotNull().hasSize(1);
 
             taskId = tasks.get(0).getId();
 
             result = uiServicesClient.getTaskFormByType(CONTAINER_ID, taskId, "en", UIServicesClient.FREE_MARKER_TYPE);
             logger.debug("Form content is '{}'", result);
-            assertNotNull(result);
-            assertFalse(result.isEmpty());
+            assertThat(result).isNotNull().isNotEmpty();
 
             taskClient.completeAutoProgress(CONTAINER_ID, taskId, USER_JOHN, parameters);
 
             tasks = taskClient.findTasksByStatusByProcessInstanceId(processInstanceId, null, 0, 10);
-            assertNotNull(tasks);
-            assertEquals(1, tasks.size());
+            assertThat(tasks).isNotNull().hasSize(1);
 
             taskId = tasks.get(0).getId();
 
             result = uiServicesClient.getTaskFormByType(CONTAINER_ID, taskId, "en", UIServicesClient.FORM_TYPE);
             logger.debug("Form content is '{}'", result);
-            assertNotNull(result);
-            assertFalse(result.isEmpty());
+            assertThat(result).isNotNull().isNotEmpty();
         } finally {
             processClient.abortProcessInstance(CONTAINER_ID, processInstanceId);
             changeUser(TestConfig.getUsername());
@@ -201,39 +207,123 @@ public class FormServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
     public void testGetProcessWithSubFormRawFormViaUIClient() throws Exception {
         String result = uiServicesClient.getProcessRawForm( CONTAINER_ID, HIRING_SUBFORM_PROCESS_ID );
         logger.debug("Form content is '{}'", result);
-        assertNotNull(result);
-        assertFalse(result.isEmpty());
+        assertThat(result).isNotNull().isNotEmpty();
 
         // check there is content from subform
-        assertTrue("Missing subform content", result.contains("creationDate"));
+        assertThat(result).contains("creationDate").withFailMessage("Missing subform content");
 
         // check there is content from multi subform
-        assertTrue("Missing multi subform content", result.contains("unitPrice"));
+        assertThat(result).contains("unitPrice").withFailMessage("Missing multi subform content");
     }
 
     @Test
     public void testGetTaskFormWithSubformsViaUIClientTest() throws Exception {
         long processInstanceId = processClient.startProcess(CONTAINER_ID, HIRING_SUBFORM_PROCESS_ID);
-        assertTrue(processInstanceId > 0);
+        assertThat(processInstanceId).isGreaterThan(0);
         try {
             List<TaskSummary> tasks = taskClient.findTasksByStatusByProcessInstanceId(processInstanceId, null, 0, 10);
-            assertNotNull(tasks);
-            assertEquals(1, tasks.size());
+            assertThat(tasks).isNotNull().hasSize(1);
 
             Long taskId = tasks.get(0).getId();
 
             String result = uiServicesClient.getTaskRawForm(CONTAINER_ID, taskId);
             logger.debug("Form content is '{}'", result);
-            assertNotNull(result);
-            assertFalse(result.isEmpty());
+            assertThat(result).isNotNull().isNotEmpty();
 
             // check there is content from subform
-            assertTrue("Missing subform content", result.contains("creationDate"));
+            assertThat(result).contains("creationDate").withFailMessage("Missing subform content");
 
             // check there is content from multi subform
-            assertTrue("Missing multi subform content", result.contains("unitPrice"));
+            assertThat(result).contains("unitPrice").withFailMessage("Missing multi subform content");
         } finally {
             processClient.abortProcessInstance(CONTAINER_ID, processInstanceId);
         }
     }
+
+    @Test
+    public void testGetProcessFormViaUIClientWithAliasTest() throws Exception {
+        String oldResultViaContainerId = uiServicesClient.getProcessRawForm(CONTAINER_ID, HIRING_PROCESS_ID);
+        logger.debug("Form content is '{}'", oldResultViaContainerId);
+        assertThat(oldResultViaContainerId).isNotNull().isNotEmpty();
+
+        String oldResultViaAlias = uiServicesClient.getProcessRawForm(CONTAINER_ALIAS, HIRING_PROCESS_ID);
+        logger.debug("Form content is '{}'", oldResultViaAlias);
+        assertThat(oldResultViaAlias).isNotNull().isNotEmpty();
+
+        assertThat(oldResultViaAlias).isEqualTo(oldResultViaContainerId);
+        assertThat(oldResultViaAlias).contains("Candidate Name");
+        assertThat(oldResultViaAlias).doesNotContain("Candidate First Name And Surname");
+
+        createExtraContainer();
+
+        String newResultViaContainerId = uiServicesClient.getProcessRawForm(CONTAINER_ID_101, HIRING_PROCESS_ID);
+        logger.debug("Form content is '{}'", newResultViaContainerId);
+        assertThat(newResultViaContainerId).isNotNull().isNotEmpty();
+
+        String newResultViaAlias = uiServicesClient.getProcessRawForm(CONTAINER_ALIAS, HIRING_PROCESS_ID);
+        logger.debug("Form content is '{}'", newResultViaAlias);
+        assertThat(newResultViaAlias).isNotNull().isNotEmpty();
+
+        assertThat(newResultViaAlias).isEqualTo(newResultViaContainerId);
+        assertThat(newResultViaAlias).contains("Candidate First Name And Surname");
+        assertThat(newResultViaAlias).doesNotContain("Candidate Name");
+
+        assertThat(oldResultViaAlias).isNotEqualTo(newResultViaAlias);
+
+    }
+
+    @Test
+    public void testGetTaskFormViaUIClientWithAliasTest() throws Exception {
+        long processInstanceId = processClient.startProcess(CONTAINER_ALIAS, HIRING_PROCESS_ID);
+        assertThat(processInstanceId).isGreaterThan(0);
+
+        ProcessInstance pi = processClient.getProcessInstance(CONTAINER_ALIAS, processInstanceId);
+        assertThat(pi.getContainerId()).isEqualTo(CONTAINER_ID);
+
+        List<TaskSummary> tasks = taskClient.findTasksByStatusByProcessInstanceId(processInstanceId, null, 0, 10);
+        assertThat(tasks).isNotNull().hasSize(1);
+
+        Long taskId = tasks.get(0).getId();
+
+        String oldResultViaContainerId = uiServicesClient.getTaskRawForm(CONTAINER_ID, taskId);
+        logger.debug("Form content is '{}'", oldResultViaContainerId);
+        assertThat(oldResultViaContainerId).isNotNull().isNotEmpty();
+
+        String oldResultViaAlias = uiServicesClient.getTaskRawForm(CONTAINER_ALIAS, taskId);
+        logger.debug("Form content is '{}'", oldResultViaAlias);
+        assertThat(oldResultViaAlias).isNotNull().isNotEmpty();
+
+        assertThat(oldResultViaAlias).isEqualTo(oldResultViaContainerId);
+        assertThat(oldResultViaAlias).contains("Candidate Name");
+        assertThat(oldResultViaAlias).doesNotContain("Candidate Whole Name");
+
+        createExtraContainer();
+
+        processInstanceId = processClient.startProcess(CONTAINER_ALIAS, HIRING_PROCESS_ID);
+        assertThat(processInstanceId).isGreaterThan(0);
+
+        pi = processClient.getProcessInstance(CONTAINER_ALIAS, processInstanceId);
+        assertThat(pi.getContainerId()).isEqualTo(CONTAINER_ID_101);
+
+        tasks = taskClient.findTasksByStatusByProcessInstanceId(processInstanceId, null, 0, 10);
+        assertThat(tasks).isNotNull().hasSize(1);
+
+        taskId = tasks.get(0).getId();
+
+        String newResultViaContainerId = uiServicesClient.getTaskRawForm(CONTAINER_ID_101, taskId);
+        logger.debug("Form content is '{}'", newResultViaContainerId);
+        assertThat(newResultViaContainerId).isNotNull().isNotEmpty();
+
+        String newResultViaAlias = uiServicesClient.getTaskRawForm(CONTAINER_ALIAS, taskId);
+        logger.debug("Form content is '{}'", newResultViaAlias);
+        assertThat(newResultViaAlias).isNotNull().isNotEmpty();
+
+        assertThat(newResultViaAlias).isEqualTo(newResultViaContainerId);
+        assertThat(newResultViaAlias).contains("Candidate Whole Name");
+        assertThat(newResultViaAlias).doesNotContain("Candidate Name");
+
+        assertThat(oldResultViaAlias).isNotEqualTo(newResultViaAlias);
+
+    }
+
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/definition-project-101/src/main/resources/signal-process.bpmn2
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/definition-project-101/src/main/resources/signal-process.bpmn2
@@ -1,0 +1,346 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_i307QPlpEeSSI76UAbQxIw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_stringDataItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_nullAcceptedItem" structureRef="Boolean"/>
+  <bpmn2:itemDefinition id="_personDataItem" structureRef="org.jbpm.data.Person"/>
+  <bpmn2:signal id="Signal1" name="Signal1"/>
+  <bpmn2:signal id="Signal2" name="Signal2"/>
+  <bpmn2:process id="definition-project.signalprocess2" drools:packageName="org.jbpm" drools:version="2.0" name="signalprocess2">
+    <bpmn2:property id="stringData" itemSubjectRef="_stringDataItem"/>
+    <bpmn2:property id="personData" itemSubjectRef="_personDataItem"/>
+    <bpmn2:property id="nullAccepted" itemSubjectRef="_nullAcceptedItem"/>
+    <bpmn2:startEvent id="processStartEvent" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:outgoing>_2F05998A-B828-4A6E-B34A-502CE1E8D2D0</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="_2F05998A-B828-4A6E-B34A-502CE1E8D2D0" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="processStartEvent" targetRef="_16C862FB-BF23-4DEE-81E1-F89AC1974105"/>
+    <bpmn2:scriptTask id="_BA8D76D0-4D52-42DB-B91E-2A9CB2B8BE30" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="About to wait for signal 1" scriptFormat="http://www.java.com/java">
+      <bpmn2:incoming>_995351DB-6388-4213-B66F-72A1FCA217B7</bpmn2:incoming>
+      <bpmn2:outgoing>_0F48F867-3BEA-41F1-B5E8-E1A51AFC1E6F</bpmn2:outgoing>
+      <bpmn2:script><![CDATA[
+      System.out.println("Waiting for Signal1");
+      if (nullAccepted == null) {
+        kcontext.setVariable("nullAccepted", true);
+      }
+      ]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="_995351DB-6388-4213-B66F-72A1FCA217B7" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_16C862FB-BF23-4DEE-81E1-F89AC1974105" targetRef="_BA8D76D0-4D52-42DB-B91E-2A9CB2B8BE30"/>
+    <bpmn2:parallelGateway id="_16C862FB-BF23-4DEE-81E1-F89AC1974105" drools:selectable="true" color:background-color="#f0e68c" color:border-color="#a67f00" color:color="#000000" name="" gatewayDirection="Diverging">
+      <bpmn2:incoming>_2F05998A-B828-4A6E-B34A-502CE1E8D2D0</bpmn2:incoming>
+      <bpmn2:outgoing>_995351DB-6388-4213-B66F-72A1FCA217B7</bpmn2:outgoing>
+      <bpmn2:outgoing>_41BF4683-24BE-4E4B-AB52-3FADF74FF5DE</bpmn2:outgoing>
+    </bpmn2:parallelGateway>
+    <bpmn2:scriptTask id="_CE022FFB-E1A0-4CB1-B551-49CDC9FC42A2" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="About to wait for signal 2" scriptFormat="http://www.java.com/java">
+      <bpmn2:incoming>_41BF4683-24BE-4E4B-AB52-3FADF74FF5DE</bpmn2:incoming>
+      <bpmn2:outgoing>_75533767-B1DE-48BD-B1B6-55C97A2533D0</bpmn2:outgoing>
+      <bpmn2:script><![CDATA[System.out.println("Waiting for Signal2");]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="_41BF4683-24BE-4E4B-AB52-3FADF74FF5DE" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_16C862FB-BF23-4DEE-81E1-F89AC1974105" targetRef="_CE022FFB-E1A0-4CB1-B551-49CDC9FC42A2"/>
+    <bpmn2:intermediateCatchEvent id="_0917DDAE-BD47-4E51-8BE4-0949BA092290" drools:selectable="true" drools:boundaryca="" color:background-color="#f5deb3" color:border-color="#a0522d" color:color="#000000" name="">
+      <bpmn2:incoming>_0F48F867-3BEA-41F1-B5E8-E1A51AFC1E6F</bpmn2:incoming>
+      <bpmn2:outgoing>_FD93D52D-82CF-4D23-AF6E-E84B9A41B49C</bpmn2:outgoing>
+      <bpmn2:dataOutput id="_0917DDAE-BD47-4E51-8BE4-0949BA092290_personEvent" name="personEvent"/>
+      <bpmn2:dataOutputAssociation id="_i307QvlpEeSSI76UAbQxIw">
+        <bpmn2:sourceRef>_0917DDAE-BD47-4E51-8BE4-0949BA092290_personEvent</bpmn2:sourceRef>
+        <bpmn2:targetRef>personData</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+      <bpmn2:outputSet id="_i307QflpEeSSI76UAbQxIw">
+        <bpmn2:dataOutputRefs>_0917DDAE-BD47-4E51-8BE4-0949BA092290_personEvent</bpmn2:dataOutputRefs>
+      </bpmn2:outputSet>
+      <bpmn2:signalEventDefinition id="_i307Q_lpEeSSI76UAbQxIw" signalRef="Signal1"/>
+    </bpmn2:intermediateCatchEvent>
+    <bpmn2:intermediateCatchEvent id="_F5690A53-1FD7-40EF-9A9C-D7BD1E535D6A" drools:selectable="true" drools:boundaryca="" color:background-color="#f5deb3" color:border-color="#a0522d" color:color="#000000" name="">
+      <bpmn2:incoming>_75533767-B1DE-48BD-B1B6-55C97A2533D0</bpmn2:incoming>
+      <bpmn2:outgoing>_E594B1EF-8E4A-4716-AE68-19C113669510</bpmn2:outgoing>
+      <bpmn2:dataOutput id="_F5690A53-1FD7-40EF-9A9C-D7BD1E535D6A_stringEvent" name="stringEvent"/>
+      <bpmn2:dataOutputAssociation id="_i307RflpEeSSI76UAbQxIw">
+        <bpmn2:sourceRef>_F5690A53-1FD7-40EF-9A9C-D7BD1E535D6A_stringEvent</bpmn2:sourceRef>
+        <bpmn2:targetRef>stringData</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+      <bpmn2:outputSet id="_i307RPlpEeSSI76UAbQxIw">
+        <bpmn2:dataOutputRefs>_F5690A53-1FD7-40EF-9A9C-D7BD1E535D6A_stringEvent</bpmn2:dataOutputRefs>
+      </bpmn2:outputSet>
+      <bpmn2:signalEventDefinition id="_i307RvlpEeSSI76UAbQxIw" signalRef="Signal2"/>
+    </bpmn2:intermediateCatchEvent>
+    <bpmn2:scriptTask id="_4723FD74-2069-4BFC-A6D0-886335673626" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Signal 2 data" scriptFormat="http://www.java.com/java">
+      <bpmn2:incoming>_E594B1EF-8E4A-4716-AE68-19C113669510</bpmn2:incoming>
+      <bpmn2:outgoing>_9E3B3FA8-409D-4591-A84E-BEDB42C44D23</bpmn2:outgoing>
+      <bpmn2:script><![CDATA[System.out.println("Signaled with data " + stringData);
+      ]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="_E594B1EF-8E4A-4716-AE68-19C113669510" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_F5690A53-1FD7-40EF-9A9C-D7BD1E535D6A" targetRef="_4723FD74-2069-4BFC-A6D0-886335673626"/>
+    <bpmn2:sequenceFlow id="_9E3B3FA8-409D-4591-A84E-BEDB42C44D23" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_4723FD74-2069-4BFC-A6D0-886335673626" targetRef="_B668F1D8-F142-425B-B427-E4ECF7AFA1D6"/>
+    <bpmn2:parallelGateway id="_B668F1D8-F142-425B-B427-E4ECF7AFA1D6" drools:selectable="true" color:background-color="#f0e68c" color:border-color="#a67f00" color:color="#000000" name="" gatewayDirection="Converging">
+      <bpmn2:incoming>_1ED21D5A-0949-46B9-A848-DC8957703808</bpmn2:incoming>
+      <bpmn2:incoming>_9E3B3FA8-409D-4591-A84E-BEDB42C44D23</bpmn2:incoming>
+      <bpmn2:outgoing>_76102DB4-6E90-4873-8748-4680CBCDE5CF</bpmn2:outgoing>
+    </bpmn2:parallelGateway>
+    <bpmn2:endEvent id="_895A52BF-B222-44C2-B970-97DBBF28D062" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:incoming>_76102DB4-6E90-4873-8748-4680CBCDE5CF</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_76102DB4-6E90-4873-8748-4680CBCDE5CF" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_B668F1D8-F142-425B-B427-E4ECF7AFA1D6" targetRef="_895A52BF-B222-44C2-B970-97DBBF28D062"/>
+    <bpmn2:scriptTask id="_EE7B0F93-D5CF-4DCF-BE15-BE6F542210E0" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Signal 1 data" scriptFormat="http://www.java.com/java">
+      <bpmn2:incoming>_FD93D52D-82CF-4D23-AF6E-E84B9A41B49C</bpmn2:incoming>
+      <bpmn2:outgoing>_1ED21D5A-0949-46B9-A848-DC8957703808</bpmn2:outgoing>
+      <bpmn2:script><![CDATA[System.out.println("Signaled with data " + personData);
+      if (!nullAccepted) {
+         System.out.println("Signaled with data " + personData.toString());
+      }]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="_FD93D52D-82CF-4D23-AF6E-E84B9A41B49C" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_0917DDAE-BD47-4E51-8BE4-0949BA092290" targetRef="_EE7B0F93-D5CF-4DCF-BE15-BE6F542210E0"/>
+    <bpmn2:sequenceFlow id="_1ED21D5A-0949-46B9-A848-DC8957703808" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_EE7B0F93-D5CF-4DCF-BE15-BE6F542210E0" targetRef="_B668F1D8-F142-425B-B427-E4ECF7AFA1D6"/>
+    <bpmn2:sequenceFlow id="_75533767-B1DE-48BD-B1B6-55C97A2533D0" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_CE022FFB-E1A0-4CB1-B551-49CDC9FC42A2" targetRef="_F5690A53-1FD7-40EF-9A9C-D7BD1E535D6A"/>
+    <bpmn2:sequenceFlow id="_0F48F867-3BEA-41F1-B5E8-E1A51AFC1E6F" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_BA8D76D0-4D52-42DB-B91E-2A9CB2B8BE30" targetRef="_0917DDAE-BD47-4E51-8BE4-0949BA092290"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_i31iUPlpEeSSI76UAbQxIw">
+    <bpmndi:BPMNPlane id="_i31iUflpEeSSI76UAbQxIw" bpmnElement="definition-project.signalprocess">
+      <bpmndi:BPMNShape id="_i31iUvlpEeSSI76UAbQxIw" bpmnElement="processStartEvent">
+        <dc:Bounds height="30.0" width="30.0" x="120.0" y="230.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_i31iU_lpEeSSI76UAbQxIw" bpmnElement="_2F05998A-B828-4A6E-B34A-502CE1E8D2D0">
+        <di:waypoint xsi:type="dc:Point" x="135.0" y="245.0"/>
+        <di:waypoint xsi:type="dc:Point" x="215.0" y="245.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_i31iVPlpEeSSI76UAbQxIw" bpmnElement="_BA8D76D0-4D52-42DB-B91E-2A9CB2B8BE30">
+        <dc:Bounds height="80.0" width="100.0" x="240.0" y="45.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_i31iVflpEeSSI76UAbQxIw" bpmnElement="_995351DB-6388-4213-B66F-72A1FCA217B7">
+        <di:waypoint xsi:type="dc:Point" x="215.0" y="245.0"/>
+        <di:waypoint xsi:type="dc:Point" x="215.0" y="85.0"/>
+        <di:waypoint xsi:type="dc:Point" x="290.0" y="85.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_i31iVvlpEeSSI76UAbQxIw" bpmnElement="_16C862FB-BF23-4DEE-81E1-F89AC1974105">
+        <dc:Bounds height="40.0" width="40.0" x="195.0" y="225.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_i31iV_lpEeSSI76UAbQxIw" bpmnElement="_CE022FFB-E1A0-4CB1-B551-49CDC9FC42A2">
+        <dc:Bounds height="80.0" width="100.0" x="240.0" y="320.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_i31iWPlpEeSSI76UAbQxIw" bpmnElement="_41BF4683-24BE-4E4B-AB52-3FADF74FF5DE">
+        <di:waypoint xsi:type="dc:Point" x="215.0" y="245.0"/>
+        <di:waypoint xsi:type="dc:Point" x="215.0" y="360.0"/>
+        <di:waypoint xsi:type="dc:Point" x="290.0" y="360.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_i31iWflpEeSSI76UAbQxIw" bpmnElement="_0917DDAE-BD47-4E51-8BE4-0949BA092290">
+        <dc:Bounds height="30.0" width="30.0" x="385.0" y="67.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_i31iWvlpEeSSI76UAbQxIw" bpmnElement="_F5690A53-1FD7-40EF-9A9C-D7BD1E535D6A">
+        <dc:Bounds height="30.0" width="30.0" x="404.0" y="345.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_i31iW_lpEeSSI76UAbQxIw" bpmnElement="_4723FD74-2069-4BFC-A6D0-886335673626">
+        <dc:Bounds height="80.0" width="100.0" x="479.0" y="320.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_i31iXPlpEeSSI76UAbQxIw" bpmnElement="_E594B1EF-8E4A-4716-AE68-19C113669510">
+        <di:waypoint xsi:type="dc:Point" x="419.0" y="360.0"/>
+        <di:waypoint xsi:type="dc:Point" x="529.0" y="360.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_i31iXflpEeSSI76UAbQxIw" bpmnElement="_9E3B3FA8-409D-4591-A84E-BEDB42C44D23">
+        <di:waypoint xsi:type="dc:Point" x="529.0" y="360.0"/>
+        <di:waypoint xsi:type="dc:Point" x="620.0" y="360.0"/>
+        <di:waypoint xsi:type="dc:Point" x="620.0" y="245.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_i31iXvlpEeSSI76UAbQxIw" bpmnElement="_B668F1D8-F142-425B-B427-E4ECF7AFA1D6">
+        <dc:Bounds height="40.0" width="40.0" x="600.0" y="225.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_i31iX_lpEeSSI76UAbQxIw" bpmnElement="_895A52BF-B222-44C2-B970-97DBBF28D062">
+        <dc:Bounds height="28.0" width="28.0" x="685.0" y="231.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_i31iYPlpEeSSI76UAbQxIw" bpmnElement="_76102DB4-6E90-4873-8748-4680CBCDE5CF">
+        <di:waypoint xsi:type="dc:Point" x="620.0" y="245.0"/>
+        <di:waypoint xsi:type="dc:Point" x="699.0" y="245.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_i32JYPlpEeSSI76UAbQxIw" bpmnElement="_EE7B0F93-D5CF-4DCF-BE15-BE6F542210E0">
+        <dc:Bounds height="80.0" width="100.0" x="460.0" y="42.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_i32JYflpEeSSI76UAbQxIw" bpmnElement="_FD93D52D-82CF-4D23-AF6E-E84B9A41B49C">
+        <di:waypoint xsi:type="dc:Point" x="400.0" y="82.0"/>
+        <di:waypoint xsi:type="dc:Point" x="510.0" y="82.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_i32JYvlpEeSSI76UAbQxIw" bpmnElement="_1ED21D5A-0949-46B9-A848-DC8957703808">
+        <di:waypoint xsi:type="dc:Point" x="510.0" y="82.0"/>
+        <di:waypoint xsi:type="dc:Point" x="620.0" y="82.0"/>
+        <di:waypoint xsi:type="dc:Point" x="620.0" y="245.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_i32JY_lpEeSSI76UAbQxIw" bpmnElement="_75533767-B1DE-48BD-B1B6-55C97A2533D0">
+        <di:waypoint xsi:type="dc:Point" x="290.0" y="360.0"/>
+        <di:waypoint xsi:type="dc:Point" x="419.0" y="360.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_i32JZPlpEeSSI76UAbQxIw" bpmnElement="_0F48F867-3BEA-41F1-B5E8-E1A51AFC1E6F">
+        <di:waypoint xsi:type="dc:Point" x="290.0" y="85.0"/>
+        <di:waypoint xsi:type="dc:Point" x="362.0" y="85.0"/>
+        <di:waypoint xsi:type="dc:Point" x="362.0" y="82.0"/>
+        <di:waypoint xsi:type="dc:Point" x="400.0" y="82.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_i32JZflpEeSSI76UAbQxIw" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_2F05998A-B828-4A6E-B34A-502CE1E8D2D0" id="_i32JZvlpEeSSI76UAbQxIw">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_995351DB-6388-4213-B66F-72A1FCA217B7" id="_i32JZ_lpEeSSI76UAbQxIw">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_41BF4683-24BE-4E4B-AB52-3FADF74FF5DE" id="_i32JaPlpEeSSI76UAbQxIw">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_CE022FFB-E1A0-4CB1-B551-49CDC9FC42A2" id="_i32JaflpEeSSI76UAbQxIw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_4723FD74-2069-4BFC-A6D0-886335673626" id="_i32JavlpEeSSI76UAbQxIw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_0917DDAE-BD47-4E51-8BE4-0949BA092290" id="_i32Ja_lpEeSSI76UAbQxIw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_895A52BF-B222-44C2-B970-97DBBF28D062" id="_i32JbPlpEeSSI76UAbQxIw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_E594B1EF-8E4A-4716-AE68-19C113669510" id="_i32JbflpEeSSI76UAbQxIw">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_9E3B3FA8-409D-4591-A84E-BEDB42C44D23" id="_i32JbvlpEeSSI76UAbQxIw">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_F5690A53-1FD7-40EF-9A9C-D7BD1E535D6A" id="_i32Jb_lpEeSSI76UAbQxIw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="processStartEvent" id="_i32JcPlpEeSSI76UAbQxIw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_76102DB4-6E90-4873-8748-4680CBCDE5CF" id="_i32JcflpEeSSI76UAbQxIw">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_0F48F867-3BEA-41F1-B5E8-E1A51AFC1E6F" id="_i32JcvlpEeSSI76UAbQxIw">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_75533767-B1DE-48BD-B1B6-55C97A2533D0" id="_i32wcPlpEeSSI76UAbQxIw">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_1ED21D5A-0949-46B9-A848-DC8957703808" id="_i32wcflpEeSSI76UAbQxIw">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_EE7B0F93-D5CF-4DCF-BE15-BE6F542210E0" id="_i32wcvlpEeSSI76UAbQxIw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_BA8D76D0-4D52-42DB-B91E-2A9CB2B8BE30" id="_i32wc_lpEeSSI76UAbQxIw">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_FD93D52D-82CF-4D23-AF6E-E84B9A41B49C" id="_i32wdPlpEeSSI76UAbQxIw">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_i307QPlpEeSSI76UAbQxIw</bpmn2:source>
+    <bpmn2:target>_i307QPlpEeSSI76UAbQxIw</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/different-gav-definition-project/package-names-white-list
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/different-gav-definition-project/package-names-white-list
@@ -1,0 +1,1 @@
+org.kie.server.testing.definition_project.**

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/different-gav-definition-project/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/different-gav-definition-project/pom.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.kie.server.testing</groupId>
+    <artifactId>common-parent</artifactId>
+    <version>1.0.0.Final</version>
+  </parent>
+
+  <groupId>org.kie.server.different</groupId>
+  <artifactId>different-gav-definition-project</artifactId>
+  <version>1.0.1.Final</version>
+  <name>different-definition-project</name>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/different-gav-definition-project/project.imports
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/different-gav-definition-project/project.imports
@@ -1,0 +1,10 @@
+<configuration>
+  <imports>
+    <imports>
+      <import>
+        <type>java.lang.Number</type>
+      </import>
+    </imports>
+  </imports>
+  <version>1.0</version>
+</configuration>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/different-gav-definition-project/src/main/resources/META-INF/kie-deployment-descriptor.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/different-gav-definition-project/src/main/resources/META-INF/kie-deployment-descriptor.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<deployment-descriptor xsi:schemaLocation="http://www.jboss.org/jbpm deployment-descriptor.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <persistence-unit>org.jbpm.domain</persistence-unit>
+    <audit-persistence-unit>org.jbpm.domain</audit-persistence-unit>
+    <audit-mode>JPA</audit-mode>
+    <persistence-mode>JPA</persistence-mode>
+    <runtime-strategy>SINGLETON</runtime-strategy>
+    <marshalling-strategies/>
+    <event-listeners/>
+    <task-event-listeners/>
+    <globals/>
+    <work-item-handlers>
+        <work-item-handler>
+            <resolver>mvel</resolver>
+            <identifier>new org.jbpm.process.workitem.bpmn2.ServiceTaskHandler(ksession, classLoader)</identifier>
+            <parameters/>
+            <name>Service Task</name>
+        </work-item-handler>
+        <work-item-handler>
+            <resolver>mvel</resolver>
+            <identifier>new org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler()</identifier>
+            <parameters/>
+            <name>Log</name>
+        </work-item-handler>
+        <work-item-handler>
+            <resolver>mvel</resolver>
+            <identifier>new org.jbpm.process.instance.impl.demo.DoNothingWorkItemHandler()</identifier>
+            <parameters/>
+            <name>Email</name>
+        </work-item-handler>
+        <work-item-handler>
+            <resolver>mvel</resolver>
+            <identifier>new org.jbpm.process.workitem.webservice.WebServiceWorkItemHandler(ksession, classLoader)</identifier>
+            <parameters/>
+            <name>WebService</name>
+        </work-item-handler>
+        <work-item-handler>
+            <resolver>mvel</resolver>
+            <identifier>new org.jbpm.process.workitem.rest.RESTWorkItemHandler()</identifier>
+            <parameters/>
+            <name>Rest</name>
+        </work-item-handler>
+    </work-item-handlers>
+    <environment-entries/>
+    <configurations/>
+    <required-roles/>
+    <remoteable-classes/>
+</deployment-descriptor>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/different-gav-definition-project/src/main/resources/META-INF/kmodule.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/different-gav-definition-project/src/main/resources/META-INF/kmodule.xml
@@ -1,0 +1,1 @@
+<kmodule xmlns="http://www.drools.org/xsd/kmodule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"/>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/different-gav-definition-project/src/main/resources/WorkDefinitions.wid
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/different-gav-definition-project/src/main/resources/WorkDefinitions.wid
@@ -1,0 +1,61 @@
+import org.drools.core.process.core.datatype.impl.type.StringDataType;
+import org.drools.core.process.core.datatype.impl.type.ObjectDataType;
+
+[
+  [
+    "name" : "Email",
+    "parameters" : [
+      "From" : new StringDataType(),
+      "To" : new StringDataType(),
+      "Subject" : new StringDataType(),
+      "Body" : new StringDataType()
+    ],
+    "displayName" : "Email",
+    "icon" : "defaultemailicon.gif"
+  ],
+
+  [
+    "name" : "Log",
+    "parameters" : [
+      "Message" : new StringDataType()
+    ],
+    "displayName" : "Log",
+    "icon" : "defaultlogicon.gif"
+  ],
+
+  [
+    "name" : "WebService",
+    "parameters" : [
+        "Url" : new StringDataType(),
+         "Namespace" : new StringDataType(),
+         "Interface" : new StringDataType(),
+         "Operation" : new StringDataType(),
+         "Parameter" : new StringDataType(),
+         "Endpoint" : new StringDataType(),
+         "Mode" : new StringDataType()
+    ],
+    "results" : [
+        "Result" : new ObjectDataType(),
+    ],
+    "displayName" : "WS",
+    "icon" : "defaultservicenodeicon.png"
+  ],
+
+  [
+    "name" : "Rest",
+    "parameters" : [
+        "Url" : new StringDataType(),
+        "Method" : new StringDataType(),
+        "ConnectTimeout" : new StringDataType(),
+        "ReadTimeout" : new StringDataType(),
+        "Username" : new StringDataType(),
+        "Password" : new StringDataType()
+    ],
+    "results" : [
+        "Result" : new ObjectDataType(),
+    ],
+    "displayName" : "REST",
+    "icon" : "defaultservicenodeicon.png"
+  ]
+
+]

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/different-gav-definition-project/src/main/resources/evaluation.bpmn2
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/different-gav-definition-project/src/main/resources/evaluation.bpmn2
@@ -1,0 +1,325 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_l8-uwF1hEeaOybVhumYfag" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_nameItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_itemItem" structureRef="java.util.List"/>
+  <bpmn2:itemDefinition id="_outcomeItem" structureRef="Boolean"/>
+  <bpmn2:itemDefinition id="__A5D8FA73-4554-4FAB-891B-38BE058D0D1C_name_inInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__A5D8FA73-4554-4FAB-891B-38BE058D0D1C_list_inInputXItem" structureRef="java.util.List"/>
+  <bpmn2:itemDefinition id="__A5D8FA73-4554-4FAB-891B-38BE058D0D1C_GroupIdInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__A5D8FA73-4554-4FAB-891B-38BE058D0D1C_SkippableInputXItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__A5D8FA73-4554-4FAB-891B-38BE058D0D1C_outcomeOutputXItem" structureRef="Boolean"/>
+  <bpmn2:itemDefinition id="__B46BD6B3-29D5-4F75-A79E-25180A359DDD_TaskNameInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__B46BD6B3-29D5-4F75-A79E-25180A359DDD_FromInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__B46BD6B3-29D5-4F75-A79E-25180A359DDD_BodyInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__B46BD6B3-29D5-4F75-A79E-25180A359DDD_SubjectInputXItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__B46BD6B3-29D5-4F75-A79E-25180A359DDD_ToInputXItem" structureRef="String"/>
+  <bpmn2:process id="definition-project.evaluation2" drools:packageName="org.jbpm" drools:version="2.0" name="evaluation2" isExecutable="true">
+    <bpmn2:property id="name" itemSubjectRef="_nameItem"/>
+    <bpmn2:property id="item" itemSubjectRef="_itemItem"/>
+    <bpmn2:property id="outcome" itemSubjectRef="_outcomeItem"/>
+    <bpmn2:startEvent id="_942E1EF2-8EC1-4753-87A4-9906A79272D0" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_FF5D61DE-D156-4853-BBC3-B289807444EB</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:userTask id="_A5D8FA73-4554-4FAB-891B-38BE058D0D1C" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Evaluate items">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Evaluate items]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_FF5D61DE-D156-4853-BBC3-B289807444EB</bpmn2:incoming>
+      <bpmn2:outgoing>_245E7CF9-1981-4843-BE72-179606F792B2</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_l8-uwV1hEeaOybVhumYfag">
+        <bpmn2:dataInput id="_A5D8FA73-4554-4FAB-891B-38BE058D0D1C_name_inInputX" drools:dtype="String" itemSubjectRef="__A5D8FA73-4554-4FAB-891B-38BE058D0D1C_name_inInputXItem" name="name_in"/>
+        <bpmn2:dataInput id="_A5D8FA73-4554-4FAB-891B-38BE058D0D1C_list_inInputX" drools:dtype="java.util.List" itemSubjectRef="__A5D8FA73-4554-4FAB-891B-38BE058D0D1C_list_inInputXItem" name="list_in"/>
+        <bpmn2:dataInput id="_A5D8FA73-4554-4FAB-891B-38BE058D0D1C_GroupIdInputX" drools:dtype="Object" itemSubjectRef="__A5D8FA73-4554-4FAB-891B-38BE058D0D1C_GroupIdInputXItem" name="GroupId"/>
+        <bpmn2:dataInput id="_A5D8FA73-4554-4FAB-891B-38BE058D0D1C_SkippableInputX" drools:dtype="Object" itemSubjectRef="__A5D8FA73-4554-4FAB-891B-38BE058D0D1C_SkippableInputXItem" name="Skippable"/>
+        <bpmn2:dataOutput id="_A5D8FA73-4554-4FAB-891B-38BE058D0D1C_outcomeOutputX" drools:dtype="Boolean" itemSubjectRef="__A5D8FA73-4554-4FAB-891B-38BE058D0D1C_outcomeOutputXItem" name="outcome"/>
+        <bpmn2:inputSet id="_l8-uwl1hEeaOybVhumYfag">
+          <bpmn2:dataInputRefs>_A5D8FA73-4554-4FAB-891B-38BE058D0D1C_name_inInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_A5D8FA73-4554-4FAB-891B-38BE058D0D1C_list_inInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_A5D8FA73-4554-4FAB-891B-38BE058D0D1C_GroupIdInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_A5D8FA73-4554-4FAB-891B-38BE058D0D1C_SkippableInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_l8-uw11hEeaOybVhumYfag">
+          <bpmn2:dataOutputRefs>_A5D8FA73-4554-4FAB-891B-38BE058D0D1C_outcomeOutputX</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_l8_V0F1hEeaOybVhumYfag">
+        <bpmn2:targetRef>_A5D8FA73-4554-4FAB-891B-38BE058D0D1C_GroupIdInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_l8_V0V1hEeaOybVhumYfag">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_l8_V0l1hEeaOybVhumYfag"><![CDATA[HR,PM]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_l8_V011hEeaOybVhumYfag">_A5D8FA73-4554-4FAB-891B-38BE058D0D1C_GroupIdInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_l8_V1F1hEeaOybVhumYfag">
+        <bpmn2:targetRef>_A5D8FA73-4554-4FAB-891B-38BE058D0D1C_SkippableInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_l8_V1V1hEeaOybVhumYfag">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_l8_V1l1hEeaOybVhumYfag">true</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_l8_V111hEeaOybVhumYfag">_A5D8FA73-4554-4FAB-891B-38BE058D0D1C_SkippableInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:potentialOwner id="_l8_V2F1hEeaOybVhumYfag">
+        <bpmn2:resourceAssignmentExpression id="_l8_V2V1hEeaOybVhumYfag">
+          <bpmn2:formalExpression id="_l8_V2l1hEeaOybVhumYfag">yoda</bpmn2:formalExpression>
+        </bpmn2:resourceAssignmentExpression>
+      </bpmn2:potentialOwner>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="_FF5D61DE-D156-4853-BBC3-B289807444EB" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_942E1EF2-8EC1-4753-87A4-9906A79272D0" targetRef="_A5D8FA73-4554-4FAB-891B-38BE058D0D1C"/>
+    <bpmn2:task id="_B46BD6B3-29D5-4F75-A79E-25180A359DDD" drools:selectable="true" drools:taskName="Email" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Email results">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Email results]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_1B4B0E99-2EF1-48C9-A378-1EF095166BD0</bpmn2:incoming>
+      <bpmn2:outgoing>_0C0722A1-0E9A-4FA8-A731-876A863AD7CA</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_l8_V211hEeaOybVhumYfag">
+        <bpmn2:dataInput id="_B46BD6B3-29D5-4F75-A79E-25180A359DDD_TaskNameInputX" drools:dtype="String" itemSubjectRef="__B46BD6B3-29D5-4F75-A79E-25180A359DDD_TaskNameInputXItem" name="TaskName"/>
+        <bpmn2:dataInput id="_B46BD6B3-29D5-4F75-A79E-25180A359DDD_FromInputX" drools:dtype="String" itemSubjectRef="__B46BD6B3-29D5-4F75-A79E-25180A359DDD_FromInputXItem" name="From"/>
+        <bpmn2:dataInput id="_B46BD6B3-29D5-4F75-A79E-25180A359DDD_BodyInputX" drools:dtype="String" itemSubjectRef="__B46BD6B3-29D5-4F75-A79E-25180A359DDD_BodyInputXItem" name="Body"/>
+        <bpmn2:dataInput id="_B46BD6B3-29D5-4F75-A79E-25180A359DDD_SubjectInputX" drools:dtype="String" itemSubjectRef="__B46BD6B3-29D5-4F75-A79E-25180A359DDD_SubjectInputXItem" name="Subject"/>
+        <bpmn2:dataInput id="_B46BD6B3-29D5-4F75-A79E-25180A359DDD_ToInputX" drools:dtype="String" itemSubjectRef="__B46BD6B3-29D5-4F75-A79E-25180A359DDD_ToInputXItem" name="To"/>
+        <bpmn2:inputSet id="_l8_V3F1hEeaOybVhumYfag">
+          <bpmn2:dataInputRefs>_B46BD6B3-29D5-4F75-A79E-25180A359DDD_FromInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_B46BD6B3-29D5-4F75-A79E-25180A359DDD_BodyInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_B46BD6B3-29D5-4F75-A79E-25180A359DDD_SubjectInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_B46BD6B3-29D5-4F75-A79E-25180A359DDD_ToInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_B46BD6B3-29D5-4F75-A79E-25180A359DDD_TaskNameInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_l8_V3V1hEeaOybVhumYfag"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_l8_V3l1hEeaOybVhumYfag">
+        <bpmn2:targetRef>_B46BD6B3-29D5-4F75-A79E-25180A359DDD_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_l8_V311hEeaOybVhumYfag">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_l8_V4F1hEeaOybVhumYfag">Email</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_l8_V4V1hEeaOybVhumYfag">_B46BD6B3-29D5-4F75-A79E-25180A359DDD_TaskNameInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_l8_V4l1hEeaOybVhumYfag">
+        <bpmn2:targetRef>_B46BD6B3-29D5-4F75-A79E-25180A359DDD_FromInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_l8_V411hEeaOybVhumYfag">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_l8_V5F1hEeaOybVhumYfag"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_l8_V5V1hEeaOybVhumYfag">_B46BD6B3-29D5-4F75-A79E-25180A359DDD_FromInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_l8_V5l1hEeaOybVhumYfag">
+        <bpmn2:targetRef>_B46BD6B3-29D5-4F75-A79E-25180A359DDD_BodyInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_l8_V511hEeaOybVhumYfag">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_l8_V6F1hEeaOybVhumYfag"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_l8_V6V1hEeaOybVhumYfag">_B46BD6B3-29D5-4F75-A79E-25180A359DDD_BodyInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_l8_V6l1hEeaOybVhumYfag">
+        <bpmn2:targetRef>_B46BD6B3-29D5-4F75-A79E-25180A359DDD_SubjectInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_l8_V611hEeaOybVhumYfag">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_l8_V7F1hEeaOybVhumYfag"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_l8_V7V1hEeaOybVhumYfag">_B46BD6B3-29D5-4F75-A79E-25180A359DDD_SubjectInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_l8_V7l1hEeaOybVhumYfag">
+        <bpmn2:targetRef>_B46BD6B3-29D5-4F75-A79E-25180A359DDD_ToInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_l8_V711hEeaOybVhumYfag">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_l8_V8F1hEeaOybVhumYfag"></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_l8_V8V1hEeaOybVhumYfag">_B46BD6B3-29D5-4F75-A79E-25180A359DDD_ToInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:task>
+    <bpmn2:endEvent id="_FDE95B1D-9B0F-40E5-A5C8-3E6BAA3BFD67" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_0C0722A1-0E9A-4FA8-A731-876A863AD7CA</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_0C0722A1-0E9A-4FA8-A731-876A863AD7CA" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_B46BD6B3-29D5-4F75-A79E-25180A359DDD" targetRef="_FDE95B1D-9B0F-40E5-A5C8-3E6BAA3BFD67"/>
+    <bpmn2:userTask id="_56FB3E50-DEDD-415B-94DD-0357C91836B9" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Approve">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Approve]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_245E7CF9-1981-4843-BE72-179606F792B2</bpmn2:incoming>
+      <bpmn2:outgoing>_1B4B0E99-2EF1-48C9-A378-1EF095166BD0</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_l8_V8l1hEeaOybVhumYfag">
+        <bpmn2:dataInput id="_56FB3E50-DEDD-415B-94DD-0357C91836B9_GroupIdInputX" name="GroupId"/>
+        <bpmn2:dataInput id="_56FB3E50-DEDD-415B-94DD-0357C91836B9_SkippableInputX" name="Skippable"/>
+        <bpmn2:inputSet id="_l8_84F1hEeaOybVhumYfag">
+          <bpmn2:dataInputRefs>_56FB3E50-DEDD-415B-94DD-0357C91836B9_GroupIdInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_56FB3E50-DEDD-415B-94DD-0357C91836B9_SkippableInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_l8_84V1hEeaOybVhumYfag">
+        <bpmn2:targetRef>_56FB3E50-DEDD-415B-94DD-0357C91836B9_GroupIdInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_l8_84l1hEeaOybVhumYfag">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_l8_8411hEeaOybVhumYfag"><![CDATA[HR,PM]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_l8_85F1hEeaOybVhumYfag">_56FB3E50-DEDD-415B-94DD-0357C91836B9_GroupIdInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_l8_85V1hEeaOybVhumYfag">
+        <bpmn2:targetRef>_56FB3E50-DEDD-415B-94DD-0357C91836B9_SkippableInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_l8_85l1hEeaOybVhumYfag">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_l8_8511hEeaOybVhumYfag">true</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_l8_86F1hEeaOybVhumYfag">_56FB3E50-DEDD-415B-94DD-0357C91836B9_SkippableInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:potentialOwner id="_l8_86V1hEeaOybVhumYfag">
+        <bpmn2:resourceAssignmentExpression id="_l8_86l1hEeaOybVhumYfag">
+          <bpmn2:formalExpression id="_l8_8611hEeaOybVhumYfag">yoda</bpmn2:formalExpression>
+        </bpmn2:resourceAssignmentExpression>
+      </bpmn2:potentialOwner>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="_245E7CF9-1981-4843-BE72-179606F792B2" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_A5D8FA73-4554-4FAB-891B-38BE058D0D1C" targetRef="_56FB3E50-DEDD-415B-94DD-0357C91836B9"/>
+    <bpmn2:sequenceFlow id="_1B4B0E99-2EF1-48C9-A378-1EF095166BD0" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_56FB3E50-DEDD-415B-94DD-0357C91836B9" targetRef="_B46BD6B3-29D5-4F75-A79E-25180A359DDD"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_l8_87F1hEeaOybVhumYfag">
+    <bpmndi:BPMNPlane id="_l8_87V1hEeaOybVhumYfag" bpmnElement="definition-project.evaluation2">
+      <bpmndi:BPMNShape id="_l8_87l1hEeaOybVhumYfag" bpmnElement="_942E1EF2-8EC1-4753-87A4-9906A79272D0">
+        <dc:Bounds height="30.0" width="30.0" x="120.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_l8_8711hEeaOybVhumYfag" bpmnElement="_A5D8FA73-4554-4FAB-891B-38BE058D0D1C">
+        <dc:Bounds height="80.0" width="100.0" x="195.0" y="140.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_l8_88F1hEeaOybVhumYfag" bpmnElement="_FF5D61DE-D156-4853-BBC3-B289807444EB" sourceElement="_l8_87l1hEeaOybVhumYfag" targetElement="_l8_8711hEeaOybVhumYfag">
+        <di:waypoint xsi:type="dc:Point" x="135.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="245.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_l8_88V1hEeaOybVhumYfag" bpmnElement="_B46BD6B3-29D5-4F75-A79E-25180A359DDD">
+        <dc:Bounds height="80.0" width="100.0" x="495.0" y="140.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_l8_88l1hEeaOybVhumYfag" bpmnElement="_FDE95B1D-9B0F-40E5-A5C8-3E6BAA3BFD67">
+        <dc:Bounds height="28.0" width="28.0" x="630.0" y="166.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_l8_8811hEeaOybVhumYfag" bpmnElement="_0C0722A1-0E9A-4FA8-A731-876A863AD7CA" sourceElement="_l8_88V1hEeaOybVhumYfag" targetElement="_l8_88l1hEeaOybVhumYfag">
+        <di:waypoint xsi:type="dc:Point" x="545.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="644.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_l8_89F1hEeaOybVhumYfag" bpmnElement="_56FB3E50-DEDD-415B-94DD-0357C91836B9">
+        <dc:Bounds height="80.0" width="100.0" x="340.0" y="140.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_l8_89V1hEeaOybVhumYfag" bpmnElement="_245E7CF9-1981-4843-BE72-179606F792B2" sourceElement="_l8_8711hEeaOybVhumYfag" targetElement="_l8_89F1hEeaOybVhumYfag">
+        <di:waypoint xsi:type="dc:Point" x="245.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="390.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_l8_89l1hEeaOybVhumYfag" bpmnElement="_1B4B0E99-2EF1-48C9-A378-1EF095166BD0" sourceElement="_l8_89F1hEeaOybVhumYfag" targetElement="_l8_88V1hEeaOybVhumYfag">
+        <di:waypoint xsi:type="dc:Point" x="390.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="545.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_l8_8911hEeaOybVhumYfag" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_1B4B0E99-2EF1-48C9-A378-1EF095166BD0" id="_l8_8-F1hEeaOybVhumYfag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_FF5D61DE-D156-4853-BBC3-B289807444EB" id="_l8_8-V1hEeaOybVhumYfag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_B46BD6B3-29D5-4F75-A79E-25180A359DDD" id="_l8_8-l1hEeaOybVhumYfag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_245E7CF9-1981-4843-BE72-179606F792B2" id="_l9Aj8F1hEeaOybVhumYfag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_A5D8FA73-4554-4FAB-891B-38BE058D0D1C" id="_l9Aj8V1hEeaOybVhumYfag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="1.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_942E1EF2-8EC1-4753-87A4-9906A79272D0" id="_l9Aj8l1hEeaOybVhumYfag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_56FB3E50-DEDD-415B-94DD-0357C91836B9" id="_l9Aj811hEeaOybVhumYfag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="1.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_0C0722A1-0E9A-4FA8-A731-876A863AD7CA" id="_l9Aj9F1hEeaOybVhumYfag">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_FDE95B1D-9B0F-40E5-A5C8-3E6BAA3BFD67" id="_l9Aj9V1hEeaOybVhumYfag">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_l8-uwF1hEeaOybVhumYfag</bpmn2:source>
+    <bpmn2:target>_l8-uwF1hEeaOybVhumYfag</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
@@ -58,6 +58,7 @@ public abstract class JbpmKieServerBaseIntegrationTest extends RestJmsSharedBase
     protected static final String PROCESS_ID_ASYNC_SCRIPT = "AsyncScriptTask";
     protected static final String PROCESS_ID_TIMER = "definition-project.timer-process";
     protected static final String PROCESS_ID_SIGNAL_PROCESS = "definition-project.signalprocess";
+    protected static final String PROCESS_ID_SIGNAL_PROCESS_2 = "definition-project.signalprocess2";
     protected static final String PROCESS_ID_SIGNAL_START = "signal-start";
     protected static final String PROCESS_ID_CUSTOM_TASK = "customtask";
     protected static final String PROCESS_ID_USERTASK_ESCALATION = "humanTaskEscalation";

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RollingUpdateProcessServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RollingUpdateProcessServiceIntegrationTest.java
@@ -15,34 +15,38 @@
 
 package org.kie.server.integrationtests.jbpm;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kie.server.remote.rest.jbpm.resources.Messages.NO_PROCESS_AVAILABLE_WITH_ID;
+import static org.kie.server.remote.rest.jbpm.resources.Messages.PROCESS_DEFINITION_NOT_FOUND;
+
+import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.text.MessageFormat;
 
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.api.KieServices;
-
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.task.model.Status;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.ProcessInstance;
+import org.kie.server.api.model.instance.TaskInstance;
 import org.kie.server.api.model.instance.TaskSummary;
+import org.kie.server.api.model.instance.WorkItemInstance;
 import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.kie.server.remote.rest.jbpm.resources.Messages.PROCESS_DEFINITION_NOT_FOUND;
-import static org.kie.server.remote.rest.jbpm.resources.Messages.NO_PROCESS_AVAILABLE_WITH_ID;
 
 public class RollingUpdateProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest {
 
     private static ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "definition-project",
-                                                       "1.0.0.Final");
+            "1.0.0.Final");
     private static final ReleaseId releaseId101 = new ReleaseId("org.kie.server.testing", "definition-project",
-                                                                "1.0.1.Final");
+            "1.0.1.Final");
 
 
     protected static final String CONTAINER_ALIAS = "project";
@@ -54,7 +58,7 @@ public class RollingUpdateProcessServiceIntegrationTest extends JbpmKieServerBas
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project-101").getFile());
-        //KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/different-gav-definition-project").getFile());
+        KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/different-gav-definition-project").getFile());
 
         kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
 
@@ -84,19 +88,18 @@ public class RollingUpdateProcessServiceIntegrationTest extends JbpmKieServerBas
 
         Object person = createPersonInstance(USER_JOHN);
 
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("test", USER_MARY);
-        parameters.put("number", new Integer(12345));
+        parameters.put("number", 12345);
 
-        List<Object> list = new ArrayList<Object>();
+        List<Object> list = new ArrayList<>();
         list.add("item");
 
         parameters.put("list", list);
         parameters.put("person", person);
         Long processInstanceId = processClient.startProcess(CONTAINER_ALIAS, PROCESS_ID_EVALUATION, parameters);
 
-        assertThat(processInstanceId).isNotNull();
-        assertThat(processInstanceId).isGreaterThan(0);
+        assertThat(processInstanceId).isNotNull().isGreaterThan(0);
 
         ProcessInstance processInstance = processClient.getProcessInstance(CONTAINER_ALIAS, processInstanceId);
         assertThat(processInstance).isNotNull();
@@ -140,7 +143,7 @@ public class RollingUpdateProcessServiceIntegrationTest extends JbpmKieServerBas
 
         Map<String, Object> newVariables = new HashMap<>();
         newVariables.put("test", USER_MARY);
-        newVariables.put("number", new Integer(6789));
+        newVariables.put("number", 6789);
 
         processClient.setProcessVariables(CONTAINER_ALIAS, processInstanceId, newVariables);
         variables = processClient.getProcessInstanceVariables(CONTAINER_ALIAS, processInstanceId);
@@ -154,11 +157,11 @@ public class RollingUpdateProcessServiceIntegrationTest extends JbpmKieServerBas
 
         Object person = createPersonInstance(USER_JOHN);
 
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("test", USER_MARY);
-        parameters.put("number", new Integer(12345));
+        parameters.put("number", 12345);
 
-        List<Object> list = new ArrayList<Object>();
+        List<Object> list = new ArrayList<>();
         list.add("item");
 
         parameters.put("list", list);
@@ -167,8 +170,7 @@ public class RollingUpdateProcessServiceIntegrationTest extends JbpmKieServerBas
 
         Long processInstanceIdV1 = processClient.startProcess(CONTAINER_ALIAS, PROCESS_ID_EVALUATION, parameters);
 
-        assertThat(processInstanceIdV1).isNotNull();
-        assertThat(processInstanceIdV1).isGreaterThan(0);
+        assertThat(processInstanceIdV1).isNotNull().isGreaterThan(0);
 
         ProcessInstance processInstance = processClient.getProcessInstance(CONTAINER_ALIAS, processInstanceIdV1);
         assertThat(processInstance).isNotNull();
@@ -185,8 +187,7 @@ public class RollingUpdateProcessServiceIntegrationTest extends JbpmKieServerBas
 
         Long processInstanceIdV2 = processClient.startProcess(CONTAINER_ALIAS, PROCESS_ID_EVALUATION_2, parameters);
 
-        assertThat(processInstanceIdV2).isNotNull();
-        assertThat(processInstanceIdV2).isGreaterThan(0);
+        assertThat(processInstanceIdV2).isNotNull().isGreaterThan(0);
 
         processInstance = processClient.getProcessInstance(CONTAINER_ALIAS, processInstanceIdV2);
         assertThat(processInstance).isNotNull();
@@ -206,11 +207,11 @@ public class RollingUpdateProcessServiceIntegrationTest extends JbpmKieServerBas
 
         Object person = createPersonInstance(USER_JOHN);
 
-        Map<String, Object> parameters = new HashMap<String, Object>();
+        Map<String, Object> parameters = new HashMap<>();
         parameters.put("test", USER_MARY);
-        parameters.put("number", new Integer(12345));
+        parameters.put("number", 12345);
 
-        List<Object> list = new ArrayList<Object>();
+        List<Object> list = new ArrayList<>();
         list.add("item");
 
         parameters.put("list", list);
@@ -218,8 +219,7 @@ public class RollingUpdateProcessServiceIntegrationTest extends JbpmKieServerBas
 
         Long processInstanceIdV1 = processClient.startProcess(CONTAINER_ID, PROCESS_ID_EVALUATION, parameters);
 
-        assertThat(processInstanceIdV1).isNotNull();
-        assertThat(processInstanceIdV1).isGreaterThan(0);
+        assertThat(processInstanceIdV1).isNotNull().isGreaterThan(0);
 
         ProcessInstance processInstance = processClient.getProcessInstance(CONTAINER_ALIAS, processInstanceIdV1);
         assertThat(processInstance).isNotNull();
@@ -236,8 +236,7 @@ public class RollingUpdateProcessServiceIntegrationTest extends JbpmKieServerBas
 
         Long processInstanceIdV2 = processClient.startProcess(CONTAINER_ID_101, PROCESS_ID_EVALUATION_2, parameters);
 
-        assertThat(processInstanceIdV2).isNotNull();
-        assertThat(processInstanceIdV2).isGreaterThan(0);
+        assertThat(processInstanceIdV2).isNotNull().isGreaterThan(0);
 
         processInstance = processClient.getProcessInstance(CONTAINER_ALIAS, processInstanceIdV2);
         assertThat(processInstance).isNotNull();
@@ -250,11 +249,10 @@ public class RollingUpdateProcessServiceIntegrationTest extends JbpmKieServerBas
 
         taskClient.completeAutoProgress(CONTAINER_ALIAS, task.getId(), USER_YODA, null);
 
-        // let's start ano  ther instance of the old version of container
+        // let's start another instance of the old version of container
         Long processInstanceIdV3 = processClient.startProcess(CONTAINER_ID, PROCESS_ID_EVALUATION, parameters);
 
-        assertThat(processInstanceIdV3).isNotNull();
-        assertThat(processInstanceIdV3).isGreaterThan(0);
+        assertThat(processInstanceIdV3).isNotNull().isGreaterThan(0);
 
         processInstance = processClient.getProcessInstance(CONTAINER_ALIAS, processInstanceIdV3);
         assertThat(processInstance).isNotNull();
@@ -272,8 +270,7 @@ public class RollingUpdateProcessServiceIntegrationTest extends JbpmKieServerBas
     @Test
     public void testDifferentGAVsWithAlias() throws Exception {
         Long oldPid = processClient.startProcess(CONTAINER_ALIAS, PROCESS_ID_EVALUATION);
-        assertThat(oldPid).isNotNull();
-        assertThat(oldPid).isGreaterThan(0);
+        assertThat(oldPid).isNotNull().isGreaterThan(0);
 
         ProcessInstance processInstance = processClient.getProcessInstance(CONTAINER_ALIAS, oldPid);
         assertThat(processInstance).isNotNull();
@@ -281,31 +278,24 @@ public class RollingUpdateProcessServiceIntegrationTest extends JbpmKieServerBas
 
         // Create a container with completely different GAV
         ReleaseId differentReleaseId101 = new ReleaseId("org.kie.server.different", "different-gav-definition-project",
-                                                        "1.0.1.Final");
+                "1.0.1.Final");
         KieContainerResource containerResource = new KieContainerResource(CONTAINER_ID_101, differentReleaseId101);
         containerResource.setContainerAlias(CONTAINER_ALIAS);
         client.createContainer(CONTAINER_ID_101, containerResource);
 
-        assertClientException(() -> processClient.startProcess(CONTAINER_ALIAS, PROCESS_ID_EVALUATION_2),
-                              404,
-                              MessageFormat.format(PROCESS_DEFINITION_NOT_FOUND, PROCESS_ID_EVALUATION_2, CONTAINER_ALIAS),
-                              MessageFormat.format(NO_PROCESS_AVAILABLE_WITH_ID, PROCESS_ID_EVALUATION_2));
-
-        Long pid = processClient.startProcess(CONTAINER_ALIAS, PROCESS_ID_EVALUATION);
-        assertThat(pid).isNotNull();
-        assertThat(pid).isGreaterThan(0);
+        Long pid = processClient.startProcess(CONTAINER_ALIAS, PROCESS_ID_EVALUATION_2);
+        assertThat(pid).isNotNull().isGreaterThan(0);
 
         processInstance = processClient.getProcessInstance(CONTAINER_ALIAS, pid);
         assertThat(processInstance).isNotNull();
-        assertThat(processInstance.getContainerId()).isEqualTo(CONTAINER_ID);
+        assertThat(processInstance.getContainerId()).isEqualTo(CONTAINER_ID_101);
 
     }
 
     @Test
     public void testContainerIdAsAlias() throws Exception {
         Long oldPid = processClient.startProcess(CONTAINER_ALIAS, PROCESS_ID_EVALUATION);
-        assertThat(oldPid).isNotNull();
-        assertThat(oldPid).isGreaterThan(0);
+        assertThat(oldPid).isNotNull().isGreaterThan(0);
 
         ProcessInstance processInstance = processClient.getProcessInstance(CONTAINER_ALIAS, oldPid);
         assertThat(processInstance).isNotNull();
@@ -316,15 +306,14 @@ public class RollingUpdateProcessServiceIntegrationTest extends JbpmKieServerBas
         containerResource.setContainerAlias(CONTAINER_ID);
         client.createContainer(CONTAINER_ID_101, containerResource);
 
-        assertClientException(() -> processClient.startProcess(CONTAINER_ID, PROCESS_ID_EVALUATION_2),
-                              404,
-                              MessageFormat.format(PROCESS_DEFINITION_NOT_FOUND, PROCESS_ID_EVALUATION_2, CONTAINER_ID),
-                              MessageFormat.format(NO_PROCESS_AVAILABLE_WITH_ID, PROCESS_ID_EVALUATION_2));
+        assertClientException(() -> processClient.startProcess(CONTAINER_ALIAS, PROCESS_ID_EVALUATION_2),
+                404,
+                MessageFormat.format(PROCESS_DEFINITION_NOT_FOUND, PROCESS_ID_EVALUATION_2, CONTAINER_ALIAS),
+                MessageFormat.format(NO_PROCESS_AVAILABLE_WITH_ID, PROCESS_ID_EVALUATION_2));
 
         // Instead the old one should be chosen, since it looks for containerId first
         oldPid = processClient.startProcess(CONTAINER_ID, PROCESS_ID_EVALUATION);
-        assertThat(oldPid).isNotNull();
-        assertThat(oldPid).isGreaterThan(0);
+        assertThat(oldPid).isNotNull().isGreaterThan(0);
 
         processInstance = processClient.getProcessInstance(CONTAINER_ALIAS, oldPid);
         assertThat(processInstance).isNotNull();
@@ -332,4 +321,115 @@ public class RollingUpdateProcessServiceIntegrationTest extends JbpmKieServerBas
 
     }
 
+    @Test
+    public void testSignalNewProcessWithAlias() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("nullAccepted", false);
+
+        Long oldPid = processClient.startProcess(CONTAINER_ALIAS, PROCESS_ID_SIGNAL_PROCESS, params);
+        assertThat(oldPid).isNotNull().isGreaterThan(0);
+
+        createExtraContainer();
+
+        Long pid = processClient.startProcess(CONTAINER_ALIAS, PROCESS_ID_SIGNAL_PROCESS_2, params);
+        assertThat(pid).isNotNull().isGreaterThan(0);
+
+        List<String> availableSignals = processClient.getAvailableSignals(CONTAINER_ALIAS, pid);
+        assertThat(availableSignals).isNotNull().hasSize(2);
+        assertThat(availableSignals).contains("Signal1");
+        assertThat(availableSignals).contains("Signal2");
+
+        Object person = createPersonInstance(USER_JOHN);
+        processClient.signalProcessInstance(CONTAINER_ALIAS, pid, "Signal1", person);
+
+        processClient.signalProcessInstances(CONTAINER_ALIAS, Collections.singletonList(pid), "Signal2", "My custom string event");
+
+        ProcessInstance pi = processClient.getProcessInstance(CONTAINER_ALIAS, pid);
+        assertThat(pi).isNotNull();
+        assertThat(pi.getState()).isEqualTo(org.kie.api.runtime.process.ProcessInstance.STATE_COMPLETED);
+
+        pi = processClient.getProcessInstance(CONTAINER_ALIAS, oldPid);
+        assertThat(pi).isNotNull();
+        assertThat(pi.getState()).isEqualTo(org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE);
+
+    }
+
+    @Test
+    public void testCompleteWorkItemInNewProcessWithAlias() throws Exception {
+        Long oldPid = processClient.startProcess(CONTAINER_ALIAS, PROCESS_ID_EVALUATION);
+        assertThat(oldPid).isNotNull().isGreaterThan(0);
+
+        createExtraContainer();
+
+        Long pid = processClient.startProcess(CONTAINER_ALIAS, PROCESS_ID_EVALUATION_2);
+        assertThat(pid).isNotNull().isGreaterThan(0);
+
+        List<TaskSummary> taskList = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
+        assertThat(taskList).hasSize(2);
+
+        // Complete task from the first (old) process
+        taskList = taskClient.findTasksByStatusByProcessInstanceId(oldPid, null, 0, 10);
+        TaskSummary taskSummary = taskList.get(0);
+        taskClient.startTask(CONTAINER_ALIAS, taskSummary.getId(), USER_YODA);
+        taskClient.completeTask(CONTAINER_ALIAS, taskSummary.getId(), USER_YODA, null);
+
+        TaskInstance userTask = taskClient.getTaskInstance(CONTAINER_ALIAS, taskSummary.getId());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getContainerId()).isEqualTo(CONTAINER_ID);
+        assertThat(userTask.getName()).isEqualTo("Evaluate items?");
+        assertThat(userTask.getStatus()).isEqualTo(Status.Completed.toString());
+
+        // Complete tasks from the second (new) process - there are two tasks instead of one
+        taskList = taskClient.findTasksByStatusByProcessInstanceId(pid, null, 0, 10);
+        assertThat(taskList).hasSize(1);
+
+        // First one - Evaluate items
+        taskSummary = taskList.get(0);
+        taskClient.startTask(CONTAINER_ALIAS, taskSummary.getId(), USER_YODA);
+        taskClient.completeTask(CONTAINER_ALIAS, taskSummary.getId(), USER_YODA, null);
+
+        userTask = taskClient.getTaskInstance(CONTAINER_ALIAS, taskSummary.getId());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getContainerId()).isEqualTo(CONTAINER_ID_101);
+        assertThat(userTask.getName()).isEqualTo("Evaluate items");
+        assertThat(userTask.getStatus()).isEqualTo(Status.Completed.toString());
+
+        //Second one - Approve
+        taskList = taskClient.findTasksByStatusByProcessInstanceId(pid, null, 0, 10);
+        assertThat(taskList).hasSize(1);
+
+        taskSummary = taskList.get(0);
+        taskClient.startTask(CONTAINER_ALIAS, taskSummary.getId(), USER_YODA);
+        taskClient.completeTask(CONTAINER_ALIAS, taskSummary.getId(), USER_YODA, null);
+
+        userTask = taskClient.getTaskInstance(CONTAINER_ALIAS, taskSummary.getId());
+        assertThat(userTask).isNotNull();
+        assertThat(userTask.getContainerId()).isEqualTo(CONTAINER_ID_101);
+        assertThat(userTask.getName()).isEqualTo("Approve");
+        assertThat(userTask.getStatus()).isEqualTo(Status.Completed.toString());
+
+        List<WorkItemInstance> workItems = processClient.getWorkItemByProcessInstance(CONTAINER_ALIAS, pid);
+        assertThat(workItems).isNotNull().hasSize(1);
+
+        WorkItemInstance workItemInstance = workItems.get(0);
+        assertThat(workItemInstance).isNotNull();
+        assertThat(workItemInstance.getContainerId()).isEqualTo(CONTAINER_ID_101);
+        assertThat(workItemInstance.getName()).isEqualTo("Email");
+        assertThat(workItemInstance.getState()).isEqualTo(WorkItem.PENDING);
+
+        WorkItemInstance workItemInstance2 = processClient.getWorkItem(CONTAINER_ALIAS, pid, workItemInstance.getId());
+
+        assertThat(workItemInstance2.getId()).isEqualTo(workItemInstance.getId());
+
+        processClient.completeWorkItem(CONTAINER_ALIAS, pid, workItemInstance.getId(), null);
+
+        ProcessInstance pi = processClient.getProcessInstance(CONTAINER_ALIAS, pid);
+        assertThat(pi).isNotNull();
+        assertThat(pi.getState()).isEqualTo(org.kie.api.runtime.process.ProcessInstance.STATE_COMPLETED);
+
+        pi = processClient.getProcessInstance(CONTAINER_ALIAS, oldPid);
+        assertThat(pi).isNotNull();
+        assertThat(pi.getState()).isEqualTo(org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE);
+
+    }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RollingUpdateUserTaskServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RollingUpdateUserTaskServiceIntegrationTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.integrationtests.jbpm;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.instance.ProcessInstance;
+import org.kie.server.api.model.instance.TaskAttachment;
+import org.kie.server.api.model.instance.TaskComment;
+import org.kie.server.api.model.instance.TaskInstance;
+import org.kie.server.api.model.instance.TaskSummary;
+import org.kie.server.integrationtests.shared.KieServerDeployer;
+
+public class RollingUpdateUserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest {
+
+    private static ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "definition-project",
+            "1.0.0.Final");
+
+    protected static final String CONTAINER_ALIAS = "project";
+
+    @BeforeClass
+    public static void buildAndDeployArtifacts() {
+
+        KieServerDeployer.buildAndDeployCommonMavenParent();
+        KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project").getFile());
+        KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/definition-project-101").getFile());
+
+        kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
+
+        createContainer(CONTAINER_ID, releaseId, CONTAINER_ALIAS);
+    }
+
+    @Test
+    public void testGetTaskInputAndOutputWithAlias() throws Exception {
+        try {
+            changeUser(USER_ADMINISTRATOR);
+
+            Long pid = processClient.startProcess(CONTAINER_ALIAS, PROCESS_ID_EVALUATION);
+            assertThat(pid).isNotNull().isGreaterThan(0);
+
+            ProcessInstance processInstance = processClient.getProcessInstance(CONTAINER_ALIAS, pid);
+            assertThat(processInstance).isNotNull();
+
+            List<TaskSummary> taskList = taskClient.findTasksAssignedAsBusinessAdministrator(USER_YODA, 0, 10);
+            assertThat(taskList).hasSize(1);
+
+            TaskSummary taskSummary = taskList.get(0);
+
+            Map<String, Object> inputContent = taskClient.getTaskInputContentByTaskId(CONTAINER_ALIAS, taskSummary.getId());
+            assertThat(inputContent).isNotNull().hasSize(4);
+            assertThat(inputContent.get("new content")).isNull();
+
+            Map<String, Object> data = new HashMap<>();
+            data.put("new content", "test");
+
+            userTaskAdminClient.addTaskInputs(CONTAINER_ALIAS, taskSummary.getId(), data);
+
+            // check this method too
+            TaskInstance taskInstance = taskClient.getTaskInstance(CONTAINER_ALIAS, taskSummary.getId(), false, false, false);
+            assertThat(taskInstance).isNotNull();
+            assertThat(taskInstance.getId()).isEqualTo(taskSummary.getId());
+
+            inputContent = taskClient.getTaskInputContentByTaskId(CONTAINER_ALIAS, taskSummary.getId());
+            assertThat(inputContent).isNotNull().hasSize(5);
+            assertThat(inputContent.get("new content")).isEqualTo("test");
+
+            userTaskAdminClient.removeTaskInputs(CONTAINER_ALIAS, taskSummary.getId(), "new content");
+
+            inputContent = taskClient.getTaskInputContentByTaskId(CONTAINER_ALIAS, taskSummary.getId());
+            assertThat(inputContent).isNotNull().hasSize(4);
+            assertThat(inputContent.get("new content")).isNull();
+
+            Map<String, Object> outputContent = taskClient.getTaskOutputContentByTaskId(CONTAINER_ALIAS, taskSummary.getId());
+            assertThat(outputContent).isNotNull().hasSize(0);
+
+            taskClient.saveTaskContent(CONTAINER_ALIAS, taskSummary.getId(), data);
+
+            outputContent = taskClient.getTaskOutputContentByTaskId(CONTAINER_ALIAS, taskSummary.getId());
+            assertThat(outputContent).isNotNull().hasSize(1);
+            assertThat(outputContent.get("new content")).isEqualTo("test");
+
+            data.put("Outcome", "Approved");
+
+            taskClient.completeAutoProgress(CONTAINER_ALIAS, taskSummary.getId(), USER_YODA, data);
+
+            outputContent = taskClient.getTaskOutputContentByTaskId(CONTAINER_ALIAS, taskSummary.getId());
+            assertThat(outputContent).isNotNull().hasSize(2);
+            assertThat(outputContent.get("new content")).isEqualTo("test");
+            assertThat(outputContent.get("Outcome")).isEqualTo("Approved");
+        } finally {
+            // In case the test fails, we need to switch back to YODA user
+            changeUser(USER_YODA);
+        }
+
+    }
+
+    @Test
+    public void testTaskAttachmentsWithAlias() throws Exception {
+        Long pid = processClient.startProcess(CONTAINER_ALIAS, PROCESS_ID_EVALUATION);
+        assertThat(pid).isNotNull().isGreaterThan(0);
+
+        ProcessInstance processInstance = processClient.getProcessInstance(CONTAINER_ALIAS, pid);
+        assertThat(processInstance).isNotNull();
+
+        List<TaskSummary> taskList = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
+        assertThat(taskList).hasSize(1);
+
+        TaskSummary taskSummary = taskList.get(0);
+
+        List<TaskAttachment> attachments = taskClient.getTaskAttachmentsByTaskId(CONTAINER_ALIAS, taskSummary.getId());
+        assertThat(attachments).isNotNull().hasSize(0);
+
+        taskClient.addTaskAttachment(CONTAINER_ALIAS, taskSummary.getId(), USER_YODA, "My attachment", "Attachment Content");
+
+        attachments = taskClient.getTaskAttachmentsByTaskId(CONTAINER_ALIAS, taskSummary.getId());
+        assertThat(attachments).isNotNull().hasSize(1);
+        assertThat(attachments.get(0).getContentType()).isEqualTo("java.lang.String");
+
+        TaskAttachment taskAttachment = taskClient.getTaskAttachmentById(CONTAINER_ALIAS, taskSummary.getId(), attachments.get(0).getId());
+        assertThat(taskAttachment.getId()).isEqualTo(attachments.get(0).getId());
+
+        Object content = taskClient.getTaskAttachmentContentById(CONTAINER_ALIAS, taskSummary.getId(), attachments.get(0).getId());
+        assertThat(content).isEqualTo("Attachment Content");
+
+    }
+
+    @Test
+    public void testTaskCommentsWithAlias() throws Exception {
+        Long pid = processClient.startProcess(CONTAINER_ALIAS, PROCESS_ID_EVALUATION);
+        assertThat(pid).isNotNull().isGreaterThan(0);
+
+        ProcessInstance processInstance = processClient.getProcessInstance(CONTAINER_ALIAS, pid);
+        assertThat(processInstance).isNotNull();
+
+        List<TaskSummary> taskList = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
+        assertThat(taskList).hasSize(1);
+
+        TaskSummary taskSummary = taskList.get(0);
+
+        List<TaskComment> taskComments = taskClient.getTaskCommentsByTaskId(CONTAINER_ALIAS, taskSummary.getId());
+        assertThat(taskComments).isNotNull().hasSize(0);
+
+        Date commentDate = new SimpleDateFormat("dd-MM-yyyy hh:mm").parse("18-03-1992 08:06");
+
+        taskClient.addTaskComment(CONTAINER_ALIAS, taskSummary.getId(), "May the force be with you!", USER_YODA, commentDate);
+
+        taskComments = taskClient.getTaskCommentsByTaskId(CONTAINER_ALIAS, taskSummary.getId());
+        assertThat(taskComments).isNotNull().hasSize(1);
+
+        TaskComment taskComment = taskComments.get(0);
+        assertThat(taskComment.getText()).isEqualTo("May the force be with you!");
+        assertThat(taskComment.getAddedBy()).isEqualTo(USER_YODA);
+        assertThat(taskComment.getAddedAt()).isEqualTo(commentDate);
+
+        taskComment = taskClient.getTaskCommentById(CONTAINER_ALIAS, taskSummary.getId(), taskComments.get(0).getId());
+        assertThat(taskComment.getId()).isEqualTo(taskComments.get(0).getId());
+        assertThat(taskComment.getText()).isEqualTo("May the force be with you!");
+        assertThat(taskComment.getAddedBy()).isEqualTo(USER_YODA);
+        assertThat(taskComment.getAddedAt()).isEqualTo(commentDate);
+
+    }
+}


### PR DESCRIPTION
Hi,

here are additional tests which cover alias functionality as described in BPMSPL-543. Tests focus on the following:

Process Service
- starting processes within containers with different GAVs using the same aliases
- signalling processes
- setting/getting process variables
- completing work items

User Task Service
- getting input/output of tasks using alias
- getting/setting task attachments
- getting/setting task comments

Form and Image Service
- getting process and task forms
- getting process and process instance images

Thanks,

Marian
