### PR TITLE
JBPM-6125 - Move KIE Server on Tomcat to use Narayana as Transaction …

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-search/src/main/java/org/kie/server/services/jbpm/search/JbpmSearchKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-search/src/main/java/org/kie/server/services/jbpm/search/JbpmSearchKieServerExtension.java
@@ -105,6 +105,9 @@ public class JbpmSearchKieServerExtension implements KieServerExtension {
         ServiceLoader<KieServerApplicationComponentsService> appComponentsServices
                 = ServiceLoader.load( KieServerApplicationComponentsService.class );
         List<Object> appComponentsList = new ArrayList<Object>();
+        if (!initialized) {
+            return appComponentsList;
+        }
         Object[] services = {queryService, context};
         for ( KieServerApplicationComponentsService appComponentsService : appComponentsServices ) {
             appComponentsList.addAll( appComponentsService.getAppComponents( EXTENSION_NAME, type, services ) );
@@ -114,6 +117,9 @@ public class JbpmSearchKieServerExtension implements KieServerExtension {
 
     @Override
     public <T> T getAppComponents(Class<T> serviceType) {
+        if (!initialized) {
+            return null;
+        }
         if ( serviceType.isAssignableFrom( queryService.getClass() ) ) {
             return (T) queryService;
         }

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-search/src/test/java/org/kie/server/services/jbpm/search/JbpmSearchKieServerExtensionTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-search/src/test/java/org/kie/server/services/jbpm/search/JbpmSearchKieServerExtensionTest.java
@@ -40,12 +40,15 @@ public class JbpmSearchKieServerExtensionTest {
 	
 		Field contextField = kieServerExtension.getClass().getDeclaredField("context");
 		Field queryServiceField = kieServerExtension.getClass().getDeclaredField("queryService");
+		Field initializedField = kieServerExtension.getClass().getDeclaredField("initialized");
 		
 		contextField.setAccessible(true);
 		queryServiceField.setAccessible(true);
+		initializedField.setAccessible(true);
 		
 		contextField.set(kieServerExtension, Mockito.mock(KieServerRegistry.class));
 		queryServiceField.set(kieServerExtension, Mockito.mock(QueryService.class));
+		initializedField.set(kieServerExtension, true);
 		
 		List<Object> appComponents = kieServerExtension.getAppComponents(SupportedTransports.REST);
 		

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
@@ -313,11 +313,14 @@
               <groupId>org.codehaus.cargo</groupId>
               <artifactId>cargo-maven2-plugin</artifactId>
               <configuration>
-                <container>
-                  <systemProperties combine.self="append">
-                    <bitronix.tm.configuration>${project.build.testOutputDirectory}/btm-config.properties</bitronix.tm.configuration>
-                  </systemProperties>
-                </container>
+                <configuration>
+                  <configfiles>
+                    <configfile>
+                      <file>${project.basedir}/src/test/config/context.xml</file>
+                      <todir>/conf</todir>
+                    </configfile>
+                  </configfiles>
+                </configuration>
               </configuration>
             </plugin>
           </plugins>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/config/context.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/config/context.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- The contents of this file will be loaded for each web application -->
+<Context>
+
+    <!-- Default set of monitored resources. If one of these changes, the    -->
+    <!-- web application will be reloaded.                                   -->
+    <WatchedResource>WEB-INF/web.xml</WatchedResource>
+    <WatchedResource>${catalina.base}/conf/web.xml</WatchedResource>
+
+    <!-- Uncomment this to disable session persistence across Tomcat restarts -->
+    <!--
+    <Manager pathname="" />
+    -->
+
+    <!-- Uncomment this to enable Comet connection tacking (provides events
+         on session expiration as well as webapp lifecycle) -->
+    <!--
+    <Valve className="org.apache.catalina.valves.CometConnectionManagerValve" />
+    -->
+    
+    <Resource name="sharedDataSource"
+       		  auth="Container"
+       		  type="org.h2.jdbcx.JdbcDataSource"
+       		  user="sa"
+              password="sa"
+              url="jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MVCC=TRUE"
+              description="H2 Data Source"
+              loginTimeout="0"
+              testOnBorrow="false"
+              factory="org.h2.jdbcx.JdbcDataSourceFactory"/>
+</Context>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/btm-config.properties
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/btm-config.properties
@@ -1,4 +1,0 @@
-bitronix.tm.serverId=tomcat-btm-node0
-bitronix.tm.journal.disk.logPart1Filename=${tmp.directory}/btm1.tlog
-bitronix.tm.journal.disk.logPart2Filename=${tmp.directory}/btm2.tlog
-bitronix.tm.resource.configuration=${conf.directory}/btm-resources.properties

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/btm-resources.properties
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/btm-resources.properties
@@ -1,9 +1,0 @@
-resource.ds1.className=bitronix.tm.resource.jdbc.lrc.LrcXADataSource
-resource.ds1.uniqueName=jdbc/jbpm
-resource.ds1.minPoolSize=10
-resource.ds1.maxPoolSize=20
-resource.ds1.driverProperties.driverClassName=org.h2.Driver
-resource.ds1.driverProperties.url=jdbc:h2:mem:test-db
-resource.ds1.driverProperties.user=sa
-resource.ds1.driverProperties.password=
-resource.ds1.allowLocalTransactions=true

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-case-id-generator/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-case-id-generator/pom.xml
@@ -199,11 +199,14 @@
               <groupId>org.codehaus.cargo</groupId>
               <artifactId>cargo-maven2-plugin</artifactId>
               <configuration>
-                <container>
-                  <systemProperties combine.self="append">
-                    <bitronix.tm.configuration>${project.build.testOutputDirectory}/btm-config.properties</bitronix.tm.configuration>
-                  </systemProperties>
-                </container>
+                <configuration>
+                  <configfiles>
+                    <configfile>
+                      <file>${project.basedir}/src/test/config/context.xml</file>
+                      <todir>/conf</todir>
+                    </configfile>
+                  </configfiles>
+                </configuration>
               </configuration>
             </plugin>
           </plugins>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-case-id-generator/src/test/config/context.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-case-id-generator/src/test/config/context.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- The contents of this file will be loaded for each web application -->
+<Context>
+
+    <!-- Default set of monitored resources. If one of these changes, the    -->
+    <!-- web application will be reloaded.                                   -->
+    <WatchedResource>WEB-INF/web.xml</WatchedResource>
+    <WatchedResource>${catalina.base}/conf/web.xml</WatchedResource>
+
+    <!-- Uncomment this to disable session persistence across Tomcat restarts -->
+    <!--
+    <Manager pathname="" />
+    -->
+
+    <!-- Uncomment this to enable Comet connection tacking (provides events
+         on session expiration as well as webapp lifecycle) -->
+    <!--
+    <Valve className="org.apache.catalina.valves.CometConnectionManagerValve" />
+    -->
+    
+    <Resource name="sharedDataSource"
+       		  auth="Container"
+       		  type="org.h2.jdbcx.JdbcDataSource"
+       		  user="sa"
+              password="sa"
+              url="jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MVCC=TRUE"
+              description="H2 Data Source"
+              loginTimeout="0"
+              testOnBorrow="false"
+              factory="org.h2.jdbcx.JdbcDataSourceFactory"/>
+</Context>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/pom.xml
@@ -58,6 +58,11 @@
       <artifactId>kie-server-services-jbpm-search</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-case-mgmt-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.kie.server</groupId>
@@ -310,11 +315,14 @@
               <groupId>org.codehaus.cargo</groupId>
               <artifactId>cargo-maven2-plugin</artifactId>
               <configuration>
-                <container>
-                  <systemProperties combine.self="append">
-                    <bitronix.tm.configuration>${project.build.testOutputDirectory}/btm-config.properties</bitronix.tm.configuration>
-                  </systemProperties>
-                </container>
+                <configuration>
+                  <configfiles>
+                    <configfile>
+                      <file>${project.basedir}/src/test/config/context.xml</file>
+                      <todir>/conf</todir>
+                    </configfile>
+                  </configfiles>
+                </configuration>
               </configuration>
             </plugin>
           </plugins>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/config/context.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/config/context.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- The contents of this file will be loaded for each web application -->
+<Context>
+
+    <!-- Default set of monitored resources. If one of these changes, the    -->
+    <!-- web application will be reloaded.                                   -->
+    <WatchedResource>WEB-INF/web.xml</WatchedResource>
+    <WatchedResource>${catalina.base}/conf/web.xml</WatchedResource>
+
+    <!-- Uncomment this to disable session persistence across Tomcat restarts -->
+    <!--
+    <Manager pathname="" />
+    -->
+
+    <!-- Uncomment this to enable Comet connection tacking (provides events
+         on session expiration as well as webapp lifecycle) -->
+    <!--
+    <Valve className="org.apache.catalina.valves.CometConnectionManagerValve" />
+    -->
+    
+    <Resource name="sharedDataSource"
+       		  auth="Container"
+       		  type="org.h2.jdbcx.JdbcDataSource"
+       		  user="sa"
+              password="sa"
+              url="jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MVCC=TRUE"
+              description="H2 Data Source"
+              loginTimeout="0"
+              testOnBorrow="false"
+              factory="org.h2.jdbcx.JdbcDataSourceFactory"/>
+</Context>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
@@ -326,11 +326,14 @@
               <groupId>org.codehaus.cargo</groupId>
               <artifactId>cargo-maven2-plugin</artifactId>
               <configuration>
-                <container>
-                  <systemProperties combine.self="append">
-                    <bitronix.tm.configuration>${project.build.testOutputDirectory}/btm-config.properties</bitronix.tm.configuration>
-                  </systemProperties>
-                </container>
+                <configuration>
+                  <configfiles>
+                    <configfile>
+                      <file>${project.basedir}/src/test/config/context.xml</file>
+                      <todir>/conf</todir>
+                    </configfile>
+                  </configfiles>
+                </configuration>
               </configuration>
             </plugin>
           </plugins>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/config/context.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/config/context.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- The contents of this file will be loaded for each web application -->
+<Context>
+
+    <!-- Default set of monitored resources. If one of these changes, the    -->
+    <!-- web application will be reloaded.                                   -->
+    <WatchedResource>WEB-INF/web.xml</WatchedResource>
+    <WatchedResource>${catalina.base}/conf/web.xml</WatchedResource>
+
+    <!-- Uncomment this to disable session persistence across Tomcat restarts -->
+    <!--
+    <Manager pathname="" />
+    -->
+
+    <!-- Uncomment this to enable Comet connection tacking (provides events
+         on session expiration as well as webapp lifecycle) -->
+    <!--
+    <Valve className="org.apache.catalina.valves.CometConnectionManagerValve" />
+    -->
+    
+    <Resource name="sharedDataSource"
+       		  auth="Container"
+       		  type="org.h2.jdbcx.JdbcDataSource"
+       		  user="sa"
+              password="sa"
+              url="jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MVCC=TRUE"
+              description="H2 Data Source"
+              loginTimeout="0"
+              testOnBorrow="false"
+              factory="org.h2.jdbcx.JdbcDataSourceFactory"/>
+</Context>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/btm-config.properties
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/btm-config.properties
@@ -1,4 +1,0 @@
-bitronix.tm.serverId=tomcat-btm-node0
-bitronix.tm.journal.disk.logPart1Filename=${tmp.directory}/btm1.tlog
-bitronix.tm.journal.disk.logPart2Filename=${tmp.directory}/btm2.tlog
-bitronix.tm.resource.configuration=${conf.directory}/btm-resources.properties

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/btm-resources.properties
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/btm-resources.properties
@@ -1,9 +1,0 @@
-resource.ds1.className=bitronix.tm.resource.jdbc.lrc.LrcXADataSource
-resource.ds1.uniqueName=jdbc/jbpm
-resource.ds1.minPoolSize=10
-resource.ds1.maxPoolSize=20
-resource.ds1.driverProperties.driverClassName=org.h2.Driver
-resource.ds1.driverProperties.url=jdbc:h2:mem:test-db
-resource.ds1.driverProperties.user=sa
-resource.ds1.driverProperties.password=
-resource.ds1.allowLocalTransactions=true

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/pom.xml
@@ -303,11 +303,14 @@
               <groupId>org.codehaus.cargo</groupId>
               <artifactId>cargo-maven2-plugin</artifactId>
               <configuration>
-                <container>
-                  <systemProperties combine.self="append">
-                    <bitronix.tm.configuration>${project.build.testOutputDirectory}/btm-config.properties</bitronix.tm.configuration>
-                  </systemProperties>
-                </container>
+                <configuration>
+                  <configfiles>
+                    <configfile>
+                      <file>${project.basedir}/src/test/config/context.xml</file>
+                      <todir>/conf</todir>
+                    </configfile>
+                  </configfiles>
+                </configuration>
               </configuration>
             </plugin>
           </plugins>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/src/test/config/context.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/src/test/config/context.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- The contents of this file will be loaded for each web application -->
+<Context>
+
+    <!-- Default set of monitored resources. If one of these changes, the    -->
+    <!-- web application will be reloaded.                                   -->
+    <WatchedResource>WEB-INF/web.xml</WatchedResource>
+    <WatchedResource>${catalina.base}/conf/web.xml</WatchedResource>
+
+    <!-- Uncomment this to disable session persistence across Tomcat restarts -->
+    <!--
+    <Manager pathname="" />
+    -->
+
+    <!-- Uncomment this to enable Comet connection tacking (provides events
+         on session expiration as well as webapp lifecycle) -->
+    <!--
+    <Valve className="org.apache.catalina.valves.CometConnectionManagerValve" />
+    -->
+    
+    <Resource name="sharedDataSource"
+       		  auth="Container"
+       		  type="org.h2.jdbcx.JdbcDataSource"
+       		  user="sa"
+              password="sa"
+              url="jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MVCC=TRUE"
+              description="H2 Data Source"
+              loginTimeout="0"
+              testOnBorrow="false"
+              factory="org.h2.jdbcx.JdbcDataSourceFactory"/>
+</Context>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/pom.xml
@@ -314,11 +314,14 @@
               <groupId>org.codehaus.cargo</groupId>
               <artifactId>cargo-maven2-plugin</artifactId>
               <configuration>
-                <container>
-                  <systemProperties combine.self="append">
-                    <bitronix.tm.configuration>${project.build.testOutputDirectory}/btm-config.properties</bitronix.tm.configuration>
-                  </systemProperties>
-                </container>
+                <configuration>
+                  <configfiles>
+                    <configfile>
+                      <file>${project.basedir}/src/test/config/context.xml</file>
+                      <todir>/conf</todir>
+                    </configfile>
+                  </configfiles>
+                </configuration>
               </configuration>
             </plugin>
           </plugins>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/src/test/config/context.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/src/test/config/context.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!-- The contents of this file will be loaded for each web application -->
+<Context>
+
+    <!-- Default set of monitored resources. If one of these changes, the    -->
+    <!-- web application will be reloaded.                                   -->
+    <WatchedResource>WEB-INF/web.xml</WatchedResource>
+    <WatchedResource>${catalina.base}/conf/web.xml</WatchedResource>
+
+    <!-- Uncomment this to disable session persistence across Tomcat restarts -->
+    <!--
+    <Manager pathname="" />
+    -->
+
+    <!-- Uncomment this to enable Comet connection tacking (provides events
+         on session expiration as well as webapp lifecycle) -->
+    <!--
+    <Valve className="org.apache.catalina.valves.CometConnectionManagerValve" />
+    -->
+    
+    <Resource name="sharedDataSource"
+       		  auth="Container"
+       		  type="org.h2.jdbcx.JdbcDataSource"
+       		  user="sa"
+              password="sa"
+              url="jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MVCC=TRUE"
+              description="H2 Data Source"
+              loginTimeout="0"
+              testOnBorrow="false"
+              factory="org.h2.jdbcx.JdbcDataSourceFactory"/>
+</Context>

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -365,35 +365,21 @@
                     <conf.directory>${project.build.testOutputDirectory}</conf.directory>
                     <tmp.directory>${project.build.directory}</tmp.directory>
                     <jbpm.tsr.jndi.lookup>java:comp/env/TransactionSynchronizationRegistry</jbpm.tsr.jndi.lookup>
-                    <org.kie.server.persistence.tm>org.hibernate.service.jta.platform.internal.BitronixJtaPlatform</org.kie.server.persistence.tm>
+                    <jbpm.tm.jndi.lookup>java:comp/env/TransactionManager</jbpm.tm.jndi.lookup>
+                    <org.kie.server.persistence.tm>JBossTS</org.kie.server.persistence.tm>
                     <org.kie.server.persistence.ds>java:comp/env/jdbc/jbpm</org.kie.server.persistence.ds>
                     <org.jboss.logging.provider>jdk</org.jboss.logging.provider>
                     <org.kie.server.sync.deploy>true</org.kie.server.sync.deploy>
+                    <hibernate.connection.release_mode>after_transaction</hibernate.connection.release_mode>
                   </systemProperties>
                   <dependencies>
-                    <dependency>
-                      <groupId>org.codehaus.btm</groupId>
-                      <artifactId>btm</artifactId>
-                    </dependency>
-                    <dependency>
-                      <groupId>org.codehaus.btm</groupId>
-                      <artifactId>btm-tomcat55-lifecycle</artifactId>
-                    </dependency>
                     <dependency>
                       <groupId>com.h2database</groupId>
                       <artifactId>h2</artifactId>
                     </dependency>
                     <dependency>
-                      <groupId>org.jboss.spec.javax.transaction</groupId>
-                      <artifactId>jboss-transaction-api_1.2_spec</artifactId>
-                    </dependency>
-                    <dependency>
                       <groupId>org.slf4j</groupId>
                       <artifactId>slf4j-api</artifactId>
-                    </dependency>
-                    <dependency>
-                      <groupId>org.slf4j</groupId>
-                      <artifactId>slf4j-jdk14</artifactId>
                     </dependency>
                     <dependency>
                       <groupId>org.jboss.spec.javax.security.jacc</groupId>
@@ -424,16 +410,6 @@
       <dependencies>
         <!-- Deps needed by Tomcat 8 -->
         <dependency>
-          <groupId>org.codehaus.btm</groupId>
-          <artifactId>btm</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.codehaus.btm</groupId>
-          <artifactId>btm-tomcat55-lifecycle</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
           <groupId>com.h2database</groupId>
           <artifactId>h2</artifactId>
           <scope>test</scope>
@@ -442,10 +418,6 @@
           <groupId>org.jboss.spec.javax.transaction</groupId>
           <artifactId>jboss-transaction-api_1.2_spec</artifactId>
           <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-jdk14</artifactId>
         </dependency>
         <dependency>
           <groupId>org.jboss.spec.javax.security.jacc</groupId>

--- a/kie-server-parent/kie-server-wars/kie-server/pom.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/pom.xml
@@ -241,6 +241,10 @@
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.narayana.tomcat</groupId>
+      <artifactId>tomcat-jta</artifactId>
+    </dependency>
 
     <!-- Timer dependencies -->
     <dependency>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-servlet-container.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-servlet-container.xml
@@ -76,6 +76,7 @@
         <include>org.hibernate:hibernate-validator</include>
         <include>dom4j:dom4j</include>
         <include>xerces:xercesImpl</include>
+        <include>org.jboss.narayana.tomcat:tomcat-jta</include>
 
         <include>org.jboss.spec.javax.jms:jboss-jms-api_2.0_spec</include>
 

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/webc-resources/META-INF/context.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/webc-resources/META-INF/context.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Context>
-  <Listener className="bitronix.tm.integration.tomcat55.BTMLifecycleListener" />
+  <!-- Narayana resources -->
+  <Transaction factory="org.jboss.narayana.tomcat.jta.UserTransactionFactory"/>
+  <Resource name="TransactionManager" type="javax.transaction.TransactionManager"
+            factory="org.jboss.narayana.tomcat.jta.TransactionManagerFactory"/>
+  <Resource name="TransactionSynchronizationRegistry" type="javax.transaction.TransactionSynchronizationRegistry"
+            factory="org.jboss.narayana.tomcat.jta.TransactionSynchronizationRegistryFactory"/>
 
-  <Resource name="jdbc/jbpm" uniqueName="jdbc/jbpm" auth="Container"
-            removeAbandoned="true" factory="bitronix.tm.resource.ResourceObjectFactory" type="javax.sql.DataSource" />
 
-  <Resource name="TransactionSynchronizationRegistry" auth="Container" type="javax.transaction.TransactionSynchronizationRegistry"
-            factory="bitronix.tm.BitronixTransactionSynchronizationRegistryObjectFactory" />
-
-  <Transaction factory="bitronix.tm.BitronixUserTransactionObjectFactory" />
+  <Resource name="jdbc/jbpm" auth="Container" type="javax.sql.DataSource"
+            username="sa" password="sa" driverClassName="com.arjuna.ats.jdbc.TransactionalDriver"
+            url="jdbc:arjuna:java:comp/env/sharedDataSource" />
 </Context>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/webc-resources/README.md
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/webc-resources/README.md
@@ -1,0 +1,80 @@
+Installing KIE Server on Tomcat 8
+
+This instruction describes all steps to install KIE Server on Tomcat 8 standalone distribution - this means it's Tomcat downloaded as zip/tar.
+
+ 1. Extract Tomcat archive into desired location - TOMCAT_HOME
+ 2. Copy following libraries into TOMCAT_HOME/lib
+   - javax.security.jacc:javax.security.jacc-api
+   - org.kie:kie-tomcat-integration
+   - org.slf4j:artifactId=slf4j-api
+   - org.slf4j:artifactId=slf4j-jdk14
+
+ versions of these libraries will depend on the release, so best to check what versions are shipped with KIE
+
+ 3. Copy JDBC driver lib into TOMCAT_HOME/lib depending on the data base of your choice, as example H2 is used
+
+ 4. Configure users and roles in tomcat-users.xml (or different user repository if applicable)
+ <tomcat-users>
+   <role rolename="admin"/>
+   <role rolename="PM"/>
+   <role rolename="HR"/>
+   <role rolename="analyst"/>
+   <role rolename="user"/>
+   <role rolename="kie-server"/>
+
+   <user username="testuser" password="testpwd" roles="admin,analyst,PM,HR,kie-server"/>
+   <user username="kieserver" password="kieserver1!" roles="kie-server"/>
+ </tomcat-users>
+
+ 5. Configure data source for data base access by jBPM extension of KIE Server
+    Edit TOMCAT_HOME/conf/context.xml and add following within Context tags of the file
+
+       <Resource name="sharedDataSource"
+       		  auth="Container"
+       		  type="org.h2.jdbcx.JdbcDataSource"
+       		  user="sa"
+              password="sa"
+              url="jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MVCC=TRUE"
+              description="H2 Data Source"
+              loginTimeout="0"
+              testOnBorrow="false"
+              factory="org.h2.jdbcx.JdbcDataSourceFactory"/>
+
+ 6. Configure JACC Valve for security integration
+    Edit TOMCAT_HOME/conf/server.xml and add following in Host section after last Valve declaration
+
+    <Valve className="org.kie.integration.tomcat.JACCValve" />
+
+ 7. Create setenv.sh|bat in TOMCAT_HOME/bin with following content
+
+    CATALINA_OPTS="-Xmx512M -Djbpm.tsr.jndi.lookup=java:comp/env/TransactionSynchronizationRegistry -Dorg.kie.server.persistence.ds=java:comp/env/jdbc/jbpm -Djbpm.tm.jndi.lookup=java:comp/env/TransactionManager -Dorg.kie.server.persistence.tm=JBossTS -Dhibernate.connection.release_mode=after_transaction -Dorg.kie.server.id=tomcat-kieserver -Dorg.kie.server.location=http://localhost:8080/kie-server/services/rest/server -Dorg.kie.server.controller=http://localhost:8080/kie-wb/rest/controller"
+
+    Last three parameters might require reconfiguration as they depend on actual environment they run on:
+    Actual kie server id to identify given kie server
+    -Dorg.kie.server.id=tomcat-kieserver
+
+    Actual location of the kie server over HTTP
+    -Dorg.kie.server.location=http://localhost:8080/kie-server/services/rest/server
+
+    Location of the controller in case kie server should run in managed mode
+    -Dorg.kie.server.controller=http://localhost:8080/kie-wb/rest/controller
+
+ 8. Configure XA Recovery
+
+    Create xa recovery file next to the context.xml with data base configuration with following content:
+
+    <?xml version="1.0" encoding="UTF-8"?>
+    <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
+    <properties>
+        <entry key="DB_1_DatabaseUser">sa</entry>
+        <entry key="DB_1_DatabasePassword">sa</entry>
+        <entry key="DB_1_DatabaseDynamicClass"></entry>
+        <entry key="DB_1_DatabaseURL">java:comp/env/h2DataSource</entry>
+    </properties>
+
+    Append to CATALINA_OPTS in setenv.sh|bat file following:
+    -Dcom.arjuna.ats.jta.recovery.XAResourceRecovery1=com.arjuna.ats.internal.jdbc.recovery.BasicXARecovery\;abs://$CATALINA_HOME/conf/xa-recovery-properties.xml\ \;1
+
+    BasicXARecovery supports following parameters:
+     - path to the properties file
+     - the number of connections defined in the properties file

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/webc-resources/WEB-INF/web.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/webc-resources/WEB-INF/web.xml
@@ -5,6 +5,7 @@
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
   <display-name>KieServer</display-name>
   <listener>
+    <listener-class>org.jboss.narayana.tomcat.jta.NarayanaJtaServletContextListener</listener-class>
     <listener-class>org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap</listener-class>
   </listener>
 


### PR DESCRIPTION
…Manager instead of bitronix

depends on https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/461

@sutaakar this completely replaces use of bitronix on kie server when running on tomcat. I didn't reconfigure local tests to use narayana at the moment it might be a good thing to do down the road.

@psiroky is there a way to test PR on tomcat for kie server? I ran most of the tests locally but would prefer to have a green light on PR that actually ran on tomcat :)