### PR TITLE
Do not keep folders with Karaf container in target folder.

### DIFF
--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/DecisionTablesIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/DecisionTablesIntegrationTest.java
@@ -76,9 +76,6 @@ public class DecisionTablesIntegrationTest extends AbstractKarafIntegrationTest 
                 getKarafDistributionOption(),
 
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/InstallFeaturesKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/InstallFeaturesKarafIntegrationTest.java
@@ -80,9 +80,6 @@ public class InstallFeaturesKarafIntegrationTest extends AbstractKarafIntegratio
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieDMNKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieDMNKarafIntegrationTest.java
@@ -78,10 +78,6 @@ public class KieDMNKarafIntegrationTest extends AbstractKarafIntegrationTest {
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieSpringDependencyKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieSpringDependencyKarafIntegrationTest.java
@@ -61,9 +61,6 @@ public class KieSpringDependencyKarafIntegrationTest extends AbstractKarafIntegr
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieSpringMetaInfAppContextKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieSpringMetaInfAppContextKarafIntegrationTest.java
@@ -56,9 +56,6 @@ public class KieSpringMetaInfAppContextKarafIntegrationTest extends AbstractKara
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieSpringjBPMPersistenceKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieSpringjBPMPersistenceKarafIntegrationTest.java
@@ -176,9 +176,6 @@ public class KieSpringjBPMPersistenceKarafIntegrationTest extends AbstractKieSpr
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/RuntimeManagerFeatureKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/RuntimeManagerFeatureKarafIntegrationTest.java
@@ -61,9 +61,6 @@ public class RuntimeManagerFeatureKarafIntegrationTest extends AbstractKarafInte
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/SimpleKieSpringKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/SimpleKieSpringKarafIntegrationTest.java
@@ -73,9 +73,6 @@ public class SimpleKieSpringKarafIntegrationTest extends AbstractKieSpringKarafI
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/WorkbenchModelsKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/WorkbenchModelsKarafIntegrationTest.java
@@ -82,10 +82,6 @@ public class WorkbenchModelsKarafIntegrationTest extends AbstractKarafIntegratio
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/blueprint/KieBlueprintDependencyKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/blueprint/KieBlueprintDependencyKarafIntegrationTest.java
@@ -60,9 +60,6 @@ public class KieBlueprintDependencyKarafIntegrationTest extends AbstractKarafInt
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/blueprint/KieBlueprintImportIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/blueprint/KieBlueprintImportIntegrationTest.java
@@ -97,9 +97,6 @@ public class KieBlueprintImportIntegrationTest extends AbstractKarafIntegrationT
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/blueprint/KieBlueprintProcessDependencyKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/blueprint/KieBlueprintProcessDependencyKarafIntegrationTest.java
@@ -74,9 +74,6 @@ public class KieBlueprintProcessDependencyKarafIntegrationTest extends AbstractK
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/blueprint/KieBlueprintScannerReimportIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/blueprint/KieBlueprintScannerReimportIntegrationTest.java
@@ -135,9 +135,6 @@ public class KieBlueprintScannerReimportIntegrationTest extends AbstractKarafInt
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/blueprint/KieBlueprintjBPMPersistenceKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/blueprint/KieBlueprintjBPMPersistenceKarafIntegrationTest.java
@@ -89,9 +89,6 @@ public class KieBlueprintjBPMPersistenceKarafIntegrationTest extends AbstractKar
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/BaseKieServerClientKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/BaseKieServerClientKarafIntegrationTest.java
@@ -161,9 +161,6 @@ public class BaseKieServerClientKarafIntegrationTest extends AbstractKarafIntegr
                 // Install Karaf Container
                 getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/KieServerClientKarafIntegrationJaxbIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/KieServerClientKarafIntegrationJaxbIntegrationTest.java
@@ -65,9 +65,6 @@ public class KieServerClientKarafIntegrationJaxbIntegrationTest extends BaseKieS
                 // Install Karaf Container
                 AbstractKarafIntegrationTest.getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/KieServerClientKarafIntegrationJsonIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/KieServerClientKarafIntegrationJsonIntegrationTest.java
@@ -65,9 +65,6 @@ public class KieServerClientKarafIntegrationJsonIntegrationTest extends BaseKieS
                 // Install Karaf Container
                 AbstractKarafIntegrationTest.getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/KieServerClientKarafIntegrationXstreamIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/KieServerClientKarafIntegrationXstreamIntegrationTest.java
@@ -66,9 +66,6 @@ public class KieServerClientKarafIntegrationXstreamIntegrationTest extends BaseK
                 // Install Karaf Container
                 AbstractKarafIntegrationTest.getKarafDistributionOption(),
 
-                // It is really nice if the container sticks around after the test so you can check the contents
-                // of the data directory when things go wrong.
-                keepRuntimeFolder(),
                 // Don't bother with local console output as it just ends up cluttering the logs
                 configureConsole().ignoreLocalConsole(),
                 // Force the log level to INFO so we have more details during the test.  It defaults to WARN.


### PR DESCRIPTION
Folder with containers may grow quite fast in pax-exam folder (few gigabytes). It is not good to keep these folders in default build. This commit disables keeping these folders. It is possible to keep folders using karaf.keep.runtime.folder property. See more details in README in karaf-itests folder.