### PR TITLE
PLANNER-815: Execution server: Support real-time planning

### DIFF
--- a/kie-server-parent/kie-server-api/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-api/src/build/revapi-config.json
@@ -14,13 +14,12 @@
       }
     }
   },
-
   "ignores": {
     "revapi": {
       "_comment": "Changes between 7.0.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.1.0.Final is available.",
       "ignore": [
-	{
-	  "code": "java.field.constantValueChanged",
+        {
+          "code": "java.field.constantValueChanged",
           "old": "field org.kie.server.api.rest.RestURI.PROCESS_INSTANCES_BY_CONTAINER_GET_URI",
           "new": "field org.kie.server.api.rest.RestURI.PROCESS_INSTANCES_BY_CONTAINER_GET_URI",
           "oldValue": "processes/instances",
@@ -30,9 +29,16 @@
           "fieldName": "PROCESS_INSTANCES_BY_CONTAINER_GET_URI",
           "elementKind": "field",
           "justification": "JBPM-6120 Invalid Kie Server REST endpoints for processes"
+        },
+        {
+          "code": "java.annotation.attributeValueChanged",
+          "new": "field org.kie.server.api.commands.CommandScript.commands",
+          "attribute": "value",
+          "annotationType": "javax.xml.bind.annotation.XmlElements",
+          "elementKind": "annotation",
+          "justification": "PLANNER-815 Support real-time planning"
         }
-
-	]
+      ]
     }
   }
 }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/CommandScript.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/CommandScript.java
@@ -28,8 +28,11 @@ import javax.xml.bind.annotation.XmlType;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.kie.server.api.commands.optaplanner.AddProblemFactChangeCommand;
+import org.kie.server.api.commands.optaplanner.AddProblemFactChangesCommand;
 import org.kie.server.api.commands.optaplanner.CreateSolverCommand;
 import org.kie.server.api.commands.optaplanner.DisposeSolverCommand;
+import org.kie.server.api.commands.optaplanner.IsEveryProblemFactChangeProcessedCommand;
 import org.kie.server.api.commands.optaplanner.GetSolverCommand;
 import org.kie.server.api.commands.optaplanner.GetSolverWithBestSolutionCommand;
 import org.kie.server.api.commands.optaplanner.GetSolversCommand;
@@ -72,7 +75,10 @@ public class CommandScript implements Serializable {
             @XmlElement(name = "get-solvers", type = GetSolversCommand.class),
             @XmlElement(name = "get-solver", type = GetSolverCommand.class),
             @XmlElement(name = "start-solver", type = SolvePlanningProblemCommand.class),
-            @XmlElement(name = "terminate-solver", type = TerminateSolverEarlyCommand.class)
+            @XmlElement(name = "terminate-solver", type = TerminateSolverEarlyCommand.class),
+            @XmlElement(name = "add-problem-fact-change", type = AddProblemFactChangeCommand.class),
+            @XmlElement(name = "add-problem-fact-changes", type = AddProblemFactChangesCommand.class),
+            @XmlElement(name = "is-every-problem-fact-change-processed", type = IsEveryProblemFactChangeProcessedCommand.class)
     })
     @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
     protected List<KieServerCommand> commands;

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/optaplanner/AddProblemFactChangeCommand.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/optaplanner/AddProblemFactChangeCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,20 @@
 
 package org.kie.server.api.commands.optaplanner;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.kie.server.api.model.KieServerCommand;
+import org.optaplanner.core.impl.solver.ProblemFactChange;
 
-import javax.xml.bind.annotation.*;
-
-@XmlRootElement(name = "create-solver")
-@XStreamAlias("create-solver")
+@XmlRootElement(name = "add-problem-fact-change")
+@XStreamAlias("add-problem-fact-change")
 @XmlAccessorType(XmlAccessType.NONE)
-public class CreateSolverCommand
+public class AddProblemFactChangeCommand
         implements KieServerCommand {
 
     private static final long serialVersionUID = -1803374525440238478L;
@@ -37,17 +42,20 @@ public class CreateSolverCommand
     @XStreamAlias("solver-id")
     private String solverId;
 
-    @XmlElement(name = "solver-config-file")
-    @XStreamAlias("solver-config-file")
-    private String solverConfigFile;
+    @XmlElement
+    @XStreamAlias("problem-fact-change")
+    // It's not possible to use ProblemFactChange type here due to JAXB marshaller limitations
+    private Object problemFactChange;
 
-    public CreateSolverCommand() {
+    public AddProblemFactChangeCommand() {
     }
 
-    public CreateSolverCommand(String containerId, String solverId, String solverConfigFile) {
+    public AddProblemFactChangeCommand(String containerId,
+                                       String solverId,
+                                       ProblemFactChange problemFactChange) {
         this.containerId = containerId;
         this.solverId = solverId;
-        this.solverConfigFile = solverConfigFile;
+        this.problemFactChange = problemFactChange;
     }
 
     public String getContainerId() {
@@ -66,20 +74,20 @@ public class CreateSolverCommand
         this.solverId = solverId;
     }
 
-    public String getSolverConfigFile() {
-        return solverConfigFile;
+    public ProblemFactChange getProblemFactChange() {
+        return (ProblemFactChange) problemFactChange;
     }
 
-    public void setSolverConfigFile(String solverConfigFile) {
-        this.solverConfigFile = solverConfigFile;
+    public void setProblemFactChange(ProblemFactChange problemFactChange) {
+        this.problemFactChange = problemFactChange;
     }
 
     @Override
     public String toString() {
-        return "CreateSolverCommand{" +
-               "containerId='" + containerId + '\'' +
-               ", solverId='" + solverId + '\'' +
-               ", solverConfigFile='" + solverConfigFile + '\'' +
-               '}';
+        return "AddProblemFactChangeCommand{" +
+                "containerId='" + containerId + '\'' +
+                ", solverId='" + solverId + '\'' +
+                ", problemFactChange='" + problemFactChange + '\'' +
+                '}';
     }
 }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/optaplanner/AddProblemFactChangesCommand.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/optaplanner/AddProblemFactChangesCommand.java
@@ -16,18 +16,23 @@
 
 package org.kie.server.api.commands.optaplanner;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import org.kie.server.api.model.KieServerCommand;
+import org.optaplanner.core.impl.solver.ProblemFactChange;
 
-@XmlRootElement(name = "terminate-solver-early")
-@XStreamAlias("terminate-solver-early")
+@XmlRootElement(name = "add-problem-fact-changes")
+@XStreamAlias("add-problem-fact-changes")
 @XmlAccessorType(XmlAccessType.NONE)
-public class TerminateSolverEarlyCommand
+public class AddProblemFactChangesCommand
         implements KieServerCommand {
 
     private static final long serialVersionUID = -1803374525440238478L;
@@ -40,13 +45,20 @@ public class TerminateSolverEarlyCommand
     @XStreamAlias("solver-id")
     private String solverId;
 
-    public TerminateSolverEarlyCommand() {
+    public AddProblemFactChangesCommand() {
     }
 
-    public TerminateSolverEarlyCommand(String containerId,
-                                       String solverId) {
+    @XmlElement
+    @XStreamAlias("problem-fact-changes")
+    // It's not possible to use ProblemFactChange list type here due to JAXB marshaller limitations
+    private List<Object> problemFactChanges;
+
+    public AddProblemFactChangesCommand(String containerId,
+                                        String solverId,
+                                        List<? extends ProblemFactChange> problemFactChanges) {
         this.containerId = containerId;
         this.solverId = solverId;
+        this.problemFactChanges = new ArrayList<>(problemFactChanges);
     }
 
     public String getContainerId() {
@@ -65,11 +77,23 @@ public class TerminateSolverEarlyCommand
         this.solverId = solverId;
     }
 
+    public List<ProblemFactChange> getProblemFactChanges() {
+        if (problemFactChanges == null) {
+            return null;
+        }
+        return problemFactChanges.stream().map(p -> (ProblemFactChange) p).collect(Collectors.toList());
+    }
+
+    public void setProblemFactChanges(List<? extends ProblemFactChange> problemFactChanges) {
+        this.problemFactChanges = new ArrayList<>(problemFactChanges);
+    }
+
     @Override
     public String toString() {
-        return "TerminateSolverEarlyCommand{" +
+        return "AddProblemFactChangesCommand{" +
                 "containerId='" + containerId + '\'' +
                 ", solverId='" + solverId + '\'' +
+                ", problemFactChanges='" + problemFactChanges + '\'' +
                 '}';
     }
 }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/optaplanner/GetSolverCommand.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/optaplanner/GetSolverCommand.java
@@ -41,7 +41,6 @@ public class GetSolverCommand
     private String solverId;
 
     public GetSolverCommand() {
-        super();
     }
 
     public GetSolverCommand(String containerId,

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/optaplanner/GetSolverWithBestSolutionCommand.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/optaplanner/GetSolverWithBestSolutionCommand.java
@@ -41,7 +41,6 @@ public class GetSolverWithBestSolutionCommand
     private String solverId;
 
     public GetSolverWithBestSolutionCommand() {
-        super();
     }
 
     public GetSolverWithBestSolutionCommand(String containerId,

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/optaplanner/GetSolversCommand.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/optaplanner/GetSolversCommand.java
@@ -36,7 +36,6 @@ public class GetSolversCommand
     private String containerId;
 
     public GetSolversCommand() {
-        super();
     }
 
     public GetSolversCommand(String containerId) {

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/optaplanner/IsEveryProblemFactChangeProcessedCommand.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/optaplanner/IsEveryProblemFactChangeProcessedCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,33 +16,35 @@
 
 package org.kie.server.api.commands.optaplanner;
 
-import com.thoughtworks.xstream.annotations.XStreamAlias;
-import org.kie.server.api.model.KieServerCommand;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
-@XmlRootElement(name="dispose-solver")
-@XStreamAlias("dispose-solver")
+import com.thoughtworks.xstream.annotations.XStreamAlias;
+import org.kie.server.api.model.KieServerCommand;
+
+@XmlRootElement(name = "is-every-problem-fact-change-processed")
+@XStreamAlias("is-every-problem-fact-change-processed")
 @XmlAccessorType(XmlAccessType.NONE)
-public class DisposeSolverCommand
+public class IsEveryProblemFactChangeProcessedCommand
         implements KieServerCommand {
+
     private static final long serialVersionUID = -1803374525440238478L;
 
-    @XmlAttribute(name="container-id")
-    @XStreamAlias( "container-id" )
-    private String    containerId;
+    @XmlAttribute(name = "container-id")
+    @XStreamAlias("container-id")
+    private String containerId;
 
-    @XmlAttribute(name="solver-id")
-    @XStreamAlias( "solver-id" )
-    private String    solverId;
+    @XmlAttribute(name = "solver-id")
+    @XStreamAlias("solver-id")
+    private String solverId;
 
-    public DisposeSolverCommand() {
+    public IsEveryProblemFactChangeProcessedCommand() {
     }
 
-    public DisposeSolverCommand(String containerId, String solverId) {
+    public IsEveryProblemFactChangeProcessedCommand(String containerId,
+                                                    String solverId) {
         this.containerId = containerId;
         this.solverId = solverId;
     }
@@ -65,9 +67,9 @@ public class DisposeSolverCommand
 
     @Override
     public String toString() {
-        return "DisposeSolverCommand{" +
-               "containerId='" + containerId + '\'' +
-               ", solverId='" + solverId + '\'' +
-               '}';
+        return "IsEveryProblemFactChangeProcessedCommand{" +
+                "containerId='" + containerId + '\'' +
+                ", solverId='" + solverId + '\'' +
+                '}';
     }
 }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/optaplanner/SolvePlanningProblemCommand.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/optaplanner/SolvePlanningProblemCommand.java
@@ -46,7 +46,6 @@ public class SolvePlanningProblemCommand
     private String planningProblem;
 
     public SolvePlanningProblemCommand() {
-        super();
     }
 
     public SolvePlanningProblemCommand(String containerId,

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
@@ -59,8 +59,11 @@ import org.kie.server.api.commands.GetServerStateCommand;
 import org.kie.server.api.commands.ListContainersCommand;
 import org.kie.server.api.commands.UpdateReleaseIdCommand;
 import org.kie.server.api.commands.UpdateScannerCommand;
+import org.kie.server.api.commands.optaplanner.AddProblemFactChangeCommand;
+import org.kie.server.api.commands.optaplanner.AddProblemFactChangesCommand;
 import org.kie.server.api.commands.optaplanner.CreateSolverCommand;
 import org.kie.server.api.commands.optaplanner.DisposeSolverCommand;
+import org.kie.server.api.commands.optaplanner.IsEveryProblemFactChangeProcessedCommand;
 import org.kie.server.api.commands.optaplanner.GetSolverWithBestSolutionCommand;
 import org.kie.server.api.commands.optaplanner.GetSolverCommand;
 import org.kie.server.api.commands.optaplanner.GetSolversCommand;
@@ -277,7 +280,7 @@ public class JaxbMarshaller implements Marshaller {
                 QueryDefinitionList.class,
                 QueryFilterSpec.class,
                 QueryParam.class,
-                
+
                 ProcessInstanceQueryFilterSpec.class,
                 TaskQueryFilterSpec.class,
 
@@ -297,6 +300,9 @@ public class JaxbMarshaller implements Marshaller {
                 GetSolverCommand.class,
                 SolvePlanningProblemCommand.class,
                 TerminateSolverEarlyCommand.class,
+                AddProblemFactChangeCommand.class,
+                AddProblemFactChangesCommand.class,
+                IsEveryProblemFactChangeProcessedCommand.class,
 
                 // admin section
                 MigrationReportInstance.class,
@@ -334,7 +340,7 @@ public class JaxbMarshaller implements Marshaller {
                 CaseStageDefinition.class,
                 CaseFileDataItem.class,
                 CaseFileDataItemList.class,
-                
+
                 // Kie DMN
                 DMNContextKS.class,
                 DMNResultKS.class,

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/xstream/XStreamMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/xstream/XStreamMarshaller.java
@@ -30,8 +30,11 @@ import org.kie.server.api.commands.GetServerInfoCommand;
 import org.kie.server.api.commands.ListContainersCommand;
 import org.kie.server.api.commands.UpdateReleaseIdCommand;
 import org.kie.server.api.commands.UpdateScannerCommand;
+import org.kie.server.api.commands.optaplanner.AddProblemFactChangeCommand;
+import org.kie.server.api.commands.optaplanner.AddProblemFactChangesCommand;
 import org.kie.server.api.commands.optaplanner.CreateSolverCommand;
 import org.kie.server.api.commands.optaplanner.DisposeSolverCommand;
+import org.kie.server.api.commands.optaplanner.IsEveryProblemFactChangeProcessedCommand;
 import org.kie.server.api.commands.optaplanner.GetSolverCommand;
 import org.kie.server.api.commands.optaplanner.GetSolverWithBestSolutionCommand;
 import org.kie.server.api.commands.optaplanner.GetSolversCommand;
@@ -165,6 +168,9 @@ public class XStreamMarshaller
         this.xstream.processAnnotations( GetSolverCommand.class );
         this.xstream.processAnnotations( SolvePlanningProblemCommand.class );
         this.xstream.processAnnotations( TerminateSolverEarlyCommand.class );
+        this.xstream.processAnnotations( AddProblemFactChangeCommand.class );
+        this.xstream.processAnnotations( AddProblemFactChangesCommand.class );
+        this.xstream.processAnnotations( IsEveryProblemFactChangeProcessedCommand.class );
 
         this.xstream.processAnnotations( DMNContextKS.class );
         this.xstream.processAnnotations( DMNResultKS.class );

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/rest/RestURI.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/rest/RestURI.java
@@ -57,7 +57,6 @@ public class RestURI {
     public static final String NOTIFICATION_ID = "notificationId";
     public static final String ERROR_ID = "errorId";
 
-
     public static final String PROCESS_URI = "containers/{" + CONTAINER_ID + "}/processes";
     public static final String PROCESS_DEF_URI = "containers/{" + CONTAINER_ID + "}/processes/definitions";
     public static final String JOB_URI = "jobs";
@@ -77,11 +76,11 @@ public class RestURI {
 
     // uris
     // process related prefixed by PROCESS_URI
-    public static final String START_PROCESS_POST_URI = "{" + PROCESS_ID +"}/instances";
-    public static final String START_PROCESS_WITH_CORRELATION_KEY_POST_URI = "{" + PROCESS_ID +"}/instances/correlation/{" + CORRELATION_KEY + "}";
-    public static final String ABORT_PROCESS_INST_DEL_URI = "instances/{" + PROCESS_INST_ID +"}";
+    public static final String START_PROCESS_POST_URI = "{" + PROCESS_ID + "}/instances";
+    public static final String START_PROCESS_WITH_CORRELATION_KEY_POST_URI = "{" + PROCESS_ID + "}/instances/correlation/{" + CORRELATION_KEY + "}";
+    public static final String ABORT_PROCESS_INST_DEL_URI = "instances/{" + PROCESS_INST_ID + "}";
     public static final String ABORT_PROCESS_INSTANCES_DEL_URI = "instances";
-    public static final String SIGNAL_PROCESS_INST_POST_URI = "instances/{" + PROCESS_INST_ID +"}/signal/{" + SIGNAL_NAME + "}";
+    public static final String SIGNAL_PROCESS_INST_POST_URI = "instances/{" + PROCESS_INST_ID + "}/signal/{" + SIGNAL_NAME + "}";
     public static final String SIGNAL_PROCESS_INSTANCES_PORT_URI = "instances/signal/{" + SIGNAL_NAME + "}";
     public static final String PROCESS_INSTANCE_GET_URI = "instances/{" + PROCESS_INST_ID + "}";
     public static final String PROCESS_INSTANCE_VAR_PUT_URI = "instances/{" + PROCESS_INST_ID + "}/variable/{" + VAR_NAME + "}";
@@ -89,31 +88,31 @@ public class RestURI {
     public static final String PROCESS_INSTANCE_VAR_GET_URI = "instances/{" + PROCESS_INST_ID + "}/variable/{" + VAR_NAME + "}";
     public static final String PROCESS_INSTANCE_VARS_GET_URI = "instances/{" + PROCESS_INST_ID + "}/variables";
     public static final String PROCESS_INSTANCE_VAR_INSTANCES_GET_URI = "instances/{" + PROCESS_INST_ID + "}/variables/instances";
-    public static final String PROCESS_INSTANCE_VAR_INSTANCE_BY_VAR_NAME_GET_URI = "instances/{" + PROCESS_INST_ID + "}/variables/instances/{" + VAR_NAME +"}";
+    public static final String PROCESS_INSTANCE_VAR_INSTANCE_BY_VAR_NAME_GET_URI = "instances/{" + PROCESS_INST_ID + "}/variables/instances/{" + VAR_NAME + "}";
     public static final String PROCESS_INSTANCE_SIGNALS_GET_URI = "instances/{" + PROCESS_INST_ID + "}/signals";
     public static final String PROCESS_INSTANCES_BY_CONTAINER_GET_URI = "instances";
     public static final String PROCESS_INSTANCES_BY_PARENT_GET_URI = "instances/{" + PROCESS_INST_ID + "}/processes";
 
     public static final String PROCESS_INSTANCES_NODE_INSTANCES_GET_URI = "instances/{" + PROCESS_INST_ID + "}/nodes/instances";
-    public static final String PROCESS_INSTANCE_WORK_ITEM_COMPLETE_PUT_URI = "instances/{" + PROCESS_INST_ID + "}/workitems/{" + WORK_ITEM_ID +"}/completed";
-    public static final String PROCESS_INSTANCE_WORK_ITEM_ABORT_PUT_URI = "instances/{" + PROCESS_INST_ID + "}/workitems/{" + WORK_ITEM_ID +"}/aborted";
-    public static final String PROCESS_INSTANCE_WORK_ITEM_BY_ID_GET_URI = "instances/{" + PROCESS_INST_ID + "}/workitems/{" + WORK_ITEM_ID +"}";
+    public static final String PROCESS_INSTANCE_WORK_ITEM_COMPLETE_PUT_URI = "instances/{" + PROCESS_INST_ID + "}/workitems/{" + WORK_ITEM_ID + "}/completed";
+    public static final String PROCESS_INSTANCE_WORK_ITEM_ABORT_PUT_URI = "instances/{" + PROCESS_INST_ID + "}/workitems/{" + WORK_ITEM_ID + "}/aborted";
+    public static final String PROCESS_INSTANCE_WORK_ITEM_BY_ID_GET_URI = "instances/{" + PROCESS_INST_ID + "}/workitems/{" + WORK_ITEM_ID + "}";
     public static final String PROCESS_INSTANCE_WORK_ITEMS_BY_PROC_INST_ID_GET_URI = "instances/{" + PROCESS_INST_ID + "}/workitems";
 
     // process definition related prefixed by PROCESS_DEF_URI
-    public static final String PROCESS_DEF_GET_URI = "{" + PROCESS_ID +"}";
-    public static final String PROCESS_DEF_SUBPROCESS_GET_URI = "{" + PROCESS_ID +"}/subprocesses";
-    public static final String PROCESS_DEF_VARIABLES_GET_URI = "{" + PROCESS_ID +"}/variables";
-    public static final String PROCESS_DEF_SERVICE_TASKS_GET_URI = "{" + PROCESS_ID +"}/tasks/service";
-    public static final String PROCESS_DEF_ASSOCIATED_ENTITIES_GET_URI = "{" + PROCESS_ID +"}/entities";
-    public static final String PROCESS_DEF_USER_TASKS_GET_URI = "{" + PROCESS_ID +"}/tasks/users";
-    public static final String PROCESS_DEF_USER_TASK_INPUT_GET_URI = "{" + PROCESS_ID +"}/tasks/users/{" + TASK_NAME + "}/inputs";
-    public static final String PROCESS_DEF_USER_TASK_OUTPUT_GET_URI = "{" + PROCESS_ID +"}/tasks/users/{" + TASK_NAME + "}/outputs";
+    public static final String PROCESS_DEF_GET_URI = "{" + PROCESS_ID + "}";
+    public static final String PROCESS_DEF_SUBPROCESS_GET_URI = "{" + PROCESS_ID + "}/subprocesses";
+    public static final String PROCESS_DEF_VARIABLES_GET_URI = "{" + PROCESS_ID + "}/variables";
+    public static final String PROCESS_DEF_SERVICE_TASKS_GET_URI = "{" + PROCESS_ID + "}/tasks/service";
+    public static final String PROCESS_DEF_ASSOCIATED_ENTITIES_GET_URI = "{" + PROCESS_ID + "}/entities";
+    public static final String PROCESS_DEF_USER_TASKS_GET_URI = "{" + PROCESS_ID + "}/tasks/users";
+    public static final String PROCESS_DEF_USER_TASK_INPUT_GET_URI = "{" + PROCESS_ID + "}/tasks/users/{" + TASK_NAME + "}/inputs";
+    public static final String PROCESS_DEF_USER_TASK_OUTPUT_GET_URI = "{" + PROCESS_ID + "}/tasks/users/{" + TASK_NAME + "}/outputs";
 
     // runtime data related prefixed by QUERY_URI
     public static final String PROCESS_INSTANCES_GET_URI = "processes/instances";
     public static final String PROCESS_INSTANCES_GET_FILTERED_URI = "processes/instances/filtered-data";
-    public static final String PROCESS_INSTANCES_BY_PROCESS_ID_GET_URI = "processes/{" + PROCESS_ID +"}/instances";
+    public static final String PROCESS_INSTANCES_BY_PROCESS_ID_GET_URI = "processes/{" + PROCESS_ID + "}/instances";
     public static final String PROCESS_INSTANCES_BY_CONTAINER_ID_GET_URI = "containers/{" + CONTAINER_ID + "}/process/instances";
     public static final String PROCESS_INSTANCE_BY_CORRELATION_KEY_GET_URI = "processes/instance/correlation/{" + CORRELATION_KEY + "}";
     public static final String PROCESS_INSTANCES_BY_CORRELATION_KEY_GET_URI = "processes/instances/correlation/{" + CORRELATION_KEY + "}";
@@ -126,10 +125,10 @@ public class RestURI {
     public static final String PROCESS_DEFINITIONS_BY_ID_GET_URI = "processes/definitions/{" + PROCESS_ID + "}";
 
     public static final String NODE_INSTANCES_BY_INSTANCE_ID_GET_URI = "processes/instances/{" + PROCESS_INST_ID + "}/nodes/instances";
-    public static final String NODE_INSTANCES_BY_WORK_ITEM_ID_GET_URI = "processes/instances/{" + PROCESS_INST_ID + "}/wi-nodes/instances/{" + WORK_ITEM_ID +"}";
+    public static final String NODE_INSTANCES_BY_WORK_ITEM_ID_GET_URI = "processes/instances/{" + PROCESS_INST_ID + "}/wi-nodes/instances/{" + WORK_ITEM_ID + "}";
 
     public static final String VAR_INSTANCES_BY_INSTANCE_ID_GET_URI = "processes/instances/{" + PROCESS_INST_ID + "}/variables/instances";
-    public static final String VAR_INSTANCES_BY_VAR_INSTANCE_ID_GET_URI = "processes/instances/{" + PROCESS_INST_ID + "}/variables/instances/{" + VAR_NAME +"}";
+    public static final String VAR_INSTANCES_BY_VAR_INSTANCE_ID_GET_URI = "processes/instances/{" + PROCESS_INST_ID + "}/variables/instances/{" + VAR_NAME + "}";
 
     // task search related prefixed by QUERY_URI
     public static final String TASKS_ASSIGN_POT_OWNERS_GET_URI = "tasks/instances/pot-owners";
@@ -169,7 +168,7 @@ public class RestURI {
     public static final String TASK_INSTANCE_OUTPUT_DATA_GET_URI = "{" + TASK_INSTANCE_ID + "}/contents/output";
     public static final String TASK_INSTANCE_INPUT_DATA_GET_URI = "{" + TASK_INSTANCE_ID + "}/contents/input";
 
-    public static final String TASK_INSTANCE_CONTENT_DATA_DELETE_URI = "{" + TASK_INSTANCE_ID + "}/contents/{" + CONTENT_ID +"}";
+    public static final String TASK_INSTANCE_CONTENT_DATA_DELETE_URI = "{" + TASK_INSTANCE_ID + "}/contents/{" + CONTENT_ID + "}";
 
     public static final String TASK_INSTANCE_COMMENT_ADD_POST_URI = "{" + TASK_INSTANCE_ID + "}/comments";
     public static final String TASK_INSTANCE_COMMENTS_GET_URI = "{" + TASK_INSTANCE_ID + "}/comments";
@@ -216,6 +215,8 @@ public class RestURI {
     public static final String SOLVER_URI = "containers/{" + CONTAINER_ID + "}/solvers";
     public static final String SOLVER_ID_URI = "{" + SOLVER_ID + "}";
     public static final String SOLVER_BEST_SOLUTION = "bestsolution";
+    public static final String SOLVER_PROBLEM_FACTS_CHANGED = "problemfactschanged";
+    public static final String SOLVER_PROBLEM_FACTS_CHANGED_PROCESSED = SOLVER_PROBLEM_FACTS_CHANGED + "/processed";
     public static final String SOLVER_STATE_RUNNING = "state/solving";
     public static final String SOLVER_STATE_TERMINATING = "state/terminating-early";
 
@@ -229,15 +230,15 @@ public class RestURI {
     public static final String DOCUMENT_INSTANCE_DELETE_URI = "{" + DOCUMENT_ID + "}";
 
     // admin process related
-    public static final String MIGRATE_PROCESS_INST_PUT_URI = "instances/{" + PROCESS_INST_ID +"}";
+    public static final String MIGRATE_PROCESS_INST_PUT_URI = "instances/{" + PROCESS_INST_ID + "}";
     public static final String MIGRATE_PROCESS_INSTANCES_PUT_URI = "instances";
-    public static final String CANCEL_NODE_INST_PROCESS_INST_DELETE_URI = "instances/{" + PROCESS_INST_ID +"}/nodeinstances/{" + NODE_INSTANCE_ID + "}";
-    public static final String RETRIGGER_NODE_INST_PROCESS_INST_PUT_URI = "instances/{" + PROCESS_INST_ID +"}/nodeinstances/{" + NODE_INSTANCE_ID + "}";
-    public static final String UPDATE_TIMER_PROCESS_INST_PUT_URI = "instances/{" + PROCESS_INST_ID +"}/timers/{" + TIMER_INSTANCE_ID + "}";
-    public static final String TRIGGER_NODE_PROCESS_INST_POST_URI = "instances/{" + PROCESS_INST_ID +"}/nodes/{" + NODE_ID + "}";
-    public static final String NODES_PROCESS_INST_GET_URI = "instances/{" + PROCESS_INST_ID +"}/nodes";
-    public static final String TIMERS_PROCESS_INST_GET_URI = "instances/{" + PROCESS_INST_ID +"}/timers";
-    public static final String NODE_INSTANCES_PROCESS_INST_GET_URI = "instances/{" + PROCESS_INST_ID +"}/nodeinstances";
+    public static final String CANCEL_NODE_INST_PROCESS_INST_DELETE_URI = "instances/{" + PROCESS_INST_ID + "}/nodeinstances/{" + NODE_INSTANCE_ID + "}";
+    public static final String RETRIGGER_NODE_INST_PROCESS_INST_PUT_URI = "instances/{" + PROCESS_INST_ID + "}/nodeinstances/{" + NODE_INSTANCE_ID + "}";
+    public static final String UPDATE_TIMER_PROCESS_INST_PUT_URI = "instances/{" + PROCESS_INST_ID + "}/timers/{" + TIMER_INSTANCE_ID + "}";
+    public static final String TRIGGER_NODE_PROCESS_INST_POST_URI = "instances/{" + PROCESS_INST_ID + "}/nodes/{" + NODE_ID + "}";
+    public static final String NODES_PROCESS_INST_GET_URI = "instances/{" + PROCESS_INST_ID + "}/nodes";
+    public static final String TIMERS_PROCESS_INST_GET_URI = "instances/{" + PROCESS_INST_ID + "}/timers";
+    public static final String NODE_INSTANCES_PROCESS_INST_GET_URI = "instances/{" + PROCESS_INST_ID + "}/nodeinstances";
 
     public static final String TASK_INSTANCE_POT_OWNERS_USERS_URI = "{" + TASK_INSTANCE_ID + "}/pot-owners";
     public static final String TASK_INSTANCE_EXL_OWNERS_USERS_URI = "{" + TASK_INSTANCE_ID + "}/exl-owners";
@@ -257,28 +258,28 @@ public class RestURI {
     public static final String TASK_INSTANCE_ADMINS_GROUPS_DELETE_URI = "{" + TASK_INSTANCE_ID + "}/admins/groups/{" + ENTITY_ID + "}";
 
     // error handling related
-    public static final String ERRORS_BY_PROCESS_INST_GET_URI = "instances/{" + PROCESS_INST_ID +"}/errors";
-    public static final String ERROR_GET_URI = "errors/{" + ERROR_ID +"}";
-    public static final String ACK_ERROR_PUT_URI = "errors/{" + ERROR_ID +"}";
+    public static final String ERRORS_BY_PROCESS_INST_GET_URI = "instances/{" + PROCESS_INST_ID + "}/errors";
+    public static final String ERROR_GET_URI = "errors/{" + ERROR_ID + "}";
+    public static final String ACK_ERROR_PUT_URI = "errors/{" + ERROR_ID + "}";
     public static final String ACK_ERRORS_PUT_URI = "errors";
 
-    public static final String ERRORS_BY_TASK_ID_GET_URI = "{" + TASK_INSTANCE_ID +"}/errors";
+    public static final String ERRORS_BY_TASK_ID_GET_URI = "{" + TASK_INSTANCE_ID + "}/errors";
     public static final String ERRORS_GET_URI = "errors";
 
     // case management related
-    public static final String START_CASE_POST_URI = "{" + CASE_DEF_ID +"}/instances";
-    public static final String REOPEN_CASE_PUT_URI = "{" + CASE_DEF_ID +"}/instances/{" + CASE_ID + "}";
-    public static final String CASE_GET_URI = "{" + CASE_DEF_ID +"}";
+    public static final String START_CASE_POST_URI = "{" + CASE_DEF_ID + "}/instances";
+    public static final String REOPEN_CASE_PUT_URI = "{" + CASE_DEF_ID + "}/instances/{" + CASE_ID + "}";
+    public static final String CASE_GET_URI = "{" + CASE_DEF_ID + "}";
     public static final String CASE_INSTANCES_GET_URI = "instances";
-    public static final String CASE_INSTANCES_BY_DEF_GET_URI = "{" + CASE_DEF_ID +"}/instances";
+    public static final String CASE_INSTANCES_BY_DEF_GET_URI = "{" + CASE_DEF_ID + "}/instances";
     public static final String CASE_INSTANCE_GET_URI = "instances/{" + CASE_ID + "}";
     public static final String CASE_INSTANCE_DELETE_URI = "instances/{" + CASE_ID + "}";
     public static final String CASE_MILESTONES_GET_URI = "instances/{" + CASE_ID + "}/milestones";
     public static final String CASE_STAGES_GET_URI = "instances/{" + CASE_ID + "}/stages";
     public static final String CASE_AD_HOC_FRAGMENTS_GET_URI = "instances/{" + CASE_ID + "}/adhocfragments";
     public static final String CASE_ROLES_GET_URI = "instances/{" + CASE_ID + "}/roles";
-    public static final String CASE_ROLES_PUT_URI = "instances/{" + CASE_ID + "}/roles/{" + CASE_ROLE_NAME +"}";
-    public static final String CASE_ROLES_DELETE_URI = "instances/{" + CASE_ID + "}/roles/{" + CASE_ROLE_NAME +"}";
+    public static final String CASE_ROLES_PUT_URI = "instances/{" + CASE_ID + "}/roles/{" + CASE_ROLE_NAME + "}";
+    public static final String CASE_ROLES_DELETE_URI = "instances/{" + CASE_ID + "}/roles/{" + CASE_ROLE_NAME + "}";
     public static final String CASE_NODE_INSTANCES_GET_URI = "instances/{" + CASE_ID + "}/nodes/instances";
     public static final String CASE_PROCESS_INSTANCES_GET_URI = "instances/{" + CASE_ID + "}/processes/instances";
     public static final String CASE_COMMENTS_GET_URI = "instances/{" + CASE_ID + "}/comments";
@@ -288,8 +289,8 @@ public class RestURI {
     public static final String CASE_FILE_GET_URI = "instances/{" + CASE_ID + "}/caseFile";
     public static final String CASE_FILE_POST_URI = "instances/{" + CASE_ID + "}/caseFile";
     public static final String CASE_FILE_DELETE_URI = "instances/{" + CASE_ID + "}/caseFile";
-    public static final String CASE_FILE_BY_NAME_GET_URI = "instances/{" + CASE_ID + "}/caseFile/{"+ CASE_FILE_ITEM +"}";
-    public static final String CASE_FILE_BY_NAME_POST_URI = "instances/{" + CASE_ID + "}/caseFile/{"+ CASE_FILE_ITEM +"}";
+    public static final String CASE_FILE_BY_NAME_GET_URI = "instances/{" + CASE_ID + "}/caseFile/{" + CASE_FILE_ITEM + "}";
+    public static final String CASE_FILE_BY_NAME_POST_URI = "instances/{" + CASE_ID + "}/caseFile/{" + CASE_FILE_ITEM + "}";
     public static final String CASE_DYNAMIC_TASK_POST_URI = "instances/{" + CASE_ID + "}/tasks";
     public static final String CASE_DYNAMIC_TASK_IN_STAGE_POST_URI = "instances/{" + CASE_ID + "}/stages/{" + CASE_STAGE_ID + "}/tasks";
     public static final String CASE_DYNAMIC_PROCESS_POST_URI = "instances/{" + CASE_ID + "}/processes/{" + PROCESS_ID + "}";
@@ -300,7 +301,7 @@ public class RestURI {
     // case queries
     public static final String CASE_ALL_INSTANCES_GET_URI = "instances";
     public static final String CASE_ALL_DEFINITIONS_GET_URI = "definitions";
-    public static final String CASE_DEFINITIONS_BY_ID_GET_URI = "definitions/{" + CASE_DEF_ID +"}";
+    public static final String CASE_DEFINITIONS_BY_ID_GET_URI = "definitions/{" + CASE_DEF_ID + "}";
     public static final String CASE_TASKS_AS_POT_OWNER_GET_URI = "instances/{" + CASE_ID + "}/tasks/instances/pot-owners";
     public static final String CASE_TASKS_AS_ADMIN_GET_URI = "instances/{" + CASE_ID + "}/tasks/instances/admins";
     public static final String CASE_TASKS_AS_STAKEHOLDER_GET_URI = "instances/{" + CASE_ID + "}/tasks/instances/stakeholders";
@@ -308,16 +309,22 @@ public class RestURI {
     public static final String CASE_ALL_PROCESSES_INSTANCES_GET_URI = "processes";
     public static final String CASE_PROCESSES_BY_CONTAINER_INSTANCES_GET_URI = "{" + CONTAINER_ID + "}/processes";
 
-
-    public static String build(String baseUrl, String template, Map<String, Object> parameters) {
-        StrSubstitutor sub = new StrSubstitutor(new SafeMapStrLookup(parameters), "{", "}", '$');
+    public static String build(String baseUrl,
+                               String template,
+                               Map<String, Object> parameters) {
+        StrSubstitutor sub = new StrSubstitutor(new SafeMapStrLookup(parameters),
+                                                "{",
+                                                "}",
+                                                '$');
         String resourceUrl = sub.replace(template);
 
         return baseUrl + "/" + resourceUrl;
     }
 
     private static class SafeMapStrLookup<V> extends StrLookup {
+
         private final Map<String, V> map;
+
         SafeMapStrLookup(Map<String, V> map) {
             this.map = map;
         }

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/build/revapi-config.json
@@ -38,7 +38,6 @@
       }
     }
   },
-
   "ignores": {
     "revapi": {
       "_comment": "Changes between 7.0.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.1.0.Final is available.",
@@ -134,56 +133,83 @@
           "justification": "JBPM-6120 Invalid Kie Server REST endpoints for processes"
         },
         {
-         "code": "java.method.addedToInterface",
-         "new": "method java.util.List<org.kie.server.api.model.cases.CaseComment> org.kie.server.client.CaseServicesClient::getComments(java.lang.String, java.lang.String, java.lang.String, java.lang.Integer, java.lang.Integer)",
-         "package": "org.kie.server.client",
-         "classSimpleName": "CaseServicesClient",
-         "methodName": "getComments",
-         "elementKind": "method",
-         "justification": "Added new method to support case instance comments basic sorting"
-         },
-         {
-		   "code": "java.method.addedToInterface",
-		   "new": "method void org.kie.server.client.admin.UserTaskAdminServicesClient::acknowledgeError(java.lang.String, java.lang.String[])",
-		   "package": "org.kie.server.client.admin",
-		   "classSimpleName": "UserTaskAdminServicesClient",
-		   "methodName": "acknowledgeError",
-		   "elementKind": "method",
-		   "justification": "JBPM-5851 Technical Error Events"
-		 },
-		 {
-		   "code": "java.method.addedToInterface",
-		   "new": "method org.kie.server.api.model.admin.ExecutionErrorInstance org.kie.server.client.admin.UserTaskAdminServicesClient::getError(java.lang.String, java.lang.String)",
-		   "package": "org.kie.server.client.admin",
-		   "classSimpleName": "UserTaskAdminServicesClient",
-		   "methodName": "getError",
-		   "elementKind": "method",
-		   "justification": "JBPM-5851 Technical Error Events"
-		 },
-		 {
-		  "code": "java.method.returnTypeChanged",
-		  "old": "method void org.kie.server.client.balancer.BalancerStrategy::markAsOffline(java.lang.String)",
-		  "new": "method java.lang.String org.kie.server.client.balancer.BalancerStrategy::markAsOffline(java.lang.String)",
-		  "oldType": "void",
-		  "newType": "java.lang.String",
-		  "package": "org.kie.server.client.balancer",
-		  "classSimpleName": "BalancerStrategy",
-		  "methodName": "markAsOffline",
-		  "elementKind": "method",
-		  "justification": "Fixed handling of urls within load balancer to take into account base url"
-		},
-		{
-		  "code": "java.method.returnTypeChanged",
-		  "old": "method void org.kie.server.client.balancer.BalancerStrategy::markAsOnline(java.lang.String)",
-		  "new": "method java.lang.String org.kie.server.client.balancer.BalancerStrategy::markAsOnline(java.lang.String)",
-		  "oldType": "void",
-		  "newType": "java.lang.String",
-		  "package": "org.kie.server.client.balancer",
-		  "classSimpleName": "BalancerStrategy",
-		  "methodName": "markAsOnline",
-		  "elementKind": "method",
-		  "justification": "Fixed handling of urls within load balancer to take into account base url"
-		}
+          "code": "java.method.addedToInterface",
+          "new": "method java.util.List<org.kie.server.api.model.cases.CaseComment> org.kie.server.client.CaseServicesClient::getComments(java.lang.String, java.lang.String, java.lang.String, java.lang.Integer, java.lang.Integer)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "CaseServicesClient",
+          "methodName": "getComments",
+          "elementKind": "method",
+          "justification": "Added new method to support case instance comments basic sorting"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.server.client.admin.UserTaskAdminServicesClient::acknowledgeError(java.lang.String, java.lang.String[])",
+          "package": "org.kie.server.client.admin",
+          "classSimpleName": "UserTaskAdminServicesClient",
+          "methodName": "acknowledgeError",
+          "elementKind": "method",
+          "justification": "JBPM-5851 Technical Error Events"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method org.kie.server.api.model.admin.ExecutionErrorInstance org.kie.server.client.admin.UserTaskAdminServicesClient::getError(java.lang.String, java.lang.String)",
+          "package": "org.kie.server.client.admin",
+          "classSimpleName": "UserTaskAdminServicesClient",
+          "methodName": "getError",
+          "elementKind": "method",
+          "justification": "JBPM-5851 Technical Error Events"
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method void org.kie.server.client.balancer.BalancerStrategy::markAsOffline(java.lang.String)",
+          "new": "method java.lang.String org.kie.server.client.balancer.BalancerStrategy::markAsOffline(java.lang.String)",
+          "oldType": "void",
+          "newType": "java.lang.String",
+          "package": "org.kie.server.client.balancer",
+          "classSimpleName": "BalancerStrategy",
+          "methodName": "markAsOffline",
+          "elementKind": "method",
+          "justification": "Fixed handling of urls within load balancer to take into account base url"
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method void org.kie.server.client.balancer.BalancerStrategy::markAsOnline(java.lang.String)",
+          "new": "method java.lang.String org.kie.server.client.balancer.BalancerStrategy::markAsOnline(java.lang.String)",
+          "oldType": "void",
+          "newType": "java.lang.String",
+          "package": "org.kie.server.client.balancer",
+          "classSimpleName": "BalancerStrategy",
+          "methodName": "markAsOnline",
+          "elementKind": "method",
+          "justification": "Fixed handling of urls within load balancer to take into account base url"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.server.client.SolverServicesClient::addProblemFactChange(java.lang.String, java.lang.String, org.optaplanner.core.impl.solver.ProblemFactChange)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "SolverServicesClient",
+          "methodName": "addProblemFactChange",
+          "elementKind": "method",
+          "justification": "PLANNER-815 Support real-time planning"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.server.client.SolverServicesClient::addProblemFactChanges(java.lang.String, java.lang.String, java.util.List<org.optaplanner.core.impl.solver.ProblemFactChange>)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "SolverServicesClient",
+          "methodName": "addProblemFactChanges",
+          "elementKind": "method",
+          "justification": "PLANNER-815 Support real-time planning"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.lang.Boolean org.kie.server.client.SolverServicesClient::isEveryProblemFactChangeProcessed(java.lang.String, java.lang.String)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "SolverServicesClient",
+          "methodName": "isEveryProblemFactChangeProcessed",
+          "elementKind": "method",
+          "justification": "PLANNER-815 Support real-time planning"
+        }
       ]
     }
   }

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/SolverServicesClient.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/SolverServicesClient.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.kie.server.api.model.instance.SolverInstance;
 import org.kie.server.client.jms.ResponseHandler;
+import org.optaplanner.core.impl.solver.ProblemFactChange;
 
 public interface SolverServicesClient {
 
@@ -40,6 +41,17 @@ public interface SolverServicesClient {
 
     void terminateSolverEarly(String containerId,
                               String solverId);
+
+    void addProblemFactChange(String containerId,
+                              String solverId,
+                              ProblemFactChange problemFactChange);
+
+    void addProblemFactChanges(String containerId,
+                              String solverId,
+                              List<ProblemFactChange> problemFactChange);
+
+    Boolean isEveryProblemFactChangeProcessed(String containerId,
+                                              String solverId);
 
     void disposeSolver(String containerId,
                        String solverId);

--- a/kie-server-parent/kie-server-remote/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/revapi-config.json
@@ -1,0 +1,27 @@
+{
+  "ignores": {
+    "revapi": {
+      "_comment": "Changes between 7.0.0.Final and the current branch. These changes are desired and thus ignored. They should be removed when 7.1.0.Final is available.",
+      "ignore": [
+        {
+        "code": "java.method.addedToInterface",
+        "new": "method void org.kie.server.client.SolverServicesClient::addProblemFactChanges(java.lang.String, java.lang.String, java.util.List<org.optaplanner.core.impl.solver.ProblemFactChange>)",
+        "package": "org.kie.server.client",
+        "classSimpleName": "SolverServicesClient",
+        "methodName": "addProblemFactChanges",
+        "elementKind": "method",
+        "justification": "PLANNER-815 Support real-time planning"
+        },
+        {
+        "code": "java.method.addedToInterface",
+        "new": "method java.lang.Boolean org.kie.server.client.SolverServicesClient::isEveryProblemFactChangeProcessed(java.lang.String, java.lang.String)",
+        "package": "org.kie.server.client",
+        "classSimpleName": "SolverServicesClient",
+        "methodName": "isEveryProblemFactChangeProcessed",
+        "elementKind": "method",
+        "justification": "PLANNER-815 Support real-time planning"
+        }
+      ]
+    }
+  }
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/pom.xml
@@ -11,6 +11,11 @@
   <version>1.0.0.Final</version>
   <packaging>kjar</packaging>
 
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.optaplanner</groupId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/java/org/kie/server/testing/AbstractPersistable.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/java/org/kie/server/testing/AbstractPersistable.java
@@ -17,23 +17,23 @@
 package org.kie.server.testing;
 
 import java.io.Serializable;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlID;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
-import javax.xml.bind.annotation.adapters.XmlAdapter;
 
 import org.apache.commons.lang3.builder.CompareToBuilder;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.optaplanner.core.api.domain.lookup.PlanningId;
 import org.optaplanner.core.api.score.constraint.ConstraintMatch;
 
-@XmlRootElement @XmlAccessorType(XmlAccessType.FIELD)
-public abstract class AbstractPersistable implements Serializable, Comparable<AbstractPersistable> {
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public abstract class AbstractPersistable implements Serializable,
+                                                     Comparable<AbstractPersistable> {
 
     // TODO Use @XmlID @XmlJavaTypeAdapter(IdAdapter.class) to allow CloudProcess's usage of @XmlIDREF
+    @PlanningId
     protected Long id;
 
     protected AbstractPersistable() {
@@ -59,29 +59,17 @@ public abstract class AbstractPersistable implements Serializable, Comparable<Ab
      */
     public int compareTo(AbstractPersistable other) {
         return new CompareToBuilder()
-                .append(getClass().getName(), other.getClass().getName())
-                .append(id, other.id)
+                .append(getClass().getName(),
+                        other.getClass().getName())
+                .append(id,
+                        other.id)
                 .toComparison();
     }
 
     public String toString() {
-        return getClass().getName().replaceAll(".*\\.", "") + "-" + id;
+        return getClass().getName().replaceAll(".*\\.",
+                                               "") + "-" + id;
     }
-
-    // TODO Needed for @XmlIDREF
-//    public static class IdAdapter extends XmlAdapter<String, Long>{
-//
-//        @Override
-//        public Long unmarshal(String v) throws Exception {
-//            return Long.parseLong(v);
-//        }
-//
-//        @Override
-//        public String marshal(Long v) throws Exception {
-//            return String.valueOf(v);
-//        }
-//
-//    }
 
     public int hashCode() {
         return new HashCodeBuilder()
@@ -95,7 +83,8 @@ public abstract class AbstractPersistable implements Serializable, Comparable<Ab
         } else if (o instanceof AbstractPersistable) {
             AbstractPersistable other = (AbstractPersistable) o;
             return new EqualsBuilder()
-                    .append(id, other.id)
+                    .append(id,
+                            other.id)
                     .isEquals();
         } else {
             return false;

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/java/org/kie/server/testing/AddComputerProblemFactChange.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/java/org/kie/server/testing/AddComputerProblemFactChange.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.testing;
+
+import java.util.ArrayList;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.optaplanner.core.impl.score.director.ScoreDirector;
+import org.optaplanner.core.impl.solver.ProblemFactChange;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class AddComputerProblemFactChange implements ProblemFactChange<CloudBalance> {
+
+    private CloudComputer computer;
+
+    public AddComputerProblemFactChange() {
+    }
+
+    public AddComputerProblemFactChange(CloudComputer computer) {
+        this.computer = computer;
+    }
+
+    public CloudComputer getComputer() {
+        return computer;
+    }
+
+    public void setComputer(CloudComputer computer) {
+        this.computer = computer;
+    }
+
+    @Override
+    public void doChange(ScoreDirector<CloudBalance> scoreDirector) {
+        CloudBalance cloudBalance = scoreDirector.getWorkingSolution();
+        // Set a unique id on the new computer
+        long nextComputerId = 0L;
+        for (CloudComputer otherComputer : cloudBalance.getComputerList()) {
+            if (nextComputerId <= otherComputer.getId()) {
+                nextComputerId = otherComputer.getId() + 1L;
+            }
+        }
+        computer.setId(nextComputerId);
+        // A SolutionCloner does not clone problem fact lists (such as computerList)
+        // Shallow clone the computerList so only workingSolution is affected, not bestSolution or guiSolution
+        cloudBalance.setComputerList(new ArrayList<>(cloudBalance.getComputerList()));
+        // Add the problem fact itself
+        scoreDirector.beforeProblemFactAdded(computer);
+        cloudBalance.getComputerList().add(computer);
+        scoreDirector.afterProblemFactAdded(computer);
+    }
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/java/org/kie/server/testing/CloudBalancingGenerator.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/java/org/kie/server/testing/CloudBalancingGenerator.java
@@ -16,7 +16,6 @@
 
 package org.kie.server.testing;
 
-import java.io.File;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,11 +25,13 @@ public class CloudBalancingGenerator {
 
     private static class Price {
 
-        private int    hardwareValue;
+        private int hardwareValue;
         private String description;
-        private int    cost;
+        private int cost;
 
-        private Price(int hardwareValue, String description, int cost) {
+        private Price(int hardwareValue,
+                      String description,
+                      int cost) {
             this.hardwareValue = hardwareValue;
             this.description = description;
             this.cost = cost;
@@ -50,31 +51,73 @@ public class CloudBalancingGenerator {
     }
 
     private static final Price[] CPU_POWER_PRICES = { // in gigahertz
-                                                      new Price( 3, "single core 3ghz", 110 ),
-                                                      new Price( 4, "dual core 2ghz", 140 ),
-                                                      new Price( 6, "dual core 3ghz", 180 ),
-                                                      new Price( 8, "quad core 2ghz", 270 ),
-                                                      new Price( 12, "quad core 3ghz", 400 ),
-                                                      new Price( 16, "quad core 4ghz", 1000 ),
-                                                      new Price( 24, "eight core 3ghz", 3000 ),
+            new Price(3,
+                      "single core 3ghz",
+                      110),
+            new Price(4,
+                      "dual core 2ghz",
+                      140),
+            new Price(6,
+                      "dual core 3ghz",
+                      180),
+            new Price(8,
+                      "quad core 2ghz",
+                      270),
+            new Price(12,
+                      "quad core 3ghz",
+                      400),
+            new Price(16,
+                      "quad core 4ghz",
+                      1000),
+            new Price(24,
+                      "eight core 3ghz",
+                      3000),
     };
     private static final Price[] MEMORY_PRICES = { // in gigabyte RAM
-            new Price(2, "2 gigabyte", 140),
-            new Price(4, "4 gigabyte", 180),
-            new Price(8, "8 gigabyte", 220),
-            new Price(16, "16 gigabyte", 300),
-            new Price(32, "32 gigabyte", 400),
-            new Price(64, "64 gigabyte", 600),
-            new Price(96, "96 gigabyte", 1000),
+            new Price(2,
+                      "2 gigabyte",
+                      140),
+            new Price(4,
+                      "4 gigabyte",
+                      180),
+            new Price(8,
+                      "8 gigabyte",
+                      220),
+            new Price(16,
+                      "16 gigabyte",
+                      300),
+            new Price(32,
+                      "32 gigabyte",
+                      400),
+            new Price(64,
+                      "64 gigabyte",
+                      600),
+            new Price(96,
+                      "96 gigabyte",
+                      1000),
     };
     private static final Price[] NETWORK_BANDWIDTH_PRICES = { // in gigabyte per hour
-            new Price(2, "2 gigabyte", 100),
-            new Price(4, "4 gigabyte", 200),
-            new Price(6, "6 gigabyte", 300),
-            new Price(8, "8 gigabyte", 400),
-            new Price(12, "12 gigabyte", 600),
-            new Price(16, "16 gigabyte", 800),
-            new Price(20, "20 gigabyte", 1000),
+            new Price(2,
+                      "2 gigabyte",
+                      100),
+            new Price(4,
+                      "4 gigabyte",
+                      200),
+            new Price(6,
+                      "6 gigabyte",
+                      300),
+            new Price(8,
+                      "8 gigabyte",
+                      400),
+            new Price(12,
+                      "12 gigabyte",
+                      600),
+            new Price(16,
+                      "16 gigabyte",
+                      800),
+            new Price(20,
+                      "20 gigabyte",
+                      1000),
     };
 
     private static final int MAXIMUM_REQUIRED_CPU_POWER = 12; // in gigahertz
@@ -93,48 +136,70 @@ public class CloudBalancingGenerator {
         }
     }
 
-    public CloudBalance createCloudBalance(int computerListSize, int processListSize) {
-        return createCloudBalance(determineFileName(computerListSize, processListSize),
-                computerListSize, processListSize);
+    public CloudBalance createCloudBalance(int computerListSize,
+                                           int processListSize) {
+        return createCloudBalance(determineFileName(computerListSize,
+                                                    processListSize),
+                                  computerListSize,
+                                  processListSize);
     }
 
-    private String determineFileName(int computerListSize, int processListSize) {
+    private String determineFileName(int computerListSize,
+                                     int processListSize) {
         return computerListSize + "computers-" + processListSize + "processes";
     }
 
-    public CloudBalance createCloudBalance(String inputId, int computerListSize, int processListSize) {
+    public CloudBalance createCloudBalance(String inputId,
+                                           int computerListSize,
+                                           int processListSize) {
         random = new Random(47);
         CloudBalance cloudBalance = new CloudBalance();
-        cloudBalance.setId( 0L );
-        createComputerList( cloudBalance, computerListSize );
-        createProcessList( cloudBalance, processListSize );
-        assureComputerCapacityTotalAtLeastProcessRequiredTotal( cloudBalance );
+        cloudBalance.setId(0L);
+        createComputerList(cloudBalance,
+                           computerListSize);
+        createProcessList(cloudBalance,
+                          processListSize);
+        assureComputerCapacityTotalAtLeastProcessRequiredTotal(cloudBalance);
         BigInteger possibleSolutionSize = BigInteger.valueOf(cloudBalance.getComputerList().size()).pow(
                 cloudBalance.getProcessList().size());
         return cloudBalance;
     }
 
-    private void createComputerList(CloudBalance cloudBalance, int computerListSize) {
+    public CloudComputer createCloudComputer(int currentNumberOfComputers) {
+        random = new Random(47);
+        return generateCloudComputer(currentNumberOfComputers);
+    }
+
+    private void createComputerList(CloudBalance cloudBalance,
+                                    int computerListSize) {
         List<CloudComputer> computerList = new ArrayList<CloudComputer>(computerListSize);
         for (int i = 0; i < computerListSize; i++) {
-            CloudComputer computer = new CloudComputer();
-            computer.setId((long) i);
-            int cpuPowerPricesIndex = random.nextInt(CPU_POWER_PRICES.length);
-            computer.setCpuPower(CPU_POWER_PRICES[cpuPowerPricesIndex].getHardwareValue());
-            int memoryPricesIndex = distortIndex(cpuPowerPricesIndex, MEMORY_PRICES.length);
-            computer.setMemory(MEMORY_PRICES[memoryPricesIndex].getHardwareValue());
-            int networkBandwidthPricesIndex = distortIndex(cpuPowerPricesIndex, NETWORK_BANDWIDTH_PRICES.length);
-            computer.setNetworkBandwidth(NETWORK_BANDWIDTH_PRICES[networkBandwidthPricesIndex].getHardwareValue());
-            int cost = CPU_POWER_PRICES[cpuPowerPricesIndex].getCost()
-                    + MEMORY_PRICES[memoryPricesIndex].getCost()
-                    + NETWORK_BANDWIDTH_PRICES[networkBandwidthPricesIndex].getCost();
-            computer.setCost(cost);
+            CloudComputer computer = generateCloudComputer((long) i);
             computerList.add(computer);
         }
         cloudBalance.setComputerList(computerList);
     }
 
-    private int distortIndex(int referenceIndex, int length) {
+    private CloudComputer generateCloudComputer(long id) {
+        CloudComputer computer = new CloudComputer();
+        computer.setId(id);
+        int cpuPowerPricesIndex = random.nextInt(CPU_POWER_PRICES.length);
+        computer.setCpuPower(CPU_POWER_PRICES[cpuPowerPricesIndex].getHardwareValue());
+        int memoryPricesIndex = distortIndex(cpuPowerPricesIndex,
+                                             MEMORY_PRICES.length);
+        computer.setMemory(MEMORY_PRICES[memoryPricesIndex].getHardwareValue());
+        int networkBandwidthPricesIndex = distortIndex(cpuPowerPricesIndex,
+                                                       NETWORK_BANDWIDTH_PRICES.length);
+        computer.setNetworkBandwidth(NETWORK_BANDWIDTH_PRICES[networkBandwidthPricesIndex].getHardwareValue());
+        int cost = CPU_POWER_PRICES[cpuPowerPricesIndex].getCost()
+                + MEMORY_PRICES[memoryPricesIndex].getCost()
+                + NETWORK_BANDWIDTH_PRICES[networkBandwidthPricesIndex].getCost();
+        computer.setCost(cost);
+        return computer;
+    }
+
+    private int distortIndex(int referenceIndex,
+                             int length) {
         int index = referenceIndex;
         double randomDouble = random.nextDouble();
         double loweringThreshold = 0.25;
@@ -150,7 +215,8 @@ public class CloudBalancingGenerator {
         return index;
     }
 
-    private void createProcessList(CloudBalance cloudBalance, int processListSize) {
+    private void createProcessList(CloudBalance cloudBalance,
+                                   int processListSize) {
         List<CloudProcess> processList = new ArrayList<CloudProcess>(processListSize);
         for (int i = 0; i < processListSize; i++) {
             CloudProcess process = new CloudProcess();
@@ -170,7 +236,8 @@ public class CloudBalancingGenerator {
     private int generateRandom(int maximumValue) {
         double randomDouble = random.nextDouble();
         double parabolaBase = 2000.0;
-        double parabolaRandomDouble = (Math.pow(parabolaBase, randomDouble) - 1.0) / (parabolaBase - 1.0);
+        double parabolaRandomDouble = (Math.pow(parabolaBase,
+                                                randomDouble) - 1.0) / (parabolaBase - 1.0);
         if (parabolaRandomDouble < 0.0 || parabolaRandomDouble >= 1.0) {
             throw new IllegalArgumentException("Invalid generated parabolaRandomDouble (" + parabolaRandomDouble + ")");
         }
@@ -223,12 +290,11 @@ public class CloudBalancingGenerator {
     }
 
     private int determineUpgrade(int lacking) {
-        for (int upgrade : new int[] {8, 4, 2, 1}) {
+        for (int upgrade : new int[]{8, 4, 2, 1}) {
             if (lacking >= upgrade) {
                 return upgrade;
             }
         }
         throw new IllegalStateException("Lacking (" + lacking + ") should be at least 1.");
     }
-
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/java/org/kie/server/testing/DeleteComputerProblemFactChange.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/java/org/kie/server/testing/DeleteComputerProblemFactChange.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.testing;
+
+import java.util.ArrayList;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.optaplanner.core.impl.score.director.ScoreDirector;
+import org.optaplanner.core.impl.solver.ProblemFactChange;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+public class DeleteComputerProblemFactChange implements ProblemFactChange<CloudBalance> {
+
+    private CloudComputer computer;
+
+    public DeleteComputerProblemFactChange() {
+    }
+
+    public DeleteComputerProblemFactChange(CloudComputer computer) {
+        this.computer = computer;
+    }
+
+    public CloudComputer getComputer() {
+        return computer;
+    }
+
+    public void setComputer(CloudComputer computer) {
+        this.computer = computer;
+    }
+
+    @Override
+    public void doChange(ScoreDirector<CloudBalance> scoreDirector) {
+        CloudBalance cloudBalance = scoreDirector.getWorkingSolution();
+        CloudComputer workingComputer = scoreDirector.lookUpWorkingObject(computer);
+        if (workingComputer == null) {
+            // The computer has already been deleted (the UI asked to changed the same computer twice), so do nothing
+            return;
+        }
+        // First remove the problem fact from all planning entities that use it
+        for (CloudProcess process : cloudBalance.getProcessList()) {
+            if (process.getComputer() == workingComputer) {
+                scoreDirector.beforeVariableChanged(process,
+                                                    "computer");
+                process.setComputer(null);
+                scoreDirector.afterVariableChanged(process,
+                                                   "computer");
+            }
+        }
+        // A SolutionCloner does not clone problem fact lists (such as computerList)
+        // Shallow clone the computerList so only workingSolution is affected, not bestSolution or guiSolution
+        ArrayList<CloudComputer> computerList = new ArrayList<>(cloudBalance.getComputerList());
+        cloudBalance.setComputerList(computerList);
+        // Remove the problem fact itself
+        scoreDirector.beforeProblemFactRemoved(workingComputer);
+        computerList.remove(workingComputer);
+        scoreDirector.afterProblemFactRemoved(workingComputer);
+        scoreDirector.triggerVariableListeners();
+    }
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/resources/cloudbalance-realtime-planning-daemon-solver.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/resources/cloudbalance-realtime-planning-daemon-solver.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solver>
+  <!-- Domain model configuration -->
+  <solutionClass>org.kie.server.testing.CloudBalance</solutionClass>
+  <entityClass>org.kie.server.testing.CloudProcess</entityClass>
+
+  <!-- Real time planning configuration -->
+  <daemon>true</daemon>
+
+  <!-- Score configuration -->
+  <scoreDirectorFactory>
+    <ksessionName>cloudBalancingKsession</ksessionName> <!-- Or delete this line and set a default ksession in kmodule.xml-->
+    <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
+  </scoreDirectorFactory>
+
+  <!-- Termination configuration -->
+  <termination>
+    <secondsSpentLimit>3</secondsSpentLimit>
+  </termination>
+</solver>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/resources/cloudbalance-realtime-planning-solver.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/resources/cloudbalance-realtime-planning-solver.xml
@@ -10,8 +10,9 @@
     <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
   </scoreDirectorFactory>
 
-  <!-- Optimization algorithms configuration -->
+  <!-- Termination configuration -->
   <termination>
     <secondsSpentLimit>5</secondsSpentLimit>
   </termination>
+
 </solver>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/resources/cloudbalance-solver.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/cloudbalance/src/main/resources/cloudbalance-solver.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solver>
+  <!-- Domain model configuration -->
+  <solutionClass>org.kie.server.testing.CloudBalance</solutionClass>
+  <entityClass>org.kie.server.testing.CloudProcess</entityClass>
+
+  <!-- Score configuration -->
+  <scoreDirectorFactory>
+    <ksessionName>cloudBalancingKsession</ksessionName> <!-- Or delete this line and set a default ksession in kmodule.xml-->
+    <initializingScoreTrend>ONLY_DOWN</initializingScoreTrend>
+  </scoreDirectorFactory>
+
+  <!-- Termination configuration -->
+  <termination>
+    <secondsSpentLimit>5</secondsSpentLimit>
+  </termination>
+</solver>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/OptaplannerIntegrationTest.java
@@ -15,21 +15,25 @@
 
 package org.kie.server.integrationtests.optaplanner;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.api.KieServices;
+import org.kie.server.api.exception.KieServicesException;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.ScoreWrapper;
 import org.kie.server.api.model.instance.SolverInstance;
 import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.KieServerReflections;
-import org.kie.server.api.exception.KieServicesException;
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
+import org.optaplanner.core.impl.solver.ProblemFactChange;
 
 import static org.junit.Assert.*;
 
@@ -44,11 +48,15 @@ public class OptaplannerIntegrationTest
     private static final String NOT_EXISTING_CONTAINER_ID = "no_container";
     private static final String CONTAINER_1_ID = "cloudbalance";
     private static final String SOLVER_1_ID = "cloudsolver";
-    private static final String SOLVER_1_CONFIG = "META-INF/cloudbalance-solver.xml";
+    private static final String SOLVER_1_CONFIG = "cloudbalance-solver.xml";
+    private static final String SOLVER_1_REALTIME_CONFIG = "cloudbalance-realtime-planning-solver.xml";
+    private static final String SOLVER_1_REALTIME_DAEMON_CONFIG = "cloudbalance-realtime-planning-daemon-solver.xml";
 
     private static final String CLASS_CLOUD_BALANCE = "org.kie.server.testing.CloudBalance";
     private static final String CLASS_CLOUD_COMPUTER = "org.kie.server.testing.CloudComputer";
     private static final String CLASS_CLOUD_PROCESS = "org.kie.server.testing.CloudProcess";
+    private static final String CLASS_ADD_COMPUTER_PROBLEM_FACT_CHANGE = "org.kie.server.testing.AddComputerProblemFactChange";
+    private static final String CLASS_DELETE_COMPUTER_PROBLEM_FACT_CHANGE = "org.kie.server.testing.DeleteComputerProblemFactChange";
     private static final String CLASS_CLOUD_GENERATOR = "org.kie.server.testing.CloudBalancingGenerator";
 
     @BeforeClass
@@ -76,6 +84,14 @@ public class OptaplannerIntegrationTest
                                        kieContainer.getClassLoader()));
         extraClasses.put(CLASS_CLOUD_PROCESS,
                          Class.forName(CLASS_CLOUD_PROCESS,
+                                       true,
+                                       kieContainer.getClassLoader()));
+        extraClasses.put(CLASS_ADD_COMPUTER_PROBLEM_FACT_CHANGE,
+                         Class.forName(CLASS_ADD_COMPUTER_PROBLEM_FACT_CHANGE,
+                                       true,
+                                       kieContainer.getClassLoader()));
+        extraClasses.put(CLASS_DELETE_COMPUTER_PROBLEM_FACT_CHANGE,
+                         Class.forName(CLASS_DELETE_COMPUTER_PROBLEM_FACT_CHANGE,
                                        true,
                                        kieContainer.getClassLoader()));
     }
@@ -263,6 +279,171 @@ public class OptaplannerIntegrationTest
                                    SOLVER_1_ID);
     }
 
+    @Test(timeout = 60_000)
+    public void testExecuteRealtimePlanningSolverSingleItemSubmit() throws Exception {
+        testExecuteRealtimePlanningSolverSingleItemSubmit(false);
+    }
+
+    @Test(timeout = 60_000)
+    public void testExecuteRealtimePlanningSolverSingleItemSubmitDaemonEnabled() throws Exception {
+        testExecuteRealtimePlanningSolverSingleItemSubmit(true);
+    }
+
+    private void testExecuteRealtimePlanningSolverSingleItemSubmit(boolean daemon) throws Exception {
+        SolverInstance solverInstance = solverClient.createSolver(CONTAINER_1_ID,
+                                                                  SOLVER_1_ID,
+                                                                  daemon ? SOLVER_1_REALTIME_DAEMON_CONFIG : SOLVER_1_REALTIME_CONFIG);
+        assertNotNull(solverInstance);
+        assertEquals(SolverInstance.SolverStatus.NOT_SOLVING,
+                     solverInstance.getStatus());
+
+        final int computerCount = 5;
+        final int numberOfComputersToAdd = 5;
+        final Object planningProblem = loadPlanningProblem(computerCount,
+                                                           15);
+        solverClient.solvePlanningProblem(CONTAINER_1_ID,
+                                          SOLVER_1_ID,
+                                          planningProblem);
+
+        SolverInstance solver = solverClient.getSolver(CONTAINER_1_ID,
+                                                       SOLVER_1_ID);
+        assertEquals(SolverInstance.SolverStatus.SOLVING,
+                     solver.getStatus());
+
+        Thread.sleep(3000);
+
+        List computerList = null;
+
+        for (int i = 0; i < numberOfComputersToAdd; i++) {
+            ProblemFactChange problemFactChange = loadAddProblemFactChange(computerCount + i);
+            solverClient.addProblemFactChange(CONTAINER_1_ID,
+                                              SOLVER_1_ID,
+                                              problemFactChange);
+
+            do {
+                final Object bestSolution = verifySolverAndGetBestSolution();
+                computerList = getCloudBalanceComputerList(bestSolution);
+            } while (computerCount + i + 1 != computerList.size());
+        }
+
+        assertTrue(solverClient.isEveryProblemFactChangeProcessed(CONTAINER_1_ID,
+                                                                  SOLVER_1_ID));
+
+        Thread.sleep(3000);
+
+        assertNotNull(computerList);
+
+        for (int i = 0; i < numberOfComputersToAdd; i++) {
+            ProblemFactChange problemFactChange = loadDeleteProblemFactChange(computerList.get(i));
+
+            solverClient.addProblemFactChange(CONTAINER_1_ID,
+                                              SOLVER_1_ID,
+                                              problemFactChange);
+
+            do {
+                final Object bestSolution = verifySolverAndGetBestSolution();
+                computerList = getCloudBalanceComputerList(bestSolution);
+            } while (computerCount + numberOfComputersToAdd - i - 1 != computerList.size());
+        }
+
+        assertTrue(solverClient.isEveryProblemFactChangeProcessed(CONTAINER_1_ID,
+                                                                  SOLVER_1_ID));
+
+        solverClient.disposeSolver(CONTAINER_1_ID,
+                                   SOLVER_1_ID);
+    }
+
+    @Test(timeout = 60_000)
+    public void testExecuteRealtimePlanningSolverBulkItemSubmit() throws Exception {
+        testExecuteRealtimePlanningSolverBulkItemSubmit(false);
+    }
+
+    @Test(timeout = 60_000)
+    public void testExecuteRealtimePlanningSolverBulkItemSubmitDaemonEnabled() throws Exception {
+        testExecuteRealtimePlanningSolverBulkItemSubmit(true);
+    }
+
+    private void testExecuteRealtimePlanningSolverBulkItemSubmit(boolean daemon) throws Exception {
+        SolverInstance solverInstance = solverClient.createSolver(CONTAINER_1_ID,
+                                                                  SOLVER_1_ID,
+                                                                  daemon ? SOLVER_1_REALTIME_DAEMON_CONFIG : SOLVER_1_REALTIME_CONFIG);
+        assertNotNull(solverInstance);
+        assertEquals(SolverInstance.SolverStatus.NOT_SOLVING,
+                     solverInstance.getStatus());
+
+        final int initialComputerCount = 5;
+        final int numberOfComputersToAdd = 5;
+        final Object planningProblem = loadPlanningProblem(initialComputerCount,
+                                                           15);
+        solverClient.solvePlanningProblem(CONTAINER_1_ID,
+                                          SOLVER_1_ID,
+                                          planningProblem);
+
+        SolverInstance solver = solverClient.getSolver(CONTAINER_1_ID,
+                                                       SOLVER_1_ID);
+        assertEquals(SolverInstance.SolverStatus.SOLVING,
+                     solver.getStatus());
+
+        Thread.sleep(3000);
+
+        List<ProblemFactChange> problemFactChangeList = new ArrayList<>(numberOfComputersToAdd);
+        for (int i = 0; i < numberOfComputersToAdd; i++) {
+            problemFactChangeList.add(loadAddProblemFactChange(initialComputerCount + i));
+        }
+        solverClient.addProblemFactChanges(CONTAINER_1_ID,
+                                           SOLVER_1_ID,
+                                           problemFactChangeList);
+
+        List computerList = null;
+        do {
+            final Object bestSolution = verifySolverAndGetBestSolution();
+            computerList = getCloudBalanceComputerList(bestSolution);
+        } while (initialComputerCount + numberOfComputersToAdd != computerList.size());
+
+        assertNotNull(computerList);
+        assertTrue(solverClient.isEveryProblemFactChangeProcessed(CONTAINER_1_ID,
+                                                                  SOLVER_1_ID));
+
+        Thread.sleep(3000);
+
+        problemFactChangeList.clear();
+        for (int i = 0; i < numberOfComputersToAdd; i++) {
+            problemFactChangeList.add(loadDeleteProblemFactChange(computerList.get(i)));
+        }
+
+        solverClient.addProblemFactChanges(CONTAINER_1_ID,
+                                           SOLVER_1_ID,
+                                           problemFactChangeList);
+
+        do {
+            final Object bestSolution = verifySolverAndGetBestSolution();
+            computerList = getCloudBalanceComputerList(bestSolution);
+        } while (initialComputerCount != computerList.size());
+
+        assertTrue(solverClient.isEveryProblemFactChangeProcessed(CONTAINER_1_ID,
+                                                                  SOLVER_1_ID));
+
+        solverClient.disposeSolver(CONTAINER_1_ID,
+                                   SOLVER_1_ID);
+    }
+
+    private Object verifySolverAndGetBestSolution() {
+        SolverInstance solver = solverClient.getSolverWithBestSolution(CONTAINER_1_ID,
+                                                                       SOLVER_1_ID);
+        assertEquals(SolverInstance.SolverStatus.SOLVING,
+                     solver.getStatus());
+
+        Object bestSolution = solver.getBestSolution();
+        assertEquals(bestSolution.getClass().getName(),
+                     CLASS_CLOUD_BALANCE);
+        return bestSolution;
+    }
+
+    private List getCloudBalanceComputerList(final Object cloudBalance) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method computerListMethod = cloudBalance.getClass().getDeclaredMethod("getComputerList");
+        return (List) computerListMethod.invoke(cloudBalance);
+    }
+
     @Test
     public void testExecuteRunningSolver() throws Exception {
         SolverInstance solverInstance = solverClient.createSolver(CONTAINER_1_ID,
@@ -429,22 +610,42 @@ public class OptaplannerIntegrationTest
     }
 
     public Object loadPlanningProblem(int computerListSize,
-                                      int processListSize) {
-        Object problem = null;
-        try {
-            Class<?> cbgc = kieContainer.getClassLoader().loadClass(CLASS_CLOUD_GENERATOR);
-            Object cbgi = cbgc.newInstance();
+                                      int processListSize) throws NoSuchMethodException, ClassNotFoundException,
+            IllegalAccessException, InstantiationException, InvocationTargetException {
+        Class<?> cbgc = kieContainer.getClassLoader().loadClass(CLASS_CLOUD_GENERATOR);
+        Object cbgi = cbgc.newInstance();
 
-            Method method = cbgc.getMethod("createCloudBalance",
-                                           int.class,
-                                           int.class);
-            problem = method.invoke(cbgi,
-                                    computerListSize,
-                                    processListSize);
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail("Exception trying to create cloud balance unsolved problem.");
-        }
-        return problem;
+        Method method = cbgc.getMethod("createCloudBalance",
+                                       int.class,
+                                       int.class);
+        return method.invoke(cbgi,
+                             computerListSize,
+                             processListSize);
+    }
+
+    private ProblemFactChange loadAddProblemFactChange(final int currentNumberOfComputers) throws ClassNotFoundException,
+            IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
+        Class<?> cbgc = kieContainer.getClassLoader().loadClass(CLASS_CLOUD_GENERATOR);
+        Object cbgi = cbgc.newInstance();
+
+        Method method = cbgc.getMethod("createCloudComputer",
+                                       int.class);
+        Object cloudComputer = method.invoke(cbgi,
+                                             currentNumberOfComputers);
+
+        Class<?> cloudComputerClass = kieContainer.getClassLoader().loadClass(CLASS_CLOUD_COMPUTER);
+        Class<?> problemFactChangeClass = kieContainer.getClassLoader().loadClass(CLASS_ADD_COMPUTER_PROBLEM_FACT_CHANGE);
+
+        Constructor constructor = problemFactChangeClass.getConstructor(cloudComputerClass);
+        return (ProblemFactChange) constructor.newInstance(cloudComputer);
+    }
+
+    private ProblemFactChange loadDeleteProblemFactChange(final Object cloudComputer) throws ClassNotFoundException,
+            NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        Class<?> cloudComputerClass = kieContainer.getClassLoader().loadClass(CLASS_CLOUD_COMPUTER);
+        Class<?> problemFactChangeClass = kieContainer.getClassLoader().loadClass(CLASS_DELETE_COMPUTER_PROBLEM_FACT_CHANGE);
+
+        Constructor constructor = problemFactChangeClass.getConstructor(cloudComputerClass);
+        return (ProblemFactChange) constructor.newInstance(cloudComputer);
     }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/jms/OptaPlannerJmsResponseHandlerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/jms/OptaPlannerJmsResponseHandlerIntegrationTest.java
@@ -54,12 +54,14 @@ public class OptaPlannerJmsResponseHandlerIntegrationTest extends OptaplannerKie
 
     private static final String CONTAINER_1_ID = "cloudbalance";
     private static final String SOLVER_1_ID = "cloudsolver";
-    private static final String SOLVER_1_CONFIG = "META-INF/cloudbalance-solver.xml";
+    private static final String SOLVER_1_CONFIG = "cloudbalance-solver.xml";
 
     private static final String CLASS_CLOUD_BALANCE = "org.kie.server.testing.CloudBalance";
     private static final String CLASS_CLOUD_COMPUTER = "org.kie.server.testing.CloudComputer";
     private static final String CLASS_CLOUD_PROCESS = "org.kie.server.testing.CloudProcess";
     private static final String CLASS_CLOUD_GENERATOR = "org.kie.server.testing.CloudBalancingGenerator";
+    private static final String CLASS_ADD_COMPUTER_PROBLEM_FACT_CHANGE = "org.kie.server.testing.AddComputerProblemFactChange";
+    private static final String CLASS_DELETE_COMPUTER_PROBLEM_FACT_CHANGE = "org.kie.server.testing.DeleteComputerProblemFactChange";
 
     @Parameterized.Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {
@@ -87,6 +89,8 @@ public class OptaPlannerJmsResponseHandlerIntegrationTest extends OptaplannerKie
         extraClasses.put(CLASS_CLOUD_BALANCE, Class.forName(CLASS_CLOUD_BALANCE, true, kieContainer.getClassLoader()));
         extraClasses.put(CLASS_CLOUD_COMPUTER, Class.forName(CLASS_CLOUD_COMPUTER, true, kieContainer.getClassLoader()));
         extraClasses.put(CLASS_CLOUD_PROCESS, Class.forName(CLASS_CLOUD_PROCESS, true, kieContainer.getClassLoader()));
+        extraClasses.put(CLASS_ADD_COMPUTER_PROBLEM_FACT_CHANGE, Class.forName(CLASS_ADD_COMPUTER_PROBLEM_FACT_CHANGE, true, kieContainer.getClassLoader()));
+        extraClasses.put(CLASS_DELETE_COMPUTER_PROBLEM_FACT_CHANGE, Class.forName(CLASS_DELETE_COMPUTER_PROBLEM_FACT_CHANGE, true, kieContainer.getClassLoader()));
     }
 
     @Test


### PR DESCRIPTION
@ge0ffrey First implementation of real-time planning on the ES side.

From https://issues.jboss.org/browse/PLANNER-815:
The problem fact changes will be registered by sending POST request to solverId/problemfactchanged with the following payload:

XSTREAM:
```
<org.kie.server.testing.AddComputerProblemFactChange>
  <computer>
    <id>5</id>
    <cpuPower>3</cpuPower>
    <memory>4</memory>
    <networkBandwidth>2</networkBandwidth>
    <cost>390</cost>
  </computer>
</org.kie.server.testing.AddComputerProblemFactChange>
```

where AddComputerProblemFactChange is a ProblemFactChange implementation (taken from optaplanner-examples with slight modifications). See JIRA for more details.