### PR TITLE
jbpm-search-tests: Do not use EqualsTo filters with dates

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerSynchronization.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerSynchronization.java
@@ -54,6 +54,10 @@ public class KieServerSynchronization {
     private static final long TIMEOUT_BETWEEN_CALLS = 200;
 
     public static void waitForJobToFinish(final JobServicesClient jobServicesClient, final Long jobId) throws Exception {
+        waitForJobToFinish(jobServicesClient, jobId, SERVICE_TIMEOUT);
+    }
+
+    public static void waitForJobToFinish(final JobServicesClient jobServicesClient, final Long jobId, final Long timeOut) throws Exception {
         waitForCondition(() -> {
             RequestInfoInstance result = jobServicesClient.getRequestById(jobId, false, false);
 
@@ -64,7 +68,7 @@ public class KieServerSynchronization {
                 return true;
             }
             return false;
-        });
+        }, timeOut);
     }
 
     public static void waitForKieServerSynchronization(final KieServicesClient client, final int numberOfExpectedContainers) throws Exception {
@@ -242,7 +246,15 @@ public class KieServerSynchronization {
      * @throws Exception
      */
     private static void waitForCondition(BooleanSupplier condition) throws Exception {
-        long timeoutTime = Calendar.getInstance().getTimeInMillis() + SERVICE_TIMEOUT;
+        waitForCondition(condition, SERVICE_TIMEOUT);
+    }
+
+    /**
+     * @param condition Condition result supplier. If returns true then condition is met.
+     * @throws Exception
+     */
+    private static void waitForCondition(BooleanSupplier condition, long timeOut) throws Exception {
+        long timeoutTime = Calendar.getInstance().getTimeInMillis() + timeOut;
         while (Calendar.getInstance().getTimeInMillis() < timeoutTime) {
 
             if (condition.getAsBoolean()) {
@@ -250,6 +262,6 @@ public class KieServerSynchronization {
             }
             Thread.sleep(TIMEOUT_BETWEEN_CALLS);
         }
-        throw new TimeoutException("Synchronization failed for defined timeout: " + SERVICE_TIMEOUT + " milliseconds.");
+        throw new TimeoutException("Synchronization failed for defined timeout: " + timeOut + " milliseconds.");
     }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/JbpmQueriesKieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/JbpmQueriesKieServerBaseIntegrationTest.java
@@ -32,7 +32,10 @@ import org.kie.server.integrationtests.jbpm.search.util.DBExternalResource;
 import org.kie.server.integrationtests.shared.KieServerSynchronization;
 import org.kie.server.integrationtests.shared.basetests.RestJmsSharedBaseIntegrationTest;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 
@@ -90,5 +93,11 @@ public abstract class JbpmQueriesKieServerBaseIntegrationTest extends RestJmsSha
         JobServicesClient jsc = createDefaultStaticClient().getServicesClient(JobServicesClient.class);
         long id = jsc.scheduleRequest(JobRequestInstance.builder().command("org.jbpm.executor.commands.LogCleanupCommand").build());
         KieServerSynchronization.waitForJobToFinish(jsc, id, 120000L);
+    }
+
+    protected Date subtractOneMinuteFromDate(Date date) {
+        Instant instant = Instant.from(date.toInstant());
+        instant = instant.minus(Duration.ofMinutes(1));
+        return Date.from(instant);
     }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/JbpmQueriesKieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/JbpmQueriesKieServerBaseIntegrationTest.java
@@ -89,6 +89,6 @@ public abstract class JbpmQueriesKieServerBaseIntegrationTest extends RestJmsSha
     public static void deleteLog() throws Exception {
         JobServicesClient jsc = createDefaultStaticClient().getServicesClient(JobServicesClient.class);
         long id = jsc.scheduleRequest(JobRequestInstance.builder().command("org.jbpm.executor.commands.LogCleanupCommand").build());
-        KieServerSynchronization.waitForJobToFinish(jsc, id);
+        KieServerSynchronization.waitForJobToFinish(jsc, id, 120000L);
     }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/ProcessSearchServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/ProcessSearchServiceIntegrationTest.java
@@ -28,8 +28,6 @@ import org.kie.server.api.model.definition.ProcessInstanceQueryFilterSpec;
 import org.kie.server.api.util.ProcessInstanceQueryFilterSpecBuilder;
 
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -220,12 +218,5 @@ public class ProcessSearchServiceIntegrationTest extends JbpmQueriesKieServerBas
         ProcessInstanceQueryFilterSpecBuilder result = new ProcessInstanceQueryFilterSpecBuilder();
         filterProperties.forEach(result::equalsTo);
         return  result.get();
-    }
-
-    private Date subtractOneMinuteFromDate(Date date) {
-        Calendar cal = Calendar.getInstance();
-        cal.setTime(date);
-        cal.add(Calendar.MINUTE, -1);
-        return cal.getTime();
     }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/TaskSearchServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/TaskSearchServiceIntegrationTest.java
@@ -28,8 +28,6 @@ import org.kie.server.api.model.definition.TaskQueryFilterSpec;
 import org.kie.server.api.util.TaskQueryFilterSpecBuilder;
 
 import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -287,12 +285,4 @@ public class TaskSearchServiceIntegrationTest extends JbpmQueriesKieServerBaseIn
         filterProperties.forEach(result::equalsTo);
         return result.get();
     }
-
-    private Date subtractOneMinuteFromDate(Date date) {
-        Calendar cal = Calendar.getInstance();
-        cal.setTime(date);
-        cal.add(Calendar.MINUTE, -1);
-        return cal.getTime();
-    }
-
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/TaskSearchServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm-search/src/test/java/org/kie/server/integrationtests/jbpm/search/TaskSearchServiceIntegrationTest.java
@@ -28,6 +28,8 @@ import org.kie.server.api.model.definition.TaskQueryFilterSpec;
 import org.kie.server.api.util.TaskQueryFilterSpecBuilder;
 
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,14 +63,14 @@ public class TaskSearchServiceIntegrationTest extends JbpmQueriesKieServerBaseIn
     }
 
     @Test
-    public void testFindTaskWithCreatedOnEqualsToFilter() throws Exception {
+    public void testFindTaskWithCreatedOnGreaterThanOrEqualsToFilter() throws Exception {
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         Assertions.assertThat(processInstanceId).isNotNull();
 
         List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
         Assertions.assertThat(tasks).isNotEmpty();
         TaskSummary task = tasks.get(0);
-        testFindTaskInstanceWithSearchService(createQueryFilterEqualsTo(TaskField.CREATEDON, task.getCreatedOn()), task.getId());
+        testFindTaskInstanceWithSearchService(createQueryFilterGreaterThanOrEqualsTo(TaskField.CREATEDON, subtractOneMinuteFromDate(task.getCreatedOn())), task.getId());
     }
 
     @Test
@@ -182,14 +184,14 @@ public class TaskSearchServiceIntegrationTest extends JbpmQueriesKieServerBaseIn
     }
 
     @Test
-    public void testFindTaskWithActivationTimeEqualsToFilter() throws Exception {
+    public void testFindTaskWithActivationTimeGreaterThanEqualsToFilter() throws Exception {
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
         Assertions.assertThat(processInstanceId).isNotNull();
 
         List<TaskSummary> tasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA, 0, 10);
         Assertions.assertThat(tasks).isNotEmpty();
         TaskSummary task = tasks.get(0);
-        testFindTaskInstanceWithSearchService(createQueryFilterEqualsTo(TaskField.ACTIVATIONTIME, task.getActivationTime()), task.getId());
+        testFindTaskInstanceWithSearchService(createQueryFilterGreaterThanOrEqualsTo(TaskField.ACTIVATIONTIME, subtractOneMinuteFromDate(task.getActivationTime())), task.getId());
     }
 
     @Test
@@ -276,10 +278,21 @@ public class TaskSearchServiceIntegrationTest extends JbpmQueriesKieServerBaseIn
         return new TaskQueryFilterSpecBuilder().greaterThan(taskField, greaterThan).equalsTo(taskField, equalsTo).get();
     }
 
+    private TaskQueryFilterSpec createQueryFilterGreaterThanOrEqualsTo(TaskField taskField, Comparable<?> equalsTo) {
+        return  new TaskQueryFilterSpecBuilder().greaterOrEqualTo(taskField, equalsTo).get();
+    }
+
     private TaskQueryFilterSpec createQueryFilterAndEqualsTo(Map<TaskField, Comparable<?>> filterProperties) {
         TaskQueryFilterSpecBuilder result = new TaskQueryFilterSpecBuilder();
         filterProperties.forEach(result::equalsTo);
         return result.get();
+    }
+
+    private Date subtractOneMinuteFromDate(Date date) {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(date);
+        cal.add(Calendar.MINUTE, -1);
+        return cal.getTime();
     }
 
 }


### PR DESCRIPTION
Removes equalsTo filters when querying with date and replaces them
with greaterThanOrEqualsTo to prevent random failures.
Modifies filters to use process instance id to minimize size
of the result returned.