### PR TITLE
DO NOT MERGE DROOLS-1649 Avoid using Class.forName in static factory methods

### DIFF
--- a/drools-android/src/main/java/org/drools/android/DexPackageClassLoader.java
+++ b/drools-android/src/main/java/org/drools/android/DexPackageClassLoader.java
@@ -17,7 +17,7 @@
 package org.drools.android;
 
 import org.drools.core.rule.JavaDialectRuntimeData;
-import org.kie.internal.utils.FastClassLoader;
+import org.kie.api.utils.FastClassLoader;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;


### PR DESCRIPTION
Depends on kiegroup/droolsjbpm-knowledge#248 .