### PR TITLE
JBPM-6012 Standalone controller can't be deployed on Tomcat 8 container

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-standalone-impl/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-standalone-impl/pom.xml
@@ -12,6 +12,7 @@
   <artifactId>kie-server-controller-standalone-impl</artifactId>
   <name>KIE :: Execution Server :: Controller :: Standalone Implementation</name>
   <description>KIE Execution Server Controller Standalone Implementation</description>
+  <packaging>jar</packaging>
 
   <dependencies>
     <dependency>
@@ -42,6 +43,11 @@
     <dependency>
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-rest-common</artifactId>
     </dependency>
 
     <dependency>

--- a/kie-server-parent/kie-server-controller/kie-server-controller-standalone/src/main/assembly/assembly-servlet-container.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-standalone/src/main/assembly/assembly-servlet-container.xml
@@ -42,8 +42,6 @@
     <dependencySet>
       <includes>
         <include>org.jboss.resteasy:resteasy-jaxrs</include>
-        <include>org.slf4j:slf4j-jdk14</include>
-
         <include>org.kie.server:kie-server-controller-api</include>
         <include>org.kie.server:kie-server-controller-impl</include>
         <include>org.kie.server:kie-server-controller-standalone</include>
@@ -51,6 +49,9 @@
         <include>com.sun.xml.bind:jaxb-core</include>
         <include>com.sun.xml.bind:jaxb-impl</include>
       </includes>
+      <excludes>
+      	<exclude>org.slf4j:slf4j-api</exclude>
+      </excludes>
       <outputDirectory>WEB-INF/lib</outputDirectory>
       <useTransitiveFiltering>true</useTransitiveFiltering>
     </dependencySet>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
@@ -193,6 +193,10 @@
       <type>war</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+    	<groupId>org.kie.server</groupId>
+    	<artifactId>kie-server-controller-standalone-impl</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieControllerExecutor.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieControllerExecutor.java
@@ -18,6 +18,8 @@ package org.kie.server.integrationtests.shared;
 import org.jboss.resteasy.plugins.server.tjws.TJWSEmbeddedJaxrsServer;
 import org.kie.server.controller.rest.RestKieServerControllerImpl;
 import org.kie.server.controller.rest.RestSpecManagementServiceImpl;
+import org.kie.server.controller.service.StandaloneKieServerControllerImpl;
+import org.kie.server.controller.service.StandaloneSpecManagementServiceImpl;
 import org.kie.server.integrationtests.config.TestConfig;
 
 public class KieControllerExecutor {
@@ -32,8 +34,8 @@ public class KieControllerExecutor {
         controller = new TJWSEmbeddedJaxrsServer();
         controller.setPort(TestConfig.getControllerAllocatedPort());
         controller.start();
-        controller.getDeployment().getRegistry().addSingletonResource(new RestKieServerControllerImpl());
-        controller.getDeployment().getRegistry().addSingletonResource(new RestSpecManagementServiceImpl());
+        controller.getDeployment().getRegistry().addSingletonResource(new StandaloneKieServerControllerImpl());
+        controller.getDeployment().getRegistry().addSingletonResource(new StandaloneSpecManagementServiceImpl());
     }
 
     public void stopKieController() {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
       <dependency>
         <groupId>org.kie.server</groupId>
-        <artifactId>kie-server-controller-test-war</artifactId>
+        <artifactId>kie-server-controller-standalone</artifactId>
         <classifier>ee7</classifier>
         <type>war</type>
         <scope>test</scope>
@@ -24,7 +24,7 @@
       </dependency>
       <dependency>
         <groupId>org.kie.server</groupId>
-        <artifactId>kie-server-controller-test-war</artifactId>
+        <artifactId>kie-server-controller-standalone</artifactId>
         <classifier>ee6</classifier>
         <type>war</type>
         <scope>test</scope>
@@ -32,7 +32,7 @@
       </dependency>
       <dependency>
         <groupId>org.kie.server</groupId>
-        <artifactId>kie-server-controller-test-war</artifactId>
+        <artifactId>kie-server-controller-standalone</artifactId>
         <classifier>webc</classifier>
         <type>war</type>
         <scope>test</scope>
@@ -129,21 +129,21 @@
     </dependency>
     <dependency>
       <groupId>org.kie.server</groupId>
-      <artifactId>kie-server-controller-test-war</artifactId>
+      <artifactId>kie-server-controller-standalone</artifactId>
       <classifier>webc</classifier>
       <type>war</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.server</groupId>
-      <artifactId>kie-server-controller-test-war</artifactId>
+      <artifactId>kie-server-controller-standalone</artifactId>
       <classifier>ee7</classifier>
       <type>war</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.server</groupId>
-      <artifactId>kie-server-controller-test-war</artifactId>
+      <artifactId>kie-server-controller-standalone</artifactId>
       <classifier>ee6</classifier>
       <type>war</type>
       <scope>test</scope>
@@ -197,15 +197,15 @@
             <deployables combine.children="append">
               <deployable>
                 <groupId>${project.groupId}</groupId>
-                <artifactId>kie-server-controller-test-war</artifactId>
+                <artifactId>kie-server-controller-standalone</artifactId>
                 <!-- default, may be overriden in container specific profiles -->
                 <classifier>${kie.server.classifier}</classifier>
                 <type>war</type>
                 <properties>
                   <context>${kie.server.controller.context}</context>
                 </properties>
-                <pingURL>${kie.server.controller.base.http.url}</pingURL>
-                <pingTimeout>30000</pingTimeout>
+                <pingURL>${kie.server.controller.base.http.url}/management/servers</pingURL>
+                <pingTimeout>60000</pingTimeout>
               </deployable>
             </deployables>
           </configuration>

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -29,6 +29,7 @@
     <kie.server.classifier>ee7</kie.server.classifier>
     <!-- Path to Kie server WAR file. Used for referencing WAR file in on-demand deployment/undeployment. -->
     <kie.server.war.path>${org.kie.server:kie-server:war:ee7}</kie.server.war.path>
+    <org.kie.server.controller.templatefile>${project.build.directory}/server-template-storage.xml</org.kie.server.controller.templatefile>
     <kie.server.base.http.url>http://${container.hostname}:${container.port}/${kie.server.context}/services/rest/server</kie.server.base.http.url>
     <kie.server.controller.base.http.url>http://${container.hostname}:${container.port}/${kie.server.controller.context}/rest/controller</kie.server.controller.base.http.url>
     <kie.server.testing.server.local.repo.dir>${project.build.directory}/kie-server-testing-server-local-repo</kie.server.testing.server.local.repo.dir>


### PR DESCRIPTION
- Re-applied the dependency on kie-server-rest-common, in kie-server-controller-standalone-impl. Removal of this dependency causes the assembly to not include the rest-easy jars in the resultant war files.
- Removed the include of slf4j-jdk14, and added an exclude of slf4j-api, to the assembly file for Tomcat (servlet container)
- Added dependency on kie-server-controller-standalone-impl to kie-server-integ-tests-common
- Changed KieControllerExecutor (in kie-server-integ-tests-common) so that it uses the new Standalone...Impl classes
- Updated kie-server-integ-tests-controller pom to use standalone components, and the pingURL to point to a valid endpoint
- Updated kie-server-tests pom to include a system property that provides a template file location for the controller