### PR TITLE
Do not keep folders with Karaf containers in target folder.

### DIFF
--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/InstallFeaturesAbstractKarafIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/InstallFeaturesAbstractKarafIntegrationTest.java
@@ -79,9 +79,6 @@ public class InstallFeaturesAbstractKarafIntegrationTest extends AbstractKarafIn
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/KieSpringDependencyKarafIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/KieSpringDependencyKarafIntegrationTest.java
@@ -61,9 +61,6 @@ public class KieSpringDependencyKarafIntegrationTest extends AbstractKarafIntegr
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/KieSpringOnKarafKarafIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/KieSpringOnKarafKarafIntegrationTest.java
@@ -73,9 +73,6 @@ public class KieSpringOnKarafKarafIntegrationTest extends AbstractKieSpringKaraf
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/KieSpringjBPMPersistenceOnKarafKarafIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/KieSpringjBPMPersistenceOnKarafKarafIntegrationTest.java
@@ -175,9 +175,6 @@ public class KieSpringjBPMPersistenceOnKarafKarafIntegrationTest extends Abstrac
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/RuntimeManagerFeatureKarafIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/RuntimeManagerFeatureKarafIntegrationTest.java
@@ -61,9 +61,6 @@ public class RuntimeManagerFeatureKarafIntegrationTest extends AbstractKarafInte
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/WorkbenchModelsKarafIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/WorkbenchModelsKarafIntegrationTest.java
@@ -81,10 +81,6 @@ public class WorkbenchModelsKarafIntegrationTest extends AbstractKarafIntegratio
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/blueprint/KieBlueprintDependencyKarafIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/blueprint/KieBlueprintDependencyKarafIntegrationTest.java
@@ -60,9 +60,6 @@ public class KieBlueprintDependencyKarafIntegrationTest extends AbstractKarafInt
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/blueprint/KieBlueprintImportIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/blueprint/KieBlueprintImportIntegrationTest.java
@@ -97,9 +97,6 @@ public class KieBlueprintImportIntegrationTest extends AbstractKarafIntegrationT
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/blueprint/KieBlueprintProcessDependencyKarafIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/blueprint/KieBlueprintProcessDependencyKarafIntegrationTest.java
@@ -74,9 +74,6 @@ public class KieBlueprintProcessDependencyKarafIntegrationTest extends AbstractK
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/blueprint/KieBlueprintScannerReimportIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/blueprint/KieBlueprintScannerReimportIntegrationTest.java
@@ -137,9 +137,6 @@ public class KieBlueprintScannerReimportIntegrationTest extends AbstractKarafInt
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/blueprint/KieBlueprintjBPMPersistenceKarafIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/blueprint/KieBlueprintjBPMPersistenceKarafIntegrationTest.java
@@ -88,9 +88,6 @@ public class KieBlueprintjBPMPersistenceKarafIntegrationTest extends AbstractKar
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/kieserver/BaseKieServerClientOnKarafIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/kieserver/BaseKieServerClientOnKarafIntegrationTest.java
@@ -160,9 +160,6 @@ public class BaseKieServerClientOnKarafIntegrationTest extends AbstractKarafInte
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/kieserver/KieServerClientKarafIntegrationJaxbIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/kieserver/KieServerClientKarafIntegrationJaxbIntegrationTest.java
@@ -65,9 +65,6 @@ public class KieServerClientKarafIntegrationJaxbIntegrationTest extends BaseKieS
                 // Install Karaf Container
                 AbstractKarafIntegrationTest.getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/kieserver/KieServerClientKarafIntegrationJsonIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/kieserver/KieServerClientKarafIntegrationJsonIntegrationTest.java
@@ -65,9 +65,6 @@ public class KieServerClientKarafIntegrationJsonIntegrationTest extends BaseKieS
                 // Install Karaf Container
                 AbstractKarafIntegrationTest.getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/kieserver/KieServerClientKarafIntegrationXstreamIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/kieserver/KieServerClientKarafIntegrationXstreamIntegrationTest.java
@@ -66,9 +66,6 @@ public class KieServerClientKarafIntegrationXstreamIntegrationTest extends BaseK
                 // Install Karaf Container
                 AbstractKarafIntegrationTest.getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/remoteclient/BaseRemoteClientOnKarafIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/remoteclient/BaseRemoteClientOnKarafIntegrationTest.java
@@ -52,9 +52,6 @@ public class BaseRemoteClientOnKarafIntegrationTest extends AbstractKarafIntegra
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/remoteclient/RemoteClientKarafIntegrationJaxbIntegrationTest.java
+++ b/drools-osgi/drools-karaf-itests/src/test/java/org/drools/karaf/itest/remoteclient/RemoteClientKarafIntegrationJaxbIntegrationTest.java
@@ -74,9 +74,6 @@ public class RemoteClientKarafIntegrationJaxbIntegrationTest extends BaseRemoteC
                 // Install Karaf Container
                 AbstractKarafIntegrationTest.getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.


### PR DESCRIPTION
Folder with containers may grow quite fast in pax-exam folder (few gigabytes). It is not good to keep these folders in default build. This commit disables keeping these folders. It is possible to keep folders using karaf.keep.runtime.folder property. See more details in README in karaf-itests folder.
