### PR TITLE
RHBRMS-2878: Start/stop container buttons are in wrong state after container upgrade

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/RuleCapabilitiesServiceImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/RuleCapabilitiesServiceImpl.java
@@ -17,6 +17,7 @@ package org.kie.server.controller.impl.service;
 
 import java.util.List;
 
+import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.KieScannerStatus;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.controller.api.model.runtime.Container;
@@ -34,7 +35,8 @@ import org.kie.server.controller.impl.storage.InMemoryKieServerTemplateStorage;
 
 public class RuleCapabilitiesServiceImpl implements RuleCapabilitiesService {
 
-    private KieServerTemplateStorage templateStorage = InMemoryKieServerTemplateStorage.getInstance();;
+    private KieServerTemplateStorage templateStorage = InMemoryKieServerTemplateStorage.getInstance();
+    ;
     private KieServerInstanceManager kieServerInstanceManager = KieServerInstanceManager.getInstance();
     private NotificationService notificationService = LoggingNotificationService.getInstance();
 
@@ -47,13 +49,17 @@ public class RuleCapabilitiesServiceImpl implements RuleCapabilitiesService {
 
         ContainerSpec containerSpec = serverTemplate.getContainerSpec(containerSpecKey.getId());
 
-        List<Container> containers = kieServerInstanceManager.scanNow(serverTemplate, containerSpec);
+        List<Container> containers = kieServerInstanceManager.scanNow(serverTemplate,
+                                                                      containerSpec);
 
-        notificationService.notify(serverTemplate, containerSpec, containers);
+        notificationService.notify(serverTemplate,
+                                   containerSpec,
+                                   containers);
     }
 
     @Override
-    public void startScanner(final ContainerSpecKey containerSpecKey, long interval) {
+    public void startScanner(final ContainerSpecKey containerSpecKey,
+                             long interval) {
 
         ServerTemplate serverTemplate = templateStorage.load(containerSpecKey.getServerTemplateKey().getId());
         if (serverTemplate == null) {
@@ -65,7 +71,8 @@ public class RuleCapabilitiesServiceImpl implements RuleCapabilitiesService {
         ContainerConfig containerConfig = containerSpec.getConfigs().get(Capability.RULE);
         if (containerConfig == null) {
             containerConfig = new RuleConfig();
-            containerSpec.getConfigs().put(Capability.RULE, containerConfig);
+            containerSpec.getConfigs().put(Capability.RULE,
+                                           containerConfig);
         }
 
         ((RuleConfig) containerConfig).setPollInterval(interval);
@@ -73,9 +80,13 @@ public class RuleCapabilitiesServiceImpl implements RuleCapabilitiesService {
 
         templateStorage.update(serverTemplate);
 
-        List<Container> containers = kieServerInstanceManager.startScanner(serverTemplate, containerSpec, interval);
+        List<Container> containers = kieServerInstanceManager.startScanner(serverTemplate,
+                                                                           containerSpec,
+                                                                           interval);
 
-        notificationService.notify(serverTemplate, containerSpec, containers);
+        notificationService.notify(serverTemplate,
+                                   containerSpec,
+                                   containers);
     }
 
     @Override
@@ -90,7 +101,8 @@ public class RuleCapabilitiesServiceImpl implements RuleCapabilitiesService {
         ContainerConfig containerConfig = containerSpec.getConfigs().get(Capability.RULE);
         if (containerConfig == null) {
             containerConfig = new RuleConfig();
-            containerSpec.getConfigs().put(Capability.RULE, containerConfig);
+            containerSpec.getConfigs().put(Capability.RULE,
+                                           containerConfig);
         }
 
         ((RuleConfig) containerConfig).setPollInterval(null);
@@ -98,13 +110,17 @@ public class RuleCapabilitiesServiceImpl implements RuleCapabilitiesService {
 
         templateStorage.update(serverTemplate);
 
-        List<Container> containers = kieServerInstanceManager.stopScanner(serverTemplate, containerSpec);
+        List<Container> containers = kieServerInstanceManager.stopScanner(serverTemplate,
+                                                                          containerSpec);
 
-        notificationService.notify(serverTemplate, containerSpec, containers);
+        notificationService.notify(serverTemplate,
+                                   containerSpec,
+                                   containers);
     }
 
     @Override
-    public void upgradeContainer(final ContainerSpecKey containerSpecKey, ReleaseId releaseId) {
+    public void upgradeContainer(final ContainerSpecKey containerSpecKey,
+                                 ReleaseId releaseId) {
         ServerTemplate serverTemplate = templateStorage.load(containerSpecKey.getServerTemplateKey().getId());
         if (serverTemplate == null) {
             throw new RuntimeException("No server template found for id " + containerSpecKey.getServerTemplateKey().getId());
@@ -114,17 +130,20 @@ public class RuleCapabilitiesServiceImpl implements RuleCapabilitiesService {
         if (releaseId.getGroupId() == null) {
             releaseId.setGroupId(containerSpec.getReleasedId().getGroupId());
         }
-        if (releaseId.getArtifactId()== null) {
+        if (releaseId.getArtifactId() == null) {
             releaseId.setArtifactId(containerSpec.getReleasedId().getArtifactId());
         }
 
         containerSpec.setReleasedId(releaseId);
-
+        containerSpec.setStatus(KieContainerStatus.STARTED);
         templateStorage.update(serverTemplate);
 
-        List<Container> containers = kieServerInstanceManager.upgradeContainer(serverTemplate, containerSpec);
+        List<Container> containers = kieServerInstanceManager.upgradeContainer(serverTemplate,
+                                                                               containerSpec);
 
-        notificationService.notify(serverTemplate, containerSpec, containers);
+        notificationService.notify(serverTemplate,
+                                   containerSpec,
+                                   containers);
     }
 
     public KieServerTemplateStorage getTemplateStorage() {

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/RuleCapabilitiesServiceImplTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/RuleCapabilitiesServiceImplTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.KieScannerStatus;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.controller.api.model.runtime.Container;
@@ -45,7 +46,7 @@ public class RuleCapabilitiesServiceImplTest extends AbstractServiceImplTest {
         specManagementService = new SpecManagementServiceImpl();
         kieServerInstanceManager = Mockito.mock(KieServerInstanceManager.class);
 
-        ((RuleCapabilitiesServiceImpl)ruleCapabilitiesService).setKieServerInstanceManager(kieServerInstanceManager);
+        ((RuleCapabilitiesServiceImpl) ruleCapabilitiesService).setKieServerInstanceManager(kieServerInstanceManager);
 
         createServerTemplateWithContainer();
     }
@@ -60,11 +61,14 @@ public class RuleCapabilitiesServiceImplTest extends AbstractServiceImplTest {
 
         List<Container> fakeResult = new ArrayList<Container>();
         fakeResult.add(container);
-        when(kieServerInstanceManager.scanNow(any(ServerTemplate.class), any(ContainerSpec.class))).thenReturn(fakeResult);
+        when(kieServerInstanceManager.scanNow(any(ServerTemplate.class),
+                                              any(ContainerSpec.class))).thenReturn(fakeResult);
 
         ruleCapabilitiesService.scanNow(containerSpec);
 
-        verify(kieServerInstanceManager, times(1)).scanNow(any(ServerTemplate.class), any(ContainerSpec.class));
+        verify(kieServerInstanceManager,
+               times(1)).scanNow(any(ServerTemplate.class),
+                                 any(ContainerSpec.class));
     }
 
     @Test
@@ -72,17 +76,24 @@ public class RuleCapabilitiesServiceImplTest extends AbstractServiceImplTest {
 
         List<Container> fakeResult = new ArrayList<Container>();
         fakeResult.add(container);
-        when(kieServerInstanceManager.startScanner(any(ServerTemplate.class), any(ContainerSpec.class), anyLong())).thenReturn(fakeResult);
+        when(kieServerInstanceManager.startScanner(any(ServerTemplate.class),
+                                                   any(ContainerSpec.class),
+                                                   anyLong())).thenReturn(fakeResult);
 
-        ruleCapabilitiesService.startScanner(containerSpec, 100l);
+        ruleCapabilitiesService.startScanner(containerSpec,
+                                             100l);
 
-        verify(kieServerInstanceManager, times(1)).startScanner(any(ServerTemplate.class), any(ContainerSpec.class), anyLong());
+        verify(kieServerInstanceManager,
+               times(1)).startScanner(any(ServerTemplate.class),
+                                      any(ContainerSpec.class),
+                                      anyLong());
 
         ServerTemplate updated = specManagementService.getServerTemplate(serverTemplate.getId());
 
         Collection<ContainerSpec> containerSpecs = updated.getContainersSpec();
         assertNotNull(containerSpecs);
-        assertEquals(1, containerSpecs.size());
+        assertEquals(1,
+                     containerSpecs.size());
 
         ContainerSpec updatedContainer = containerSpecs.iterator().next();
         assertNotNull(updatedContainer);
@@ -93,25 +104,31 @@ public class RuleCapabilitiesServiceImplTest extends AbstractServiceImplTest {
 
         RuleConfig ruleCg = (RuleConfig) ruleConfig;
 
-        assertEquals(KieScannerStatus.STARTED, ruleCg.getScannerStatus());
-        assertEquals(100l, ruleCg.getPollInterval().longValue());
+        assertEquals(KieScannerStatus.STARTED,
+                     ruleCg.getScannerStatus());
+        assertEquals(100l,
+                     ruleCg.getPollInterval().longValue());
     }
 
     @Test
     public void testStopScanner() {
         List<Container> fakeResult = new ArrayList<Container>();
         fakeResult.add(container);
-        when(kieServerInstanceManager.stopScanner(any(ServerTemplate.class), any(ContainerSpec.class))).thenReturn(fakeResult);
+        when(kieServerInstanceManager.stopScanner(any(ServerTemplate.class),
+                                                  any(ContainerSpec.class))).thenReturn(fakeResult);
 
         ruleCapabilitiesService.stopScanner(containerSpec);
 
-        verify(kieServerInstanceManager, times(1)).stopScanner(any(ServerTemplate.class), any(ContainerSpec.class));
+        verify(kieServerInstanceManager,
+               times(1)).stopScanner(any(ServerTemplate.class),
+                                     any(ContainerSpec.class));
 
         ServerTemplate updated = specManagementService.getServerTemplate(serverTemplate.getId());
 
         Collection<ContainerSpec> containerSpecs = updated.getContainersSpec();
         assertNotNull(containerSpecs);
-        assertEquals(1, containerSpecs.size());
+        assertEquals(1,
+                     containerSpecs.size());
 
         ContainerSpec updatedContainer = containerSpecs.iterator().next();
         assertNotNull(updatedContainer);
@@ -122,7 +139,8 @@ public class RuleCapabilitiesServiceImplTest extends AbstractServiceImplTest {
 
         RuleConfig ruleCg = (RuleConfig) ruleConfig;
 
-        assertEquals(KieScannerStatus.STOPPED, ruleCg.getScannerStatus());
+        assertEquals(KieScannerStatus.STOPPED,
+                     ruleCg.getScannerStatus());
         assertNull(ruleCg.getPollInterval());
     }
 
@@ -131,27 +149,37 @@ public class RuleCapabilitiesServiceImplTest extends AbstractServiceImplTest {
 
         List<Container> fakeResult = new ArrayList<Container>();
         fakeResult.add(container);
-        when(kieServerInstanceManager.upgradeContainer(any(ServerTemplate.class), any(ContainerSpec.class))).thenReturn(fakeResult);
+        when(kieServerInstanceManager.upgradeContainer(any(ServerTemplate.class),
+                                                       any(ContainerSpec.class))).thenReturn(fakeResult);
 
         ReleaseId initial = containerSpec.getReleasedId();
-        ReleaseId upgradeTo = new ReleaseId("org.kie", "kie-server-kjar", "2.0");
+        ReleaseId upgradeTo = new ReleaseId("org.kie",
+                                            "kie-server-kjar",
+                                            "2.0");
 
-        ruleCapabilitiesService.upgradeContainer(containerSpec, upgradeTo);
+        ruleCapabilitiesService.upgradeContainer(containerSpec,
+                                                 upgradeTo);
 
-        verify(kieServerInstanceManager, times(1)).upgradeContainer(any(ServerTemplate.class), any(ContainerSpec.class));
+        verify(kieServerInstanceManager,
+               times(1)).upgradeContainer(any(ServerTemplate.class),
+                                          any(ContainerSpec.class));
 
         ServerTemplate updated = specManagementService.getServerTemplate(serverTemplate.getId());
 
         Collection<ContainerSpec> containerSpecs = updated.getContainersSpec();
         assertNotNull(containerSpecs);
-        assertEquals(1, containerSpecs.size());
+        assertEquals(1,
+                     containerSpecs.size());
 
         ContainerSpec updatedContainer = containerSpecs.iterator().next();
         assertNotNull(updatedContainer);
 
         assertNotNull(updatedContainer.getReleasedId());
-        assertNotEquals(initial, updatedContainer.getReleasedId());
-        assertEquals(upgradeTo, updatedContainer.getReleasedId());
+        assertNotEquals(initial,
+                        updatedContainer.getReleasedId());
+        assertEquals(upgradeTo,
+                     updatedContainer.getReleasedId());
+        assertEquals(updatedContainer.getStatus(),
+                     KieContainerStatus.STARTED);
     }
-
 }


### PR DESCRIPTION
See https://issues.jboss.org/browse/RHBRMS-2878

Before:
![before](https://user-images.githubusercontent.com/1079279/28672421-1550423c-72b6-11e7-9f1d-b4bd1def47db.gif)

After:
![after](https://user-images.githubusercontent.com/1079279/28672451-2f91995c-72b6-11e7-8e5f-56bae8e6e724.gif)

