### PR TITLE
Advanced search integration tests fixes

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/ProcessSearchServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/ProcessSearchServiceIntegrationTest.java
@@ -27,9 +27,7 @@ import org.kie.server.api.model.definition.ProcessInstanceField;
 import org.kie.server.api.model.definition.ProcessInstanceQueryFilterSpec;
 import org.kie.server.api.util.ProcessInstanceQueryFilterSpecBuilder;
 
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -71,19 +69,20 @@ public class ProcessSearchServiceIntegrationTest extends JbpmQueriesKieServerBas
     }
 
     @Test
-    public void testFindProcessInstanceWithProcessInstanceIdGreaterThanFilter() throws Exception {
+    public void testFindProcessInstanceWithProcessInstanceIdEqualsToFilter() throws Exception {
         Map<String, Object> parameters = new HashMap<>();
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_EVALUATION, parameters);
         Assertions.assertThat(processInstanceId).isNotNull();
-        testFindProcessInstanceWithQueryFilter(createQueryFilterGreaterThan(ProcessInstanceField.PROCESSINSTANCEID, 0), processInstanceId);
+        testFindProcessInstanceWithQueryFilter(createQueryFilterEqualsTo(ProcessInstanceField.PROCESSINSTANCEID, processInstanceId), processInstanceId);
     }
 
     @Test
-    public void testFindProcessInstanceWithStartDateGreaterThanFilter() throws Exception {
+    public void testFindProcessInstanceWithStartDateEqualsToFilter() throws Exception {
         Map<String, Object> parameters = new HashMap<>();
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_EVALUATION, parameters);
         Assertions.assertThat(processInstanceId).isNotNull();
-        testFindProcessInstanceWithQueryFilter(createQueryFilterGreaterThan(ProcessInstanceField.START_DATE, Date.from(Instant.EPOCH)), processInstanceId);
+        ProcessInstance pi = processClient.getProcessInstance(CONTAINER_ID, processInstanceId);
+        testFindProcessInstanceWithQueryFilter(createQueryFilterEqualsTo(ProcessInstanceField.START_DATE, pi.getDate()), processInstanceId);
     }
 
     @Test

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/ProcessSearchServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/ProcessSearchServiceIntegrationTest.java
@@ -87,11 +87,11 @@ public class ProcessSearchServiceIntegrationTest extends JbpmQueriesKieServerBas
     }
 
     @Test
-    public void testFindProcessInstanceWithCorrelationKeyGreaterThanFilter() throws Exception {
+    public void testFindProcessInstanceWithCorrelationKeyEqualsToFilter() throws Exception {
        Map<String, Object> parameters = new HashMap<>();
        Long processInstanceId  = processClient.startProcess(CONTAINER_ID, PROCESS_ID_EVALUATION, parameters);
-        Assertions.assertThat(processInstanceId).isNotNull();
-        testFindProcessInstanceWithQueryFilter(createQueryFilterEqualsTo(ProcessInstanceField.CORRELATIONKEY, processInstanceId), processInstanceId);
+       Assertions.assertThat(processInstanceId).isNotNull();
+       testFindProcessInstanceWithQueryFilter(createQueryFilterEqualsTo(ProcessInstanceField.CORRELATIONKEY, String.valueOf(processInstanceId)), processInstanceId);
     }
 
     @Test

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/TaskSearchServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/TaskSearchServiceIntegrationTest.java
@@ -27,8 +27,6 @@ import org.kie.server.api.model.definition.TaskField;
 import org.kie.server.api.model.definition.TaskQueryFilterSpec;
 import org.kie.server.api.util.TaskQueryFilterSpecBuilder;
 
-import java.util.Date;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -70,7 +68,7 @@ public class TaskSearchServiceIntegrationTest extends JbpmQueriesKieServerBaseIn
         List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
         Assertions.assertThat(tasks).isNotEmpty();
         TaskSummary task = tasks.get(0);
-        testFindTaskInstanceWithSearchService(createQueryFilterGreaterThan(TaskField.CREATEDON, Date.from(Instant.EPOCH)), task.getId());
+        testFindTaskInstanceWithSearchService(createQueryFilterEqualsTo(TaskField.CREATEDON, task.getCreatedOn()), task.getId());
     }
 
     @Test
@@ -184,14 +182,14 @@ public class TaskSearchServiceIntegrationTest extends JbpmQueriesKieServerBaseIn
     }
 
     @Test
-    public void testFindTaskWithActivationTimeGreaterThanFilter() throws Exception {
+    public void testFindTaskWithActivationTimeEqualsToFilter() throws Exception {
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         Assertions.assertThat(processInstanceId).isNotNull();
 
         List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
         Assertions.assertThat(tasks).isNotEmpty();
         TaskSummary task = tasks.get(0);
-        testFindTaskInstanceWithSearchService(createQueryFilterGreaterThan(TaskField.ACTIVATIONTIME, Date.from(Instant.EPOCH)), task.getId());
+        testFindTaskInstanceWithSearchService(createQueryFilterEqualsTo(TaskField.ACTIVATIONTIME, task.getActivationTime()), task.getId());
     }
 
     @Test


### PR DESCRIPTION
Contains fixes for issues revealed while testing different databases.

Makes tests send correlation key as string.
_Note: This seems to happen only on postgresql and other databases seem to handle correlation key even when sent as number, without 500 error being returned_

Updates tests using date in filter to use equalsTo rather than greaterThan
filter, since they tend to return more results and desired instance wouldn't get in the result.