### PR TITLE
RHBPMS-4790 - KIE Scanner not starting correctly when started using C…

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/SpecManagementServiceImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/SpecManagementServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.api.model.KieScannerStatus;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.controller.api.KieServerControllerException;
 import org.kie.server.controller.api.KieServerControllerNotFoundException;
@@ -42,12 +43,15 @@ import org.kie.server.controller.api.service.SpecManagementService;
 import org.kie.server.controller.api.storage.KieServerTemplateStorage;
 import org.kie.server.controller.impl.KieServerInstanceManager;
 import org.kie.server.controller.impl.storage.InMemoryKieServerTemplateStorage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SpecManagementServiceImpl implements SpecManagementService {
 
     private KieServerInstanceManager kieServerInstanceManager = KieServerInstanceManager.getInstance();
     private KieServerTemplateStorage templateStorage = InMemoryKieServerTemplateStorage.getInstance();
     private NotificationService notificationService = LoggingNotificationService.getInstance();
+    private static Logger logger = LoggerFactory.getLogger(SpecManagementServiceImpl.class);
 
     @Override
     public synchronized void saveContainerSpec( String serverTemplateId,
@@ -172,7 +176,10 @@ public class SpecManagementServiceImpl implements SpecManagementService {
         if ( serverTemplate == null ) {
             throw new KieServerControllerNotFoundException( "No server template found for id " + serverTemplateId );
         }
+        
         if (serverTemplate.hasContainerSpec(containerSpecId)) {
+            ContainerSpec containerSpec = serverTemplate.getContainerSpec(containerSpecId);
+            kieServerInstanceManager.stopContainer(serverTemplate, containerSpec);
             serverTemplate.deleteContainerSpec(containerSpecId);
 
             templateStorage.update(serverTemplate);
@@ -265,6 +272,31 @@ public class SpecManagementServiceImpl implements SpecManagementService {
         ContainerSpec containerSpec = serverTemplate.getContainerSpec( containerSpecId );
         if ( containerSpec == null ) {
             throw new KieServerControllerNotFoundException( "No container spec found for id " + containerSpecId + " within server template with id " + serverTemplateId );
+        }
+        List<Container> affectedContainers = null;
+        if (containerConfig instanceof RuleConfig) {
+            RuleConfig rc = (RuleConfig)containerConfig;
+            long interval = rc.getPollInterval();
+            KieScannerStatus status = rc.getScannerStatus();
+            if (status == KieScannerStatus.STARTED) {
+                affectedContainers = kieServerInstanceManager.startScanner(serverTemplate, containerSpec, interval);
+            } else if (status == KieScannerStatus.STOPPED) {
+                affectedContainers = kieServerInstanceManager.stopScanner(serverTemplate, containerSpec);
+            }
+        } else if (containerConfig instanceof ProcessConfig) {
+            ProcessConfig pc = (ProcessConfig)containerConfig;
+            kieServerInstanceManager.stopContainer(serverTemplate, containerSpec);
+            containerSpec.getConfigs().put(capability, pc);
+            affectedContainers = kieServerInstanceManager.startContainer(serverTemplate, containerSpec);
+        }
+        if (affectedContainers == null) {
+            logger.info("Update of container configuration resulted in no changes to containers running on kie-servers");
+        } else {
+            affectedContainers.forEach(ac -> {
+                logger.debug("Container {} on server {} was affected by a change in the scanner"
+                        ,ac.getContainerSpecId()
+                        ,ac.getServerInstanceKey());
+            });
         }
 
         containerSpec.getConfigs().put( capability, containerConfig );

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerManagementIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerManagementIntegrationTest.java
@@ -18,6 +18,7 @@ package org.kie.server.integrationtests.controller;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
@@ -28,8 +29,11 @@ import org.junit.experimental.categories.Category;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieContainerResourceList;
 import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.api.model.KieScannerResource;
 import org.kie.server.api.model.KieScannerStatus;
+import org.kie.server.api.model.KieServerConfigItem;
 import org.kie.server.api.model.KieServerInfo;
+import org.kie.server.api.model.KieServerStateInfo;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.controller.api.ModelFactory;
@@ -887,4 +891,94 @@ public class KieControllerManagementIntegrationTest extends KieControllerManagem
         assertEquals(kieServerInfo.getServerId(), actual.getId());
         assertEquals(kieServerInfo.getName(), actual.getName());
     }
+
+    @Test
+    public void testUpdateContainerConfigSent() {
+        // The usual setup of the kie-server along with a container spec
+        ServerTemplate serverTemplate = createServerTemplate();
+        Map<Capability, ContainerConfig> containerConfigMap = new HashMap();
+        ProcessConfig processConfig = new ProcessConfig("PER_PROCESS_INSTANCE", "kieBase", "kieSession", "MERGE_COLLECTION");
+        containerConfigMap.put(Capability.PROCESS, processConfig);
+        RuleConfig ruleConfig = new RuleConfig(500l, KieScannerStatus.STARTED);
+        containerConfigMap.put(Capability.RULE, ruleConfig);
+        ContainerSpec containerSpec = new ContainerSpec(CONTAINER_ID, CONTAINER_NAME, serverTemplate, releaseId, KieContainerStatus.STARTED, containerConfigMap);
+
+        // Tell the controller to save the spec for the given template, which since the
+        // container status is STARTED should also cause it to be deployed to the kie-server
+        mgmtControllerClient.saveContainerSpec(serverTemplate.getId(), containerSpec);
+        checkContainerConfigAgainstServer(processConfig,ruleConfig);
+
+        // Update the container configuration, turning off the scanner
+        ruleConfig = new RuleConfig(1000l, KieScannerStatus.STOPPED);
+        mgmtControllerClient.updateContainerConfig(kieServerInfo.getServerId(), CONTAINER_ID, Capability.RULE, ruleConfig);
+        checkContainerConfigAgainstServer(ruleConfig);
+
+        processConfig = new ProcessConfig("SINGLETON", "defaultKieBase", "defaultKieSession", "OVERRIDE_ALL");
+        mgmtControllerClient.updateContainerConfig(kieServerInfo.getServerId(), CONTAINER_ID, Capability.PROCESS, processConfig);
+        checkContainerConfigAgainstServer(processConfig);
+
+        // Restart the scanner with the new interval
+        ruleConfig.setScannerStatus(KieScannerStatus.STARTED);
+        mgmtControllerClient.updateContainerConfig(kieServerInfo.getServerId(), CONTAINER_ID, Capability.RULE, ruleConfig);
+        checkContainerConfigAgainstServer(ruleConfig,processConfig);
+    }
+
+    @Test
+    public void testDeleteContainerStopsContainer() {
+        ServerTemplate serverTemplate = createServerTemplate();
+        Map<Capability, ContainerConfig> containerConfigMap = new HashMap();
+
+        ContainerSpec containerSpec = new ContainerSpec(CONTAINER_ID, CONTAINER_NAME, serverTemplate, releaseId, KieContainerStatus.STARTED, containerConfigMap);
+        mgmtControllerClient.saveContainerSpec(serverTemplate.getId(), containerSpec);
+
+        ServiceResponse<KieServerStateInfo> response = client.getServerState();
+        assumeThat(response.getType(), is(ServiceResponse.ResponseType.SUCCESS));
+
+        KieServerStateInfo serverState = response.getResult();
+        assertNotNull(serverState);
+        assertTrue("Expected to find containers, but none were found", serverState.getContainers() != null && serverState.getContainers().size() > 0);
+
+        mgmtControllerClient.deleteContainerSpec(serverTemplate.getId(), CONTAINER_ID);
+        response = client.getServerState();
+        serverState = response.getResult();
+        assertNotNull(serverState);
+        assertFalse("Did not expect to find containers", serverState.getContainers() != null && serverState.getContainers().size() > 0);
+    }
+
+    protected void checkContainerConfigAgainstServer(ContainerConfig...configs) {
+        ServiceResponse<KieContainerResource> containerResource = client.getContainerInfo(CONTAINER_ID);
+        assumeThat(containerResource.getType(), is(ServiceResponse.ResponseType.SUCCESS));
+
+        KieContainerResource kcr = containerResource.getResult();
+        assertNotNull(kcr);
+        for (ContainerConfig config: configs) {
+            if (config instanceof ProcessConfig) {
+                ProcessConfig pc = (ProcessConfig)config;
+                Map<String, String> configMap = new HashMap();
+                configMap.put("KBase", pc.getKBase());
+                configMap.put("KSession", pc.getKSession());
+                configMap.put("MergeMode", pc.getMergeMode());
+                configMap.put("RuntimeStrategy", pc.getRuntimeStrategy());
+
+                assertNotNull("No configuration items found for checking process configuration",kcr.getConfigItems());
+                List<KieServerConfigItem> kci = kcr.getConfigItems();
+                for (KieServerConfigItem item: kci) {
+                    String name = item.getName();
+                    String value = item.getValue();
+                    assertEquals(configMap.get(name),value);
+                }
+            } else if (config instanceof RuleConfig) {
+                RuleConfig rc = (RuleConfig)config;
+                KieScannerResource scanner = kcr.getScanner();
+                assertNotNull("No scanner resource found",scanner);
+                assertEquals(rc.getScannerStatus(),scanner.getStatus());
+                // Only test the polling interval when starting the scanner
+                // since it could be wrong at any other time
+                if (rc.getScannerStatus() == KieScannerStatus.STARTED) {
+                    assertEquals(rc.getPollInterval(),scanner.getPollInterval());
+                }
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
…ontroller REST API

* Updated SpecManagementServiceImpl.updateContainerConfig(...) so that the update of a container's configuration (i.e. changing the scanner settings) results in the server being informed of the change; thus causing the kie-server to change the container's scanner also
* Updated SpecManagementServiceImpl.deleteContainerSpec(...) so that deleting the container would call the KieServerInstanceManager.stopContainer(...) method, which tells the kie-server to stop (undeploy) the container