### PR TITLE
RHBPMS-4794 - History REST endpoints not behaving correctlly on WAS

### DIFF
--- a/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/HistoryResourceImpl.java
+++ b/kie-remote/kie-remote-services/src/main/java/org/kie/remote/services/rest/HistoryResourceImpl.java
@@ -203,7 +203,7 @@ public class HistoryResourceImpl extends ResourceBase {
     }
     
     @GET
-    @Path("/variable/{varId: [a-zA-Z0-9-:\\._]+}/value/{value: [%a-zA-Z0-9-:\\._]+}")
+    @Path("/variable/{varId: [a-zA-Z0-9-:\\._]+}/value/{value: .+}")
     @RolesAllowed({REST_ROLE, REST_PROCESS_RO_ROLE, REST_PROCESS_ROLE})
     public Response getVariableInstanceLogsByVariableIdByVariableValue(@PathParam("varId") String variableId, @PathParam("value") String value) {
         Map<String, String []> params = getRequestParams();
@@ -240,7 +240,7 @@ public class HistoryResourceImpl extends ResourceBase {
     }
     
     @GET
-    @Path("/variable/{varId: [a-zA-Z0-9-:\\._]+}/value/{value: [%a-zA-Z0-9-:\\._]+}/instances")
+    @Path("/variable/{varId: [a-zA-Z0-9-:\\._]+}/value/{value: .+}/instances")
     @RolesAllowed({REST_ROLE, REST_PROCESS_RO_ROLE, REST_PROCESS_ROLE})
     public Response getProcessInstanceLogsByVariableIdByVariableValue(@PathParam("varId") String variableId, @PathParam("value") String value) {
         Map<String, String[]> params = getRequestParams();

--- a/kie-remote/kie-remote-services/src/test/java/org/kie/remote/services/rest/HistoryResourceRestParamTest.java
+++ b/kie-remote/kie-remote-services/src/test/java/org/kie/remote/services/rest/HistoryResourceRestParamTest.java
@@ -37,16 +37,15 @@ public class HistoryResourceRestParamTest {
                              "" );
         String regex = path.substring( 0,
                                        path.length() - 1 );
-
         // Test : value with space
         String test = "my%20value%20with%20spaces";
         assertTrue( test,
                     Pattern.matches( regex,
                                      test ) );
         test = "my value";
-        assertFalse( test,
-                     Pattern.matches( regex,
-                                      test ) );
+        assertTrue(test,
+                Pattern.matches(regex,
+                        test));
     }
 
     @Test
@@ -60,16 +59,15 @@ public class HistoryResourceRestParamTest {
                              "" );
         String regex = path.substring( 0,
                                        path.indexOf( "}" ) );
-
         // Test : value with space
         String test = "my%20value%20with%20spaces";
         assertTrue( test,
                     Pattern.matches( regex,
                                      test ) );
         test = "my value";
-        assertFalse( test,
-                     Pattern.matches( regex,
-                                      test ) );
+        assertTrue(test,
+                Pattern.matches(regex,
+                        test));
 
     }
 


### PR DESCRIPTION
@krisv @markcoble I decided to relax the regex for the variable value on the rest endpoint as it causes issues on WAS but more importantly we don't limit/restrict on variable values on process level.