### PR TITLE
JBPM-6073 getComments method not returning desired page

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/CaseServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/CaseServicesClientImpl.java
@@ -647,6 +647,7 @@ public class CaseServicesClientImpl extends AbstractKieServicesClientImpl implem
             valuesMap.put(CASE_ID, caseId);
 
             String queryString = getPagingQueryString("", page, pageSize);
+
             list = makeHttpGetRequestAndCreateCustomResponse(
                     build(loadBalancer.getUrl(), CASE_URI + "/" + CASE_COMMENTS_GET_URI, valuesMap) + queryString, CaseCommentList.class);
 
@@ -660,11 +661,12 @@ public class CaseServicesClientImpl extends AbstractKieServicesClientImpl implem
             if (shouldReturnWithNullResponse(response)) {
                 return null;
             }
+            
             list = response.getResult();
         }
 
-        if (list != null) {
-            return list.getItems();
+        if (list != null) {       	
+            return internalGetPaginatedCaseComments(list, page, pageSize);
         }
 
         return Collections.emptyList();
@@ -1333,6 +1335,23 @@ public class CaseServicesClientImpl extends AbstractKieServicesClientImpl implem
     /*
      * internal methods
      */
+    
+    protected List<CaseComment> internalGetPaginatedCaseComments(CaseCommentList caseComments, int page, int pageSize) {
+    	
+    	int allCommentsSize = caseComments.getItems().size();    	    	
+    	int pageIndex = (allCommentsSize + pageSize - 1) / pageSize;
+    	
+    	if (allCommentsSize < pageSize) {
+    		return caseComments.getItems();
+    	}    	
+    	else if (pageIndex == page + 1) {
+    		return caseComments.getItems().subList(page * pageSize, allCommentsSize);
+    	}
+    	else {
+    	    return caseComments.getItems().subList(page * pageSize, (page * pageSize) + pageSize);
+    	}
+    	
+    }
 
     protected List<CaseFileDataItem> internalGetCaseInstanceDataItems(String caseId, List<String> names, List<String> types, Integer page, Integer pageSize) {
         CaseFileDataItemList list = null;

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseRuntimeDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseRuntimeDataServiceIntegrationTest.java
@@ -967,6 +967,41 @@ public class CaseRuntimeDataServiceIntegrationTest extends JbpmKieServerBaseInte
         assertNotNull(instances);
         assertEquals(2, instances.size());
     }
+    
+    @Test
+    public void testGetCommentPagination() {
+    	
+    	int pageSize = 20;
+    	
+        String caseId = startUserTaskCase(USER_YODA, USER_JOHN);
+        assertNotNull(caseId);
+        assertTrue(caseId.startsWith(CASE_HR_ID_PREFIX));
+    	
+        for (int i = 0 ; i < 55 ; i++) {
+            caseClient.addComment(CONTAINER_ID, caseId, USER_YODA, "comment" + i);
+        }
+        
+        List<CaseComment> firstPage = caseClient.getComments(CONTAINER_ID, caseId, 0, pageSize);
+        assertNotNull(firstPage);
+        assertEquals(20, firstPage.size());
+        for (int i = 0; i < 20 ; i++) {
+        	assertEquals("comment" + i, firstPage.get(i).getText());
+        }
+        
+        List<CaseComment> secondPage = caseClient.getComments(CONTAINER_ID, caseId, 1, pageSize);
+        assertNotNull(secondPage);
+        assertEquals(20, secondPage.size());
+        for (int i = 20; i < 40 ; i++) {
+        	assertEquals("comment" + i, secondPage.get(i-20).getText());
+        }
+        
+        List<CaseComment> thirdPage = caseClient.getComments(CONTAINER_ID, caseId, 2, pageSize);
+        assertNotNull(thirdPage);
+        assertEquals(15, thirdPage.size());
+        for (int i = 40; i < 55 ; i++) {
+        	assertEquals("comment" + i, thirdPage.get(i-40).getText());
+        }
+    }
 
     @Test
     public void testCreateCaseWithCaseFileWithComments() {


### PR DESCRIPTION
During REST call, getComments was returning all comment results instead of only the desired page.  See JIRA here for reproduction and more info: https://issues.jboss.org/browse/JBPM-6073