### PR TITLE
JBPM-5457: Start and Stop container buttons change states even though they fail

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
@@ -55,189 +55,282 @@ public class KieServerInstanceManager {
         return INSTANCE;
     }
 
-    public List<Container> startScanner(ServerTemplate serverTemplate, final ContainerSpec containerSpec, final long interval) {
+    public List<Container> startScanner(ServerTemplate serverTemplate,
+                                        final ContainerSpec containerSpec,
+                                        final long interval) {
 
-        return callRemoteKieServerOperation(serverTemplate, containerSpec, new RemoteKieServerOperation<Void>(){
-            @Override
-            public Void doOperation(KieServicesClient client, Container container) {
-                KieScannerResource scannerResource = new KieScannerResource();
-                scannerResource.setPollInterval(interval);
-                scannerResource.setStatus(KieScannerStatus.STARTED);
+        return callRemoteKieServerOperation(serverTemplate,
+                                            containerSpec,
+                                            new RemoteKieServerOperation<Void>() {
+                                                @Override
+                                                public Void doOperation(KieServicesClient client,
+                                                                        Container container) {
+                                                    KieScannerResource scannerResource = new KieScannerResource();
+                                                    scannerResource.setPollInterval(interval);
+                                                    scannerResource.setStatus(KieScannerStatus.STARTED);
 
-                ServiceResponse<KieScannerResource> response = client.updateScanner(containerSpec.getId(), scannerResource);
-                if (!response.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
-                    logger.debug("Scanner failed to start on server instance {} due to {}", container.getUrl(), response.getMsg());
-                }
-                collectContainerInfo(containerSpec, client, container);
+                                                    ServiceResponse<KieScannerResource> response = client.updateScanner(containerSpec.getId(),
+                                                                                                                        scannerResource);
+                                                    if (!response.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
+                                                        logger.debug("Scanner failed to start on server instance {} due to {}",
+                                                                     container.getUrl(),
+                                                                     response.getMsg());
+                                                    }
+                                                    collectContainerInfo(containerSpec,
+                                                                         client,
+                                                                         container);
 
-                return null;
-            }
-        });
+                                                    return null;
+                                                }
+                                            });
     }
 
-    public List<Container> stopScanner(ServerTemplate serverTemplate, final ContainerSpec containerSpec) {
+    public List<Container> stopScanner(ServerTemplate serverTemplate,
+                                       final ContainerSpec containerSpec) {
 
-        return callRemoteKieServerOperation(serverTemplate, containerSpec, new RemoteKieServerOperation<Void>(){
-            @Override
-            public Void doOperation(KieServicesClient client, Container container) {
-                KieScannerResource scannerResource = new KieScannerResource();
-                scannerResource.setPollInterval(null);
-                scannerResource.setStatus(KieScannerStatus.STOPPED);
+        return callRemoteKieServerOperation(serverTemplate,
+                                            containerSpec,
+                                            new RemoteKieServerOperation<Void>() {
+                                                @Override
+                                                public Void doOperation(KieServicesClient client,
+                                                                        Container container) {
+                                                    KieScannerResource scannerResource = new KieScannerResource();
+                                                    scannerResource.setPollInterval(null);
+                                                    scannerResource.setStatus(KieScannerStatus.STOPPED);
 
-                ServiceResponse<KieScannerResource> response = client.updateScanner(containerSpec.getId(), scannerResource);
-                if (!response.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
-                    logger.debug("Scanner failed to stop on server instance {} due to {}", container.getUrl(), response.getMsg());
-                }
+                                                    ServiceResponse<KieScannerResource> response = client.updateScanner(containerSpec.getId(),
+                                                                                                                        scannerResource);
+                                                    if (!response.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
+                                                        logger.debug("Scanner failed to stop on server instance {} due to {}",
+                                                                     container.getUrl(),
+                                                                     response.getMsg());
+                                                    }
 
-                collectContainerInfo(containerSpec, client, container);
+                                                    collectContainerInfo(containerSpec,
+                                                                         client,
+                                                                         container);
 
-                return null;
-            }
-        });
+                                                    return null;
+                                                }
+                                            });
     }
 
-    public List<Container> scanNow(ServerTemplate serverTemplate, final ContainerSpec containerSpec) {
+    public List<Container> scanNow(ServerTemplate serverTemplate,
+                                   final ContainerSpec containerSpec) {
 
-        return callRemoteKieServerOperation(serverTemplate, containerSpec, new RemoteKieServerOperation<Void>(){
-            @Override
-            public Void doOperation(KieServicesClient client, Container container) {
-                KieScannerResource scannerResource = new KieScannerResource();
-                scannerResource.setPollInterval(null);
-                scannerResource.setStatus(KieScannerStatus.SCANNING);
+        return callRemoteKieServerOperation(serverTemplate,
+                                            containerSpec,
+                                            new RemoteKieServerOperation<Void>() {
+                                                @Override
+                                                public Void doOperation(KieServicesClient client,
+                                                                        Container container) {
+                                                    KieScannerResource scannerResource = new KieScannerResource();
+                                                    scannerResource.setPollInterval(null);
+                                                    scannerResource.setStatus(KieScannerStatus.SCANNING);
 
-                ServiceResponse<KieScannerResource> response = client.updateScanner(containerSpec.getId(), scannerResource);
-                if (!response.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
-                    logger.debug("Scanner (scan now) failed on server instance {} due to {}", container.getUrl(), response.getMsg());
-                }
-                collectContainerInfo(containerSpec, client, container);
-                return null;
-            }
-        });
+                                                    ServiceResponse<KieScannerResource> response = client.updateScanner(containerSpec.getId(),
+                                                                                                                        scannerResource);
+                                                    if (!response.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
+                                                        logger.debug("Scanner (scan now) failed on server instance {} due to {}",
+                                                                     container.getUrl(),
+                                                                     response.getMsg());
+                                                    }
+                                                    collectContainerInfo(containerSpec,
+                                                                         client,
+                                                                         container);
+                                                    return null;
+                                                }
+                                            });
     }
 
+    public List<Container> startContainer(final ServerTemplate serverTemplate,
+                                          final ContainerSpec containerSpec) {
 
-    public List<Container> startContainer(ServerTemplate serverTemplate, final ContainerSpec containerSpec) {
+        return callRemoteKieServerOperation(serverTemplate,
+                                            containerSpec,
+                                            new RemoteKieServerOperation<Void>() {
+                                                @Override
+                                                public Void doOperation(KieServicesClient client,
+                                                                        Container container) {
+                                                    KieContainerResource containerResource = new KieContainerResource(containerSpec.getId(),
+                                                                                                                      containerSpec.getReleasedId(),
+                                                                                                                      container.getResolvedReleasedId(),
+                                                                                                                      container.getStatus());
+                                                    containerResource.setContainerAlias(containerSpec.getContainerName());
+                                                    containerResource.setMessages((List<Message>) container.getMessages());
 
-        return callRemoteKieServerOperation(serverTemplate, containerSpec, new RemoteKieServerOperation<Void>(){
-            @Override
-            public Void doOperation(KieServicesClient client, Container container) {
-                KieContainerResource containerResource = new KieContainerResource(containerSpec.getId(), containerSpec.getReleasedId(), container.getResolvedReleasedId(), container.getStatus());
-                containerResource.setContainerAlias(containerSpec.getContainerName());
-                containerResource.setMessages((List<Message>) container.getMessages());
+                                                    if (containerSpec.getConfigs() != null) {
+                                                        // cover scanner and rules config
+                                                        ContainerConfig containerConfig = containerSpec.getConfigs().get(Capability.RULE);
+                                                        if (containerConfig != null) {
+                                                            RuleConfig ruleConfig = (RuleConfig) containerConfig;
 
-                if (containerSpec.getConfigs() != null) {
-                    // cover scanner and rules config
-                    ContainerConfig containerConfig = containerSpec.getConfigs().get(Capability.RULE);
-                    if (containerConfig != null) {
-                        RuleConfig ruleConfig = (RuleConfig) containerConfig;
+                                                            KieScannerResource scannerResource = new KieScannerResource();
+                                                            scannerResource.setPollInterval(ruleConfig.getPollInterval());
+                                                            scannerResource.setStatus(ruleConfig.getScannerStatus());
 
-                        KieScannerResource scannerResource = new KieScannerResource();
-                        scannerResource.setPollInterval(ruleConfig.getPollInterval());
-                        scannerResource.setStatus(ruleConfig.getScannerStatus());
+                                                            containerResource.setScanner(scannerResource);
+                                                        }
+                                                        // cover process config
+                                                        containerConfig = containerSpec.getConfigs().get(Capability.PROCESS);
+                                                        if (containerConfig != null) {
+                                                            ProcessConfig processConfig = (ProcessConfig) containerConfig;
 
-                        containerResource.setScanner(scannerResource);
-                    }
-                    // cover process config
-                    containerConfig = containerSpec.getConfigs().get(Capability.PROCESS);
-                    if (containerConfig != null) {
-                        ProcessConfig processConfig = (ProcessConfig) containerConfig;
+                                                            KieServerConfigItem configItem = new KieServerConfigItem();
+                                                            configItem.setType(KieServerConstants.CAPABILITY_BPM);
+                                                            configItem.setName(KieServerConstants.PCFG_KIE_BASE);
+                                                            configItem.setValue(processConfig.getKBase());
 
-                        KieServerConfigItem configItem = new KieServerConfigItem();
-                        configItem.setType(KieServerConstants.CAPABILITY_BPM);
-                        configItem.setName(KieServerConstants.PCFG_KIE_BASE);
-                        configItem.setValue(processConfig.getKBase());
+                                                            containerResource.addConfigItem(configItem);
 
-                        containerResource.addConfigItem(configItem);
+                                                            configItem = new KieServerConfigItem();
+                                                            configItem.setType(KieServerConstants.CAPABILITY_BPM);
+                                                            configItem.setName(KieServerConstants.PCFG_KIE_SESSION);
+                                                            configItem.setValue(processConfig.getKSession());
 
-                        configItem = new KieServerConfigItem();
-                        configItem.setType(KieServerConstants.CAPABILITY_BPM);
-                        configItem.setName(KieServerConstants.PCFG_KIE_SESSION);
-                        configItem.setValue(processConfig.getKSession());
+                                                            containerResource.addConfigItem(configItem);
 
-                        containerResource.addConfigItem(configItem);
+                                                            configItem = new KieServerConfigItem();
+                                                            configItem.setType(KieServerConstants.CAPABILITY_BPM);
+                                                            configItem.setName(KieServerConstants.PCFG_MERGE_MODE);
+                                                            configItem.setValue(processConfig.getMergeMode());
 
-                        configItem = new KieServerConfigItem();
-                        configItem.setType(KieServerConstants.CAPABILITY_BPM);
-                        configItem.setName(KieServerConstants.PCFG_MERGE_MODE);
-                        configItem.setValue(processConfig.getMergeMode());
+                                                            containerResource.addConfigItem(configItem);
 
-                        containerResource.addConfigItem(configItem);
+                                                            configItem = new KieServerConfigItem();
+                                                            configItem.setType(KieServerConstants.CAPABILITY_BPM);
+                                                            configItem.setName(KieServerConstants.PCFG_RUNTIME_STRATEGY);
+                                                            configItem.setValue(processConfig.getRuntimeStrategy());
 
-                        configItem = new KieServerConfigItem();
-                        configItem.setType(KieServerConstants.CAPABILITY_BPM);
-                        configItem.setName(KieServerConstants.PCFG_RUNTIME_STRATEGY);
-                        configItem.setValue(processConfig.getRuntimeStrategy());
+                                                            containerResource.addConfigItem(configItem);
+                                                        }
+                                                    }
 
-                        containerResource.addConfigItem(configItem);
-                    }
-                }
-
-                ServiceResponse<KieContainerResource> response = client.createContainer(containerSpec.getId(), containerResource);
-                if (!response.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
-                    logger.debug("Container {} failed to start on server instance {} due to {}", containerSpec.getId(), container.getUrl(), response.getMsg());
-                }
-                collectContainerInfo(containerSpec, client, container);
-                return null;
-            }
-        });
+                                                    ServiceResponse<KieContainerResource> response = client.createContainer(containerSpec.getId(),
+                                                                                                                            containerResource);
+                                                    if (!response.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
+                                                        logger.debug("Container {} failed to start on server instance {} due to {}",
+                                                                     containerSpec.getId(),
+                                                                     container.getUrl(),
+                                                                     response.getMsg());
+                                                    }
+                                                    collectContainerInfo(containerSpec,
+                                                                         client,
+                                                                         container);
+                                                    return null;
+                                                }
+                                            });
     }
 
-    public List<Container> stopContainer(ServerTemplate serverTemplate, final ContainerSpec containerSpec) {
+    public List<Container> stopContainer(final ServerTemplate serverTemplate,
+                                         final ContainerSpec containerSpec,
+                                         final Runnable onSuccess,
+                                         final Runnable onError) {
 
-        return callRemoteKieServerOperation(serverTemplate, containerSpec, new RemoteKieServerOperation<Void>(){
-            @Override
-            public Void doOperation(KieServicesClient client, Container container) {
+        final RemoteKieServerOperation<Void> remoteKieServerOperation = stopOperation(containerSpec,
+                                                                                      onSuccess,
+                                                                                      onError);
 
-                ServiceResponse<Void> response = client.disposeContainer(containerSpec.getId());
-                if (!response.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
-                    logger.debug("Container {} failed to stop on server instance {} due to {}", containerSpec.getId(), container.getUrl(), response.getMsg());
-                }
-                collectContainerInfo(containerSpec, client, container);
-                return null;
-            }
-        });
+        return callRemoteKieServerOperation(serverTemplate,
+                                            containerSpec,
+                                            remoteKieServerOperation);
     }
 
-    public List<Container> upgradeContainer(ServerTemplate serverTemplate, final ContainerSpec containerSpec) {
-
-        return callRemoteKieServerOperation(serverTemplate, containerSpec, new RemoteKieServerOperation<Void>(){
+    RemoteKieServerOperation<Void> stopOperation(final ContainerSpec containerSpec,
+                                                 final Runnable onSuccess,
+                                                 final Runnable onError) {
+        return new RemoteKieServerOperation<Void>() {
             @Override
-            public Void doOperation(KieServicesClient client, Container container) {
+            public Void doOperation(KieServicesClient client,
+                                    Container container) {
 
-                ServiceResponse<ReleaseId> response = client.updateReleaseId(containerSpec.getId(), containerSpec.getReleasedId());
-                if (!response.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
-                    logger.debug("Container {} failed to upgrade on server instance {} due to {}", containerSpec.getId(), container.getUrl(), response.getMsg());
+                final ServiceResponse<Void> response = client.disposeContainer(containerSpec.getId());
+
+                if (response.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
+                    onSuccess.run();
+                } else {
+                    onError.run();
+
+                    logger.debug("Container {} failed to stop on server instance {} due to {}",
+                                 containerSpec.getId(),
+                                 container.getUrl(),
+                                 response.getMsg());
                 }
-                collectContainerInfo(containerSpec, client, container);
+
+                collectContainerInfo(containerSpec,
+                                     client,
+                                     container);
                 return null;
             }
-        });
+        };
     }
 
-    public List<Container> getContainers(final ServerTemplate serverTemplate, final ContainerSpec containerSpec) {
+    public List<Container> stopContainer(final ServerTemplate serverTemplate,
+                                         final ContainerSpec containerSpec) {
+        return stopContainer(serverTemplate,
+                             containerSpec,
+                             emptyCallback(),
+                             emptyCallback());
+    }
 
-        return callRemoteKieServerOperation(serverTemplate, containerSpec, new RemoteKieServerOperation<Void>(){
-            @Override
-            public Void doOperation(KieServicesClient client, Container container) {
+    Runnable emptyCallback() {
+        return () -> {
+        };
+    }
 
-                if (containerSpec.getStatus().equals(KieContainerStatus.STARTED)) {
-                    ServiceResponse<KieContainerResource> response = client.getContainerInfo(containerSpec.getId());
-                    if (response.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
-                        KieContainerResource containerResource = response.getResult();
+    public List<Container> upgradeContainer(ServerTemplate serverTemplate,
+                                            final ContainerSpec containerSpec) {
 
-                        container.setContainerSpecId(containerResource.getContainerId());
-                        container.setContainerName(containerResource.getContainerId());
-                        container.setResolvedReleasedId(containerResource.getResolvedReleaseId() == null ? containerResource.getReleaseId() : containerResource.getResolvedReleaseId());
-                        container.setServerTemplateId(serverTemplate.getId());
-                        container.setStatus(containerResource.getStatus());
-                        container.setMessages(containerResource.getMessages());
+        return callRemoteKieServerOperation(serverTemplate,
+                                            containerSpec,
+                                            new RemoteKieServerOperation<Void>() {
+                                                @Override
+                                                public Void doOperation(KieServicesClient client,
+                                                                        Container container) {
 
-                    }
-                }
+                                                    ServiceResponse<ReleaseId> response = client.updateReleaseId(containerSpec.getId(),
+                                                                                                                 containerSpec.getReleasedId());
+                                                    if (!response.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
+                                                        logger.debug("Container {} failed to upgrade on server instance {} due to {}",
+                                                                     containerSpec.getId(),
+                                                                     container.getUrl(),
+                                                                     response.getMsg());
+                                                    }
+                                                    collectContainerInfo(containerSpec,
+                                                                         client,
+                                                                         container);
+                                                    return null;
+                                                }
+                                            });
+    }
 
-                return null;
-            }
-        });
+    public List<Container> getContainers(final ServerTemplate serverTemplate,
+                                         final ContainerSpec containerSpec) {
+
+        return callRemoteKieServerOperation(serverTemplate,
+                                            containerSpec,
+                                            new RemoteKieServerOperation<Void>() {
+                                                @Override
+                                                public Void doOperation(KieServicesClient client,
+                                                                        Container container) {
+
+                                                    if (containerSpec.getStatus().equals(KieContainerStatus.STARTED)) {
+                                                        ServiceResponse<KieContainerResource> response = client.getContainerInfo(containerSpec.getId());
+                                                        if (response.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
+                                                            KieContainerResource containerResource = response.getResult();
+
+                                                            container.setContainerSpecId(containerResource.getContainerId());
+                                                            container.setContainerName(containerResource.getContainerId());
+                                                            container.setResolvedReleasedId(containerResource.getResolvedReleaseId() == null ? containerResource.getReleaseId() : containerResource.getResolvedReleaseId());
+                                                            container.setServerTemplateId(serverTemplate.getId());
+                                                            container.setStatus(containerResource.getStatus());
+                                                            container.setMessages(containerResource.getMessages());
+                                                        }
+                                                    }
+
+                                                    return null;
+                                                }
+                                            });
     }
 
     public List<Container> getContainers(ServerInstanceKey serverInstanceKey) {
@@ -262,17 +355,18 @@ public class KieServerInstanceManager {
                     container.setContainerName(containerResource.getContainerId());
                     container.setServerInstanceId(serverInstanceKey.getServerInstanceId());
                     container.setUrl(serverInstanceKey.getUrl() + CONTAINERS_URI_PART + containerResource.getContainerId());
-                    container.setResolvedReleasedId(containerResource.getResolvedReleaseId() == null ? containerResource.getReleaseId():containerResource.getResolvedReleaseId());
+                    container.setResolvedReleasedId(containerResource.getResolvedReleaseId() == null ? containerResource.getReleaseId() : containerResource.getResolvedReleaseId());
                     container.setServerTemplateId(serverInstanceKey.getServerTemplateId());
                     container.setStatus(containerResource.getStatus());
                     container.setMessages(containerResource.getMessages());
 
                     containers.add(container);
                 }
-
             }
         } catch (Exception e) {
-            logger.warn("Unable to get list of containers from remote server at url {} due to {}", serverInstanceKey.getUrl(), e.getMessage());
+            logger.warn("Unable to get list of containers from remote server at url {} due to {}",
+                        serverInstanceKey.getUrl(),
+                        e.getMessage());
         }
         return containers;
     }
@@ -282,7 +376,9 @@ public class KieServerInstanceManager {
      * helper methods
      */
 
-    protected List<Container> callRemoteKieServerOperation(ServerTemplate serverTemplate, ContainerSpec containerSpec, RemoteKieServerOperation operation) {
+    protected List<Container> callRemoteKieServerOperation(ServerTemplate serverTemplate,
+                                                           ContainerSpec containerSpec,
+                                                           RemoteKieServerOperation operation) {
         List<Container> containers = new ArrayList<org.kie.server.controller.api.model.runtime.Container>();
 
         if (serverTemplate.getServerInstanceKeys() == null || serverTemplate.getServerInstanceKeys().isEmpty()) {
@@ -300,13 +396,14 @@ public class KieServerInstanceManager {
             container.setResolvedReleasedId(containerSpec.getReleasedId());
             container.setStatus(containerSpec.getStatus());
 
-
             try {
                 KieServicesClient client = getClient(instanceUrl.getUrl());
 
-                operation.doOperation(client, container);
+                operation.doOperation(client,
+                                      container);
             } catch (Exception e) {
-                logger.debug("Unable to connect to {}", instanceUrl);
+                logger.debug("Unable to connect to {}",
+                             instanceUrl);
             }
 
             containers.add(container);
@@ -322,15 +419,18 @@ public class KieServerInstanceManager {
             getClient(serverInstanceKey.getUrl());
             alive = true;
         } catch (Exception e) {
-            logger.debug("Unable to connect to server instance at {} due to {}", serverInstanceKey.getUrl(), e.getMessage());
+            logger.debug("Unable to connect to server instance at {} due to {}",
+                         serverInstanceKey.getUrl(),
+                         e.getMessage());
         }
         return alive;
     }
 
-
     protected KieServicesClient getClient(String url) {
 
-        KieServicesConfiguration configuration = KieServicesFactory.newRestConfiguration(url, getUser(), getPassword());
+        KieServicesConfiguration configuration = KieServicesFactory.newRestConfiguration(url,
+                                                                                         getUser(),
+                                                                                         getPassword());
         configuration.setTimeout(60000);
 
         configuration.setMarshallingFormat(MarshallingFormat.JSON);
@@ -340,12 +440,14 @@ public class KieServerInstanceManager {
             configuration.setCredentialsProvider(new EnteredTokenCredentialsProvider(authToken));
         }
 
-        KieServicesClient kieServicesClient =  KieServicesFactory.newKieServicesClient(configuration);
+        KieServicesClient kieServicesClient = KieServicesFactory.newKieServicesClient(configuration);
 
         return kieServicesClient;
     }
 
-    protected void collectContainerInfo(ContainerSpec containerSpec, KieServicesClient client, Container container) {
+    protected void collectContainerInfo(ContainerSpec containerSpec,
+                                        KieServicesClient client,
+                                        Container container) {
         // collect up to date information
         ServiceResponse<KieContainerResource> serviceResponse = client.getContainerInfo(containerSpec.getId());
         if (serviceResponse.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
@@ -356,19 +458,23 @@ public class KieServerInstanceManager {
     }
 
     protected String getUser() {
-        return System.getProperty(KieServerConstants.CFG_KIE_USER, "kieserver");
+        return System.getProperty(KieServerConstants.CFG_KIE_USER,
+                                  "kieserver");
     }
 
     protected String getPassword() {
-        return System.getProperty(KieServerConstants.CFG_KIE_PASSWORD, "kieserver1!");
+        return System.getProperty(KieServerConstants.CFG_KIE_PASSWORD,
+                                  "kieserver1!");
     }
 
     protected String getToken() {
         return System.getProperty(KieServerConstants.CFG_KIE_TOKEN);
     }
+
     protected class RemoteKieServerOperation<T> {
 
-        public T doOperation(KieServicesClient client, Container container) {
+        public T doOperation(KieServicesClient client,
+                             Container container) {
 
             return null;
         }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/KieServerInstanceManagerTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/KieServerInstanceManagerTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.controller.impl;
+
+import java.util.ArrayList;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.controller.api.model.runtime.Container;
+import org.kie.server.controller.api.model.spec.ContainerSpec;
+import org.kie.server.controller.api.model.spec.ServerTemplate;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KieServerInstanceManagerTest {
+
+    @Mock
+    private ContainerSpec containerSpec;
+
+    @Mock
+    private Runnable onSuccess;
+
+    @Mock
+    private Runnable onError;
+
+    @Mock
+    private KieServicesClient client;
+
+    @Mock
+    private Container container;
+
+    @Mock
+    private ServiceResponse<?> response;
+
+    @Mock
+    private ServerTemplate serverTemplate;
+
+    private KieServerInstanceManager instanceManager;
+
+    @Before
+    public void setUp() {
+        final ArrayList<Container> containers = new ArrayList<>();
+
+        instanceManager = spy(new KieServerInstanceManager());
+
+        doReturn(containers).when(instanceManager).callRemoteKieServerOperation(any(),
+                                                                                any(),
+                                                                                any());
+        doNothing().when(instanceManager).collectContainerInfo(any(),
+                                                               any(),
+                                                               any());
+    }
+
+    @Test
+    public void testStopOperationWhenDisposeContainerIsSuccessfully() throws Exception {
+        doReturn(ServiceResponse.ResponseType.SUCCESS).when(response).getType();
+        doReturn(response).when(client).disposeContainer(any());
+
+        final KieServerInstanceManager.RemoteKieServerOperation<Void> operation = instanceManager.stopOperation(containerSpec,
+                                                                                                                onSuccess,
+                                                                                                                onError);
+
+        operation.doOperation(client,
+                              container);
+
+        verify(onSuccess).run();
+        verify(onError,
+               never()).run();
+        verify(instanceManager).collectContainerInfo(any(),
+                                                     any(),
+                                                     any());
+    }
+
+    @Test
+    public void testStopOperationWhenDisposeContainerIsNotSuccessfully() throws Exception {
+        doReturn(ServiceResponse.ResponseType.NO_RESPONSE).when(response).getType();
+        doReturn(response).when(client).disposeContainer(any());
+
+        final KieServerInstanceManager.RemoteKieServerOperation<Void> operation = instanceManager.stopOperation(containerSpec,
+                                                                                                                onSuccess,
+                                                                                                                onError);
+
+        operation.doOperation(client,
+                              container);
+
+        verify(onError).run();
+        verify(onSuccess,
+               never()).run();
+        verify(instanceManager).collectContainerInfo(any(),
+                                                     any(),
+                                                     any());
+    }
+
+    @Test
+    public void testStopContainerWithCallbacks() throws Exception {
+        final KieServerInstanceManager.RemoteKieServerOperation<?> operation = mock(KieServerInstanceManager.RemoteKieServerOperation.class);
+
+        doReturn(operation).when(instanceManager).stopOperation(containerSpec,
+                                                                onSuccess,
+                                                                onError);
+
+        instanceManager.stopContainer(serverTemplate,
+                                      containerSpec,
+                                      onSuccess,
+                                      onError);
+
+        verify(instanceManager).stopOperation(containerSpec,
+                                              onSuccess,
+                                              onError);
+        verify(instanceManager).callRemoteKieServerOperation(serverTemplate,
+                                                             containerSpec,
+                                                             operation);
+    }
+
+    @Test
+    public void testStopContainerWithoutCallbacks() throws Exception {
+        final ArrayList<Container> containers = new ArrayList<>();
+        final Runnable emptyCallback = () -> {
+        };
+
+        doReturn(emptyCallback).when(instanceManager).emptyCallback();
+        doReturn(containers).when(instanceManager).stopContainer(any(),
+                                                                 any(),
+                                                                 any(),
+                                                                 any());
+
+        instanceManager.stopContainer(serverTemplate,
+                                      containerSpec);
+
+        verify(instanceManager).stopContainer(serverTemplate,
+                                              containerSpec,
+                                              emptyCallback,
+                                              emptyCallback);
+    }
+}

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/SpecManagementServiceImplTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/SpecManagementServiceImplTest.java
@@ -46,16 +46,13 @@ import static org.mockito.Mockito.*;
 
 public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
-
     @Before
     public void setup() {
         specManagementService = new SpecManagementServiceImpl();
         kieServerInstanceManager = Mockito.mock(KieServerInstanceManager.class);
 
-        ((SpecManagementServiceImpl)specManagementService).setKieServerInstanceManager(kieServerInstanceManager);
-
+        ((SpecManagementServiceImpl) specManagementService).setKieServerInstanceManager(kieServerInstanceManager);
     }
-
 
     @After
     public void cleanup() {
@@ -74,12 +71,15 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
         Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey> existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(1, existing.size());
+        assertEquals(1,
+                     existing.size());
 
         org.kie.server.controller.api.model.spec.ServerTemplateKey saved = existing.iterator().next();
 
-        assertEquals(serverTemplate.getName(), saved.getName());
-        assertEquals(serverTemplate.getId(), saved.getId());
+        assertEquals(serverTemplate.getName(),
+                     saved.getName());
+        assertEquals(serverTemplate.getId(),
+                     saved.getId());
     }
 
     @Test
@@ -94,14 +94,16 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
         Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey> existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(1, existing.size());
+        assertEquals(1,
+                     existing.size());
 
         Map<Capability, ContainerConfig> configs = new HashMap<Capability, ContainerConfig>();
         RuleConfig ruleConfig = new RuleConfig();
         ruleConfig.setPollInterval(1000l);
         ruleConfig.setScannerStatus(KieScannerStatus.STARTED);
 
-        configs.put(Capability.RULE, ruleConfig);
+        configs.put(Capability.RULE,
+                    ruleConfig);
 
         ProcessConfig processConfig = new ProcessConfig();
         processConfig.setKBase("defaultKieBase");
@@ -109,54 +111,71 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
         processConfig.setMergeMode("MERGE_COLLECTION");
         processConfig.setRuntimeStrategy("PER_PROCESS_INSTANCE");
 
-        configs.put(Capability.PROCESS, processConfig);
+        configs.put(Capability.PROCESS,
+                    processConfig);
 
         ContainerSpec containerSpec = new ContainerSpec();
         containerSpec.setId("test container");
-        containerSpec.setServerTemplateKey(new ServerTemplateKey(serverTemplate.getId(), serverTemplate.getName()));
-        containerSpec.setReleasedId(new ReleaseId("org.kie", "kie-server-kjar", "1.0"));
+        containerSpec.setServerTemplateKey(new ServerTemplateKey(serverTemplate.getId(),
+                                                                 serverTemplate.getName()));
+        containerSpec.setReleasedId(new ReleaseId("org.kie",
+                                                  "kie-server-kjar",
+                                                  "1.0"));
         containerSpec.setStatus(KieContainerStatus.STOPPED);
         containerSpec.setConfigs(configs);
 
-        specManagementService.saveContainerSpec(serverTemplate.getId(), containerSpec);
+        specManagementService.saveContainerSpec(serverTemplate.getId(),
+                                                containerSpec);
 
         org.kie.server.controller.api.model.spec.ServerTemplate createdServerTemplate = specManagementService.getServerTemplate(serverTemplate.getId());
         assertNotNull(createdServerTemplate);
         assertNotNull(createdServerTemplate.getContainersSpec());
-        assertEquals(1, createdServerTemplate.getContainersSpec().size());
+        assertEquals(1,
+                     createdServerTemplate.getContainersSpec().size());
 
         org.kie.server.controller.api.model.spec.ContainerSpec container = createdServerTemplate.getContainersSpec().iterator().next();
         assertNotNull(container);
 
-        assertEquals(containerSpec.getId(), container.getId());
-        assertEquals(containerSpec.getStatus(), container.getStatus());
-        assertEquals(containerSpec.getServerTemplateKey(), container.getServerTemplateKey());
-        assertEquals(containerSpec.getReleasedId(), container.getReleasedId());
+        assertEquals(containerSpec.getId(),
+                     container.getId());
+        assertEquals(containerSpec.getStatus(),
+                     container.getStatus());
+        assertEquals(containerSpec.getServerTemplateKey(),
+                     container.getServerTemplateKey());
+        assertEquals(containerSpec.getReleasedId(),
+                     container.getReleasedId());
 
         assertNotNull(container.getConfigs());
-        assertEquals(containerSpec.getConfigs().size(), container.getConfigs().size());
-
+        assertEquals(containerSpec.getConfigs().size(),
+                     container.getConfigs().size());
 
         Collection<org.kie.server.controller.api.model.spec.ContainerSpec> specs = specManagementService.listContainerSpec(serverTemplate.getId());
         assertNotNull(specs);
-        assertEquals(1, specs.size());
+        assertEquals(1,
+                     specs.size());
 
         container = specs.iterator().next();
         assertNotNull(container);
 
-        assertEquals(containerSpec.getId(), container.getId());
-        assertEquals(containerSpec.getStatus(), container.getStatus());
-        assertEquals(containerSpec.getServerTemplateKey(), container.getServerTemplateKey());
-        assertEquals(containerSpec.getReleasedId(), container.getReleasedId());
+        assertEquals(containerSpec.getId(),
+                     container.getId());
+        assertEquals(containerSpec.getStatus(),
+                     container.getStatus());
+        assertEquals(containerSpec.getServerTemplateKey(),
+                     container.getServerTemplateKey());
+        assertEquals(containerSpec.getReleasedId(),
+                     container.getReleasedId());
 
         assertNotNull(container.getConfigs());
-        assertEquals(containerSpec.getConfigs().size(), container.getConfigs().size());
+        assertEquals(containerSpec.getConfigs().size(),
+                     container.getConfigs().size());
     }
 
     @Test
     public void testListServerTemplates() {
 
-        int limit = getRandomInt(5, 10);
+        int limit = getRandomInt(5,
+                                 10);
         for (int x = 0; x < limit; x++) {
             ServerTemplate serverTemplate = new ServerTemplate();
 
@@ -167,12 +186,13 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
         }
         Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey> existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(limit, existing.size());
+        assertEquals(limit,
+                     existing.size());
 
         Collection<org.kie.server.controller.api.model.spec.ServerTemplate> allTemplates = specManagementService.listServerTemplates();
         assertNotNull(allTemplates);
-        assertEquals(limit, allTemplates.size());
-
+        assertEquals(limit,
+                     allTemplates.size());
     }
 
     @Test
@@ -187,17 +207,21 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
         Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey> existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(1, existing.size());
+        assertEquals(1,
+                     existing.size());
 
         org.kie.server.controller.api.model.spec.ServerTemplateKey saved = existing.iterator().next();
 
-        assertEquals(serverTemplate.getName(), saved.getName());
-        assertEquals(serverTemplate.getId(), saved.getId());
+        assertEquals(serverTemplate.getName(),
+                     saved.getName());
+        assertEquals(serverTemplate.getId(),
+                     saved.getId());
 
         specManagementService.deleteServerTemplate(serverTemplate.getId());
         existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(0, existing.size());
+        assertEquals(0,
+                     existing.size());
     }
 
     @Test
@@ -212,9 +236,11 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
         Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey> existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(1, existing.size());
+        assertEquals(1,
+                     existing.size());
 
-        int limit = getRandomInt(3, 6);
+        int limit = getRandomInt(3,
+                                 6);
         for (int x = 0; x < limit; x++) {
 
             Map<Capability, ContainerConfig> configs = new HashMap<Capability, ContainerConfig>();
@@ -230,27 +256,33 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
             ContainerSpec containerSpec = new ContainerSpec();
             containerSpec.setId("test container " + x);
-            containerSpec.setServerTemplateKey(new ServerTemplateKey(serverTemplate.getId(), serverTemplate.getName()));
-            containerSpec.setReleasedId(new ReleaseId("org.kie", "kie-server-kjar", x + ".0"));
+            containerSpec.setServerTemplateKey(new ServerTemplateKey(serverTemplate.getId(),
+                                                                     serverTemplate.getName()));
+            containerSpec.setReleasedId(new ReleaseId("org.kie",
+                                                      "kie-server-kjar",
+                                                      x + ".0"));
             containerSpec.setStatus(KieContainerStatus.STOPPED);
             containerSpec.setConfigs(configs);
 
-            specManagementService.saveContainerSpec(serverTemplate.getId(), containerSpec);
+            specManagementService.saveContainerSpec(serverTemplate.getId(),
+                                                    containerSpec);
         }
 
         org.kie.server.controller.api.model.spec.ServerTemplate createdServerTemplate = specManagementService.getServerTemplate(serverTemplate.getId());
         assertNotNull(createdServerTemplate);
         assertNotNull(createdServerTemplate.getContainersSpec());
-        assertEquals(limit, createdServerTemplate.getContainersSpec().size());
-
+        assertEquals(limit,
+                     createdServerTemplate.getContainersSpec().size());
 
         // remove first container with suffix 0
-        specManagementService.deleteContainerSpec(serverTemplate.getId(), "test container " + 0);
+        specManagementService.deleteContainerSpec(serverTemplate.getId(),
+                                                  "test container " + 0);
 
         createdServerTemplate = specManagementService.getServerTemplate(serverTemplate.getId());
         assertNotNull(createdServerTemplate);
         assertNotNull(createdServerTemplate.getContainersSpec());
-        assertEquals(limit-1, createdServerTemplate.getContainersSpec().size());
+        assertEquals(limit - 1,
+                     createdServerTemplate.getContainersSpec().size());
     }
 
     @Test
@@ -265,7 +297,8 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
         Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey> existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(1, existing.size());
+        assertEquals(1,
+                     existing.size());
 
         Map<Capability, ContainerConfig> configs = new HashMap<Capability, ContainerConfig>();
         RuleConfig ruleConfig = new RuleConfig();
@@ -280,56 +313,78 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
         ContainerSpec containerSpec = new ContainerSpec();
         containerSpec.setId("test container");
-        containerSpec.setServerTemplateKey(new ServerTemplateKey(serverTemplate.getId(), serverTemplate.getName()));
-        containerSpec.setReleasedId(new ReleaseId("org.kie", "kie-server-kjar", "1.0"));
+        containerSpec.setServerTemplateKey(new ServerTemplateKey(serverTemplate.getId(),
+                                                                 serverTemplate.getName()));
+        containerSpec.setReleasedId(new ReleaseId("org.kie",
+                                                  "kie-server-kjar",
+                                                  "1.0"));
         containerSpec.setStatus(KieContainerStatus.STOPPED);
         containerSpec.setConfigs(configs);
 
-        specManagementService.saveContainerSpec(serverTemplate.getId(), containerSpec);
+        specManagementService.saveContainerSpec(serverTemplate.getId(),
+                                                containerSpec);
 
         org.kie.server.controller.api.model.spec.ServerTemplate createdServerTemplate = specManagementService.getServerTemplate(serverTemplate.getId());
         assertNotNull(createdServerTemplate);
         assertNotNull(createdServerTemplate.getContainersSpec());
-        assertEquals(1, createdServerTemplate.getContainersSpec().size());
+        assertEquals(1,
+                     createdServerTemplate.getContainersSpec().size());
 
         org.kie.server.controller.api.model.spec.ContainerSpec container = createdServerTemplate.getContainersSpec().iterator().next();
         assertNotNull(container);
 
-        assertEquals(containerSpec.getId(), container.getId());
-        assertEquals(containerSpec.getStatus(), container.getStatus());
-        assertEquals(containerSpec.getServerTemplateKey(), container.getServerTemplateKey());
-        assertEquals(containerSpec.getReleasedId(), container.getReleasedId());
+        assertEquals(containerSpec.getId(),
+                     container.getId());
+        assertEquals(containerSpec.getStatus(),
+                     container.getStatus());
+        assertEquals(containerSpec.getServerTemplateKey(),
+                     container.getServerTemplateKey());
+        assertEquals(containerSpec.getReleasedId(),
+                     container.getReleasedId());
 
         assertNotNull(container.getConfigs());
-        assertEquals(containerSpec.getConfigs().size(), container.getConfigs().size());
+        assertEquals(containerSpec.getConfigs().size(),
+                     container.getConfigs().size());
 
         String newServerTemplateId = "Copied server id";
         String newServerTemplateName = "Copied server name";
 
-        specManagementService.copyServerTemplate(serverTemplate.getId(), newServerTemplateId, newServerTemplateName);
+        specManagementService.copyServerTemplate(serverTemplate.getId(),
+                                                 newServerTemplateId,
+                                                 newServerTemplateName);
 
         existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(2, existing.size());
+        assertEquals(2,
+                     existing.size());
 
         createdServerTemplate = specManagementService.getServerTemplate(newServerTemplateId);
         assertNotNull(createdServerTemplate);
-        assertEquals(newServerTemplateName, createdServerTemplate.getName());
-        assertEquals(newServerTemplateId, createdServerTemplate.getId());
+        assertEquals(newServerTemplateName,
+                     createdServerTemplate.getName());
+        assertEquals(newServerTemplateId,
+                     createdServerTemplate.getId());
         assertNotNull(createdServerTemplate.getContainersSpec());
-        assertEquals(1, createdServerTemplate.getContainersSpec().size());
+        assertEquals(1,
+                     createdServerTemplate.getContainersSpec().size());
 
         container = createdServerTemplate.getContainersSpec().iterator().next();
         assertNotNull(container);
 
-        assertEquals(containerSpec.getId(), container.getId());
-        assertEquals(containerSpec.getStatus(), container.getStatus());
-        assertEquals(newServerTemplateId, container.getServerTemplateKey().getId());
-        assertEquals(newServerTemplateName, container.getServerTemplateKey().getName());
-        assertEquals(containerSpec.getReleasedId(), container.getReleasedId());
+        assertEquals(containerSpec.getId(),
+                     container.getId());
+        assertEquals(containerSpec.getStatus(),
+                     container.getStatus());
+        assertEquals(newServerTemplateId,
+                     container.getServerTemplateKey().getId());
+        assertEquals(newServerTemplateName,
+                     container.getServerTemplateKey().getName());
+        assertEquals(containerSpec.getReleasedId(),
+                     container.getReleasedId());
 
         assertNotNull(container.getConfigs());
-        assertEquals(containerSpec.getConfigs().size(), container.getConfigs().size());
+        assertEquals(containerSpec.getConfigs().size(),
+                     container.getConfigs().size());
     }
 
     @Test
@@ -344,14 +399,16 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
         Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey> existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(1, existing.size());
+        assertEquals(1,
+                     existing.size());
 
         Map<Capability, ContainerConfig> configs = new HashMap<Capability, ContainerConfig>();
         RuleConfig ruleConfig = new RuleConfig();
         ruleConfig.setPollInterval(1000l);
         ruleConfig.setScannerStatus(KieScannerStatus.STARTED);
 
-        configs.put(Capability.RULE, ruleConfig);
+        configs.put(Capability.RULE,
+                    ruleConfig);
 
         ProcessConfig processConfig = new ProcessConfig();
         processConfig.setKBase("defaultKieBase");
@@ -359,66 +416,89 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
         processConfig.setMergeMode("MERGE_COLLECTION");
         processConfig.setRuntimeStrategy("PER_PROCESS_INSTANCE");
 
-        configs.put(Capability.PROCESS, processConfig);
+        configs.put(Capability.PROCESS,
+                    processConfig);
 
         ContainerSpec containerSpec = new ContainerSpec();
         containerSpec.setId("test container");
-        containerSpec.setServerTemplateKey(new ServerTemplateKey(serverTemplate.getId(), serverTemplate.getName()));
-        containerSpec.setReleasedId(new ReleaseId("org.kie", "kie-server-kjar", "1.0"));
+        containerSpec.setServerTemplateKey(new ServerTemplateKey(serverTemplate.getId(),
+                                                                 serverTemplate.getName()));
+        containerSpec.setReleasedId(new ReleaseId("org.kie",
+                                                  "kie-server-kjar",
+                                                  "1.0"));
         containerSpec.setStatus(KieContainerStatus.STOPPED);
         containerSpec.setConfigs(configs);
 
-        specManagementService.saveContainerSpec(serverTemplate.getId(), containerSpec);
+        specManagementService.saveContainerSpec(serverTemplate.getId(),
+                                                containerSpec);
 
         org.kie.server.controller.api.model.spec.ServerTemplate createdServerTemplate = specManagementService.getServerTemplate(serverTemplate.getId());
         assertNotNull(createdServerTemplate);
         assertNotNull(createdServerTemplate.getContainersSpec());
-        assertEquals(1, createdServerTemplate.getContainersSpec().size());
+        assertEquals(1,
+                     createdServerTemplate.getContainersSpec().size());
 
         org.kie.server.controller.api.model.spec.ContainerSpec container = createdServerTemplate.getContainersSpec().iterator().next();
         assertNotNull(container);
 
-        assertEquals(containerSpec.getId(), container.getId());
-        assertEquals(containerSpec.getStatus(), container.getStatus());
-        assertEquals(containerSpec.getServerTemplateKey(), container.getServerTemplateKey());
-        assertEquals(containerSpec.getReleasedId(), container.getReleasedId());
+        assertEquals(containerSpec.getId(),
+                     container.getId());
+        assertEquals(containerSpec.getStatus(),
+                     container.getStatus());
+        assertEquals(containerSpec.getServerTemplateKey(),
+                     container.getServerTemplateKey());
+        assertEquals(containerSpec.getReleasedId(),
+                     container.getReleasedId());
 
         assertNotNull(container.getConfigs());
-        assertEquals(containerSpec.getConfigs().size(), container.getConfigs().size());
+        assertEquals(containerSpec.getConfigs().size(),
+                     container.getConfigs().size());
 
         ContainerConfig ruleConfigCurrent = containerSpec.getConfigs().get(Capability.RULE);
         assertNotNull(ruleConfigCurrent);
         assertTrue(ruleConfigCurrent instanceof org.kie.server.controller.api.model.spec.RuleConfig);
-        assertEquals(ruleConfig.getPollInterval(), ((org.kie.server.controller.api.model.spec.RuleConfig)ruleConfigCurrent).getPollInterval());
-        assertEquals(ruleConfig.getScannerStatus(), ((org.kie.server.controller.api.model.spec.RuleConfig)ruleConfigCurrent).getScannerStatus());
+        assertEquals(ruleConfig.getPollInterval(),
+                     ((org.kie.server.controller.api.model.spec.RuleConfig) ruleConfigCurrent).getPollInterval());
+        assertEquals(ruleConfig.getScannerStatus(),
+                     ((org.kie.server.controller.api.model.spec.RuleConfig) ruleConfigCurrent).getScannerStatus());
 
         ContainerConfig containerConfig = new RuleConfig();
         ((RuleConfig) containerConfig).setScannerStatus(KieScannerStatus.SCANNING);
         ((RuleConfig) containerConfig).setPollInterval(10l);
 
-        specManagementService.updateContainerConfig(serverTemplate.getId(), containerSpec.getId(), Capability.RULE, containerConfig);
+        specManagementService.updateContainerConfig(serverTemplate.getId(),
+                                                    containerSpec.getId(),
+                                                    Capability.RULE,
+                                                    containerConfig);
 
         Collection<org.kie.server.controller.api.model.spec.ContainerSpec> specs = specManagementService.listContainerSpec(serverTemplate.getId());
         assertNotNull(specs);
-        assertEquals(1, specs.size());
+        assertEquals(1,
+                     specs.size());
 
         container = specs.iterator().next();
         assertNotNull(container);
 
-        assertEquals(containerSpec.getId(), container.getId());
-        assertEquals(containerSpec.getStatus(), container.getStatus());
-        assertEquals(containerSpec.getServerTemplateKey(), container.getServerTemplateKey());
-        assertEquals(containerSpec.getReleasedId(), container.getReleasedId());
+        assertEquals(containerSpec.getId(),
+                     container.getId());
+        assertEquals(containerSpec.getStatus(),
+                     container.getStatus());
+        assertEquals(containerSpec.getServerTemplateKey(),
+                     container.getServerTemplateKey());
+        assertEquals(containerSpec.getReleasedId(),
+                     container.getReleasedId());
 
         assertNotNull(container.getConfigs());
-        assertEquals(containerSpec.getConfigs().size(), container.getConfigs().size());
+        assertEquals(containerSpec.getConfigs().size(),
+                     container.getConfigs().size());
 
         ContainerConfig ruleConfigCurrent2 = containerSpec.getConfigs().get(Capability.RULE);
         assertNotNull(ruleConfigCurrent2);
         assertTrue(ruleConfigCurrent2 instanceof org.kie.server.controller.api.model.spec.RuleConfig);
-        assertEquals(((org.kie.server.controller.api.model.spec.RuleConfig)containerConfig).getPollInterval(), ((org.kie.server.controller.api.model.spec.RuleConfig)ruleConfigCurrent2).getPollInterval());
-        assertEquals(((org.kie.server.controller.api.model.spec.RuleConfig)containerConfig).getScannerStatus(), ((org.kie.server.controller.api.model.spec.RuleConfig)ruleConfigCurrent2).getScannerStatus());
-
+        assertEquals(((org.kie.server.controller.api.model.spec.RuleConfig) containerConfig).getPollInterval(),
+                     ((org.kie.server.controller.api.model.spec.RuleConfig) ruleConfigCurrent2).getPollInterval());
+        assertEquals(((org.kie.server.controller.api.model.spec.RuleConfig) containerConfig).getScannerStatus(),
+                     ((org.kie.server.controller.api.model.spec.RuleConfig) ruleConfigCurrent2).getScannerStatus());
     }
 
     @Test
@@ -426,11 +506,14 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
         createServerTemplateWithContainer();
         List<Container> fakeResult = new ArrayList<Container>();
         fakeResult.add(container);
-        when(kieServerInstanceManager.startContainer(any(ServerTemplate.class), any(ContainerSpec.class))).thenReturn(fakeResult);
+        when(kieServerInstanceManager.startContainer(any(ServerTemplate.class),
+                                                     any(ContainerSpec.class))).thenReturn(fakeResult);
 
         specManagementService.startContainer(containerSpec);
 
-        verify(kieServerInstanceManager, times(1)).startContainer(any(ServerTemplate.class), any(ContainerSpec.class));
+        verify(kieServerInstanceManager,
+               times(1)).startContainer(any(ServerTemplate.class),
+                                        any(ContainerSpec.class));
 
         ServerTemplate updated = specManagementService.getServerTemplate(serverTemplate.getId());
         assertNotNull(updated);
@@ -438,30 +521,50 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
         ContainerSpec updatedContainer = updated.getContainerSpec(containerSpec.getId());
         assertNotNull(updatedContainer);
 
-        assertEquals(KieContainerStatus.STARTED, updatedContainer.getStatus());
+        assertEquals(KieContainerStatus.STARTED,
+                     updatedContainer.getStatus());
     }
 
     @Test
     public void testStopContainer() {
         createServerTemplateWithContainer();
-        List<Container> fakeResult = new ArrayList<Container>();
-        fakeResult.add(container);
-        when(kieServerInstanceManager.stopContainer(any(ServerTemplate.class), any(ContainerSpec.class))).thenReturn(fakeResult);
 
-        specManagementService.stopContainer(containerSpec);
+        final SpecManagementServiceImpl spy = spy((SpecManagementServiceImpl) specManagementService);
+        final List<Container> fakeResult = new ArrayList<Container>() {{
+            add(container);
+        }};
+        final Runnable successCallback = () -> {
+        };
+        final Runnable errorCallback = () -> {
+        };
 
-        verify(kieServerInstanceManager, times(1)).stopContainer(any(ServerTemplate.class), any(ContainerSpec.class));
+        doReturn(successCallback).when(spy).updateContainerAsStopped(any(),
+                                                                     any());
+        doReturn(errorCallback).when(spy).updateContainerAsStarted(any(),
+                                                                   any());
+        when(kieServerInstanceManager.stopContainer(any(ServerTemplate.class),
+                                                    any(ContainerSpec.class),
+                                                    eq(successCallback),
+                                                    eq(errorCallback))).thenReturn(fakeResult);
 
-        ServerTemplate updated = specManagementService.getServerTemplate(serverTemplate.getId());
-        assertNotNull(updated);
+        spy.stopContainer(containerSpec);
 
-        ContainerSpec updatedContainer = updated.getContainerSpec(containerSpec.getId());
+        verify(kieServerInstanceManager).stopContainer(any(ServerTemplate.class),
+                                                       any(ContainerSpec.class),
+                                                       eq(successCallback),
+                                                       eq(errorCallback));
+
+        final ServerTemplate updatedServerTemplate = spy.getServerTemplate(serverTemplate.getId());
+        final ContainerSpec updatedContainer = updatedServerTemplate.getContainerSpec(containerSpec.getId());
+
+        assertNotNull(updatedServerTemplate);
         assertNotNull(updatedContainer);
-
-        assertEquals(KieContainerStatus.STOPPED, updatedContainer.getStatus());
+        assertEquals(KieContainerStatus.STOPPED,
+                     updatedContainer.getStatus());
     }
 
-    protected int getRandomInt(int min, int max) {
+    protected int getRandomInt(int min,
+                               int max) {
         return (int) Math.floor(Math.random() * (max - min + 1)) + min;
     }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerStartupIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerStartupIntegrationTest.java
@@ -220,10 +220,9 @@ public class KieControllerStartupIntegrationTest extends KieControllerManagement
         assertEquals(1, instanceList.size());
 
         // Turn kie server off, dispose container and start kie server again.
-        server.stopKieServer();
-
         mgmtControllerClient.stopContainer(kieServerInfo.getResult().getServerId(), CONTAINER_ID);
         mgmtControllerClient.deleteContainerSpec(serverTemplate.getId(), CONTAINER_ID);
+        server.stopKieServer();
 
         server.startKieServer();
 

--- a/kie-spring/src/test/java/org/kie/spring/CodeVersion.java
+++ b/kie-spring/src/test/java/org/kie/spring/CodeVersion.java
@@ -18,6 +18,6 @@ package org.kie.spring;
 public class CodeVersion {
 
     // Do not modify this: this is automatically incremented by the maven replacer plugin
-    public final static String VERSION = "7.1.0-SNAPSHOT";
+    public final static String VERSION = "7.2.0-SNAPSHOT";
 
 }


### PR DESCRIPTION
This PR solves the issue [JBPM-5457](https://issues.jboss.org/browse/JBPM-5457) and the [RHBRMS-2874](https://issues.jboss.org/browse/RHBRMS-2874).

----
Part of an ensemble:
- https://github.com/kiegroup/droolsjbpm-integration/pull/1057
- https://github.com/kiegroup/kie-wb-common/pull/987

----

- https://issues.jboss.org/browse/JBPM-5457

Before:
![before](https://user-images.githubusercontent.com/1079279/28383662-55140f12-6c98-11e7-85b6-22c772bf1143.gif)

After:
![after](https://user-images.githubusercontent.com/1079279/28383667-57f46452-6c98-11e7-9aa1-157300227b7a.gif)

----

- https://issues.jboss.org/browse/RHBRMS-2874

Before:
![before](https://user-images.githubusercontent.com/1079279/28387701-8471e32a-6ca6-11e7-937a-3ba00775d117.gif)

After:
![after](https://user-images.githubusercontent.com/1079279/28387704-869e26ae-6ca6-11e7-9e94-8697ebabfbb0.gif)
(my gif has a super low FPS rate, but when you’re using the screen, the containers are shown)
