### PR TITLE
RHBRMS-2874: Start/stop container buttons should be enabled/disabled only when the operation finished

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
@@ -116,7 +116,7 @@ public class KieServerInstanceManager {
     }
 
 
-    public List<Container> startContainer(ServerTemplate serverTemplate, final ContainerSpec containerSpec) {
+    public synchronized List<Container> startContainer(ServerTemplate serverTemplate, final ContainerSpec containerSpec) {
 
         return callRemoteKieServerOperation(serverTemplate, containerSpec, new RemoteKieServerOperation<Void>(){
             @Override
@@ -182,7 +182,7 @@ public class KieServerInstanceManager {
         });
     }
 
-    public List<Container> stopContainer(ServerTemplate serverTemplate, final ContainerSpec containerSpec) {
+    public synchronized List<Container> stopContainer(ServerTemplate serverTemplate, final ContainerSpec containerSpec) {
 
         return callRemoteKieServerOperation(serverTemplate, containerSpec, new RemoteKieServerOperation<Void>(){
             @Override


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-2874

Before:
![before](https://user-images.githubusercontent.com/1079279/28649694-0b5d43c4-724d-11e7-9a12-ad9357be1d97.gif)

After:
![after](https://user-images.githubusercontent.com/1079279/28649696-0dce89ce-724d-11e7-922e-be30c8333223.gif)

Part of an ensemble:
- https://github.com/kiegroup/droolsjbpm-integration/pull/1073
- https://github.com/kiegroup/kie-wb-common/pull/995
