### PR TITLE
Advanced search tests stabilization

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/filtered-resources/kjars-sources/definition-project/src/main/resources/evaluation.bpmn2
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/filtered-resources/kjars-sources/definition-project/src/main/resources/evaluation.bpmn2
@@ -10,7 +10,7 @@
   <bpmn2:itemDefinition id="__8BFDD5E5-1D06-4F2C-9D98-F71795AEB6F0_BodyInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__8BFDD5E5-1D06-4F2C-9D98-F71795AEB6F0_SubjectInputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__8BFDD5E5-1D06-4F2C-9D98-F71795AEB6F0_ToInputXItem" structureRef="String"/>
-  <bpmn2:process id="definition-project.evaluation" drools:packageName="org.jbpm" drools:version="1.0" name="evaluation" isExecutable="true">
+  <bpmn2:process id="definition-project.evaluation-search" drools:packageName="org.jbpm" drools:version="1.0" name="evaluation-search" isExecutable="true">
     <bpmn2:property id="name" itemSubjectRef="_nameItem"/>
     <bpmn2:property id="item" itemSubjectRef="_itemItem"/>
     <bpmn2:property id="outcome" itemSubjectRef="_outcomeItem"/>
@@ -118,7 +118,7 @@
     <bpmn2:sequenceFlow id="_5F738344-23B6-4308-908B-2141A1660CCD" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_4E8E7545-FB70-494E-9136-2B9ABE655889" targetRef="_8BFDD5E5-1D06-4F2C-9D98-F71795AEB6F0"/>
   </bpmn2:process>
   <bpmndi:BPMNDiagram id="_lYQh4PMtEeSoD-9HcIhmjA">
-    <bpmndi:BPMNPlane id="_lYQh4fMtEeSoD-9HcIhmjA" bpmnElement="definition-project.evaluation">
+    <bpmndi:BPMNPlane id="_lYQh4fMtEeSoD-9HcIhmjA" bpmnElement="definition-project.evaluation-search">
       <bpmndi:BPMNShape id="_lYQh4vMtEeSoD-9HcIhmjA" bpmnElement="processStartEvent">
         <dc:Bounds height="30.0" width="30.0" x="120.0" y="165.0"/>
       </bpmndi:BPMNShape>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/filtered-resources/kjars-sources/definition-project/src/main/resources/usertask.bpmn2
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/filtered-resources/kjars-sources/definition-project/src/main/resources/usertask.bpmn2
@@ -8,13 +8,13 @@
   <bpmn2:itemDefinition id="__44BE4412-91B0-4707-89DD-D45CECA36413_person_OutputXItem" structureRef="org.jbpm.data.Person"/>
   <bpmn2:itemDefinition id="__87C563E0-EB8C-4184-BDB0-219E05780A0E_string2_InputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__87C563E0-EB8C-4184-BDB0-219E05780A0E_person2_InputXItem" structureRef="org.jbpm.data.Person"/>
-  <bpmn2:process id="definition-project.usertask" drools:packageName="org.jbpm" drools:version="1.0" name="usertask" isExecutable="true">
+  <bpmn2:process id="definition-project.usertask-search" drools:packageName="org.jbpm" drools:version="1.0" name="usertask-search" isExecutable="true">
     <bpmn2:property id="stringData" itemSubjectRef="_stringDataItem"/>
     <bpmn2:property id="personData" itemSubjectRef="_personDataItem"/>
     <bpmn2:startEvent id="processStartEvent" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="start">
       <bpmn2:outgoing>_7DD40B5F-AE51-4DEA-99E3-79E8B02542F4</bpmn2:outgoing>
     </bpmn2:startEvent>
-    <bpmn2:userTask id="_44BE4412-91B0-4707-89DD-D45CECA36413" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="First task">
+    <bpmn2:userTask id="_44BE4412-91B0-4707-89DD-D45CECA36413" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="First task first">
       <bpmn2:incoming>_7DD40B5F-AE51-4DEA-99E3-79E8B02542F4</bpmn2:incoming>
       <bpmn2:outgoing>_3A18378C-AF7E-4A46-9E3F-439990743823</bpmn2:outgoing>
       <bpmn2:ioSpecification id="_u5JCEfpbEeSqMsMWx6c2wQ">
@@ -105,7 +105,7 @@
     <bpmn2:sequenceFlow id="_75C9F602-54EC-4C49-8B5F-90A1527ED698" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_87C563E0-EB8C-4184-BDB0-219E05780A0E" targetRef="_12205041-6185-4BC6-A152-CDC1569F1205"/>
   </bpmn2:process>
   <bpmndi:BPMNDiagram id="_u5KQMvpbEeSqMsMWx6c2wQ">
-    <bpmndi:BPMNPlane id="_u5KQM_pbEeSqMsMWx6c2wQ" bpmnElement="definition-project.usertask">
+    <bpmndi:BPMNPlane id="_u5KQM_pbEeSqMsMWx6c2wQ" bpmnElement="definition-project.usertask-search">
       <bpmndi:BPMNShape id="_u5KQNPpbEeSqMsMWx6c2wQ" bpmnElement="processStartEvent">
         <dc:Bounds height="30.0" width="30.0" x="120.0" y="165.0"/>
       </bpmndi:BPMNShape>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/ProcessSearchServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/ProcessSearchServiceIntegrationTest.java
@@ -65,7 +65,7 @@ public class ProcessSearchServiceIntegrationTest extends JbpmQueriesKieServerBas
         Map<String, Object> parameters = new HashMap<>();
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_EVALUATION, parameters);
         Assertions.assertThat(processInstanceId).isNotNull();
-        testFindProcessInstanceWithQueryFilter(createQueryFilterEqualsTo(ProcessInstanceField.PROCESSNAME, "evaluation"), processInstanceId);
+        testFindProcessInstanceWithQueryFilter(createQueryFilterEqualsTo(ProcessInstanceField.PROCESSNAME, PROCESS_NAME_EVALUATION), processInstanceId);
     }
 
     @Test
@@ -94,27 +94,42 @@ public class ProcessSearchServiceIntegrationTest extends JbpmQueriesKieServerBas
     }
 
     @Test
-    public void testFindProcessInstanceWithExternalIdEqualsToFilter() throws Exception {
+    public void testFindProcessInstanceWithExternalIdAndPidEqualsToFilter() throws Exception {
         Map<String, Object> parameters = new HashMap<>();
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_EVALUATION, parameters);
         Assertions.assertThat(processInstanceId).isNotNull();
-        testFindProcessInstanceWithQueryFilter(createQueryFilterEqualsTo(ProcessInstanceField.EXTERNALID, "definition-project"), processInstanceId);
+
+        HashMap<ProcessInstanceField, Comparable<?>> compareList = new HashMap<>();
+        compareList.put(ProcessInstanceField.EXTERNALID, CONTAINER_ID);
+        compareList.put(ProcessInstanceField.PROCESSID, PROCESS_ID_EVALUATION);
+
+        testFindProcessInstanceWithQueryFilter(createQueryFilterAndEqualsTo(compareList), processInstanceId);
     }
 
     @Test
-    public void testFindProcessInstanceWithUserIdEqualsToFilter() throws Exception {
+    public void testFindProcessInstanceWithUserIdAndPidEqualsToFilter() throws Exception {
         Map<String, Object> parameters = new HashMap<>();
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_EVALUATION, parameters);
         Assertions.assertThat(processInstanceId).isNotNull();
-        testFindProcessInstanceWithQueryFilter(createQueryFilterEqualsTo(ProcessInstanceField.USER_IDENTITY, USER_YODA), processInstanceId);
+
+        HashMap<ProcessInstanceField, Comparable<?>> compareList = new HashMap<>();
+        compareList.put(ProcessInstanceField.PROCESSID, PROCESS_ID_EVALUATION);
+        compareList.put(ProcessInstanceField.USER_IDENTITY, USER_YODA);
+
+        testFindProcessInstanceWithQueryFilter(createQueryFilterAndEqualsTo(compareList), processInstanceId);
     }
 
     @Test
-    public void testFindProcessInstanceWithParentIdEqualsToFilter() throws Exception {
+    public void testFindProcessInstanceWithParentIdAndProcessNameEqualsToFilter() throws Exception {
         Map<String, Object> parameters = new HashMap<>();
         Long processInstanceId  = processClient.startProcess(CONTAINER_ID, PROCESS_ID_EVALUATION, parameters);
         Assertions.assertThat(processInstanceId).isNotNull();
-        testFindProcessInstanceWithQueryFilter(createQueryFilterEqualsTo(ProcessInstanceField.PARENTPROCESSINSTANCEID, -1), processInstanceId);
+
+        HashMap<ProcessInstanceField, Comparable<?>> compareList = new HashMap<>();
+        compareList.put(ProcessInstanceField.PARENTPROCESSINSTANCEID, -1);
+        compareList.put(ProcessInstanceField.PROCESSNAME, PROCESS_NAME_EVALUATION);
+
+        testFindProcessInstanceWithQueryFilter(createQueryFilterAndEqualsTo(compareList), processInstanceId);
     }
 
     public void testFindProcessInstanceWithStatusEqualsToFilter() throws Exception {
@@ -188,10 +203,6 @@ public class ProcessSearchServiceIntegrationTest extends JbpmQueriesKieServerBas
 
     private ProcessInstanceQueryFilterSpec createQueryFilterEqualsTo(ProcessInstanceField processInstanceField, Comparable<?> equalsTo) {
         return  new ProcessInstanceQueryFilterSpecBuilder().equalsTo(processInstanceField, equalsTo).get();
-    }
-
-    private ProcessInstanceQueryFilterSpec createQueryFilterGreaterThan(ProcessInstanceField processInstanceField, Comparable<?> greaterThan) {
-        return  new ProcessInstanceQueryFilterSpecBuilder().greaterThan(processInstanceField, greaterThan).get();
     }
 
     private ProcessInstanceQueryFilterSpec createQueryFilterAndEqualsTo(Map<ProcessInstanceField, Comparable<?>> filterProperties) {


### PR DESCRIPTION
This should fix issues where large results are being returned and  due to page size, tests are unable to find expected instance in the result. I have modified the processes to use unique names so API won't return data that was used by other tests and stayed in history logs. 

Modified process files to use unique names for tasks and processes.
Modified some tests to use one more unique field in the filter.
Modified deleteLog() method to be static and run only once before tests.

@sutaakar Could you take a look please?  