### PR TITLE
[6.5.x] RHBRMS-2878: Start/stop container buttons are in wrong state after container upgrade

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/RuleCapabilitiesServiceImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/RuleCapabilitiesServiceImpl.java
@@ -17,6 +17,7 @@ package org.kie.server.controller.impl.service;
 
 import java.util.List;
 
+import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.KieScannerStatus;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.controller.api.model.runtime.Container;
@@ -119,7 +120,7 @@ public class RuleCapabilitiesServiceImpl implements RuleCapabilitiesService {
         }
 
         containerSpec.setReleasedId(releaseId);
-
+        containerSpec.setStatus(KieContainerStatus.STARTED);
         templateStorage.update(serverTemplate);
 
         List<Container> containers = kieServerInstanceManager.upgradeContainer(serverTemplate, containerSpec);

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/RuleCapabilitiesServiceImplTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/RuleCapabilitiesServiceImplTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.KieScannerStatus;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.controller.api.model.runtime.Container;
@@ -152,6 +153,7 @@ public class RuleCapabilitiesServiceImplTest extends AbstractServiceImplTest {
         assertNotNull(updatedContainer.getReleasedId());
         assertNotEquals(initial, updatedContainer.getReleasedId());
         assertEquals(upgradeTo, updatedContainer.getReleasedId());
+        assertEquals(updatedContainer.getStatus(), KieContainerStatus.STARTED);
     }
 
 }


### PR DESCRIPTION
Cherry picked from https://github.com/kiegroup/droolsjbpm-integration/pull/1074