### PR TITLE
JBPM-6274 - Update batik to 1.9 for 6.5.x

### DIFF
--- a/jbpm-process-svg/pom.xml
+++ b/jbpm-process-svg/pom.xml
@@ -13,7 +13,7 @@
 
   <dependencies>
     <dependency>
-      <groupId>batik</groupId>
+      <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-svg-dom</artifactId>
       <exclusions>
         <exclusion>
@@ -23,8 +23,12 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>batik</groupId>
+      <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.xmlgraphics</groupId>
+      <artifactId>batik-anim</artifactId>
     </dependency>
 
     <!-- test dependencies -->

--- a/jbpm-process-svg/src/main/java/org/jbpm/process/svg/SVGImageProcessor.java
+++ b/jbpm-process-svg/src/main/java/org/jbpm/process/svg/SVGImageProcessor.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -26,8 +26,8 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import org.apache.batik.dom.svg.SAXSVGDocumentFactory;
-import org.apache.batik.dom.svg.SVGOMTSpanElement;
+import org.apache.batik.anim.dom.SAXSVGDocumentFactory;
+import org.apache.batik.anim.dom.SVGOMTSpanElement;
 import org.apache.batik.util.XMLResourceDescriptor;
 import org.jbpm.process.svg.model.NodeSummary;
 import org.jbpm.process.svg.model.SVGSummary;
@@ -49,7 +49,7 @@ public class SVGImageProcessor {
     public SVGImageProcessor(InputStream svg) {
         this(svg, true);
     }
-    
+
     public SVGImageProcessor(InputStream svg, boolean mapById) {
         this.mapById = mapById;
         try {
@@ -161,5 +161,5 @@ public class SVGImageProcessor {
             processNodes(node.getChildNodes());
         }
     }
-    
+
 }

--- a/jbpm-process-svg/src/test/java/org/jbpm/process/svg/TestEvalutionSVG.java
+++ b/jbpm-process-svg/src/test/java/org/jbpm/process/svg/TestEvalutionSVG.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -26,7 +26,7 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
-import org.apache.batik.dom.svg.SAXSVGDocumentFactory;
+import org.apache.batik.anim.dom.SAXSVGDocumentFactory;
 import org.apache.batik.util.XMLResourceDescriptor;
 import org.junit.Test;
 import org.w3c.dom.Document;

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee6-container.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee6-container.xml
@@ -59,7 +59,7 @@
         <exclude>stax:stax-api</exclude>
         <exclude>javax.activation:activation</exclude>
         <exclude>org.hibernate.javax.persistence:hibernate-jpa-2.0-api</exclude>
-        <exclude>xml-apis:xml-apis</exclude>
+        <exclude>xml-apis:xml-apis:*</exclude>
         <exclude>org.javassist:javassist</exclude>
       </excludes>
       <includes>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee7-container.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee7-container.xml
@@ -85,7 +85,7 @@
         <exclude>stax:stax-api</exclude>
         <exclude>javax.activation:activation</exclude>
         <exclude>org.hibernate.javax.persistence:hibernate-jpa-2.0-api</exclude>
-        <exclude>xml-apis:xml-apis</exclude>
+        <exclude>xml-apis:xml-apis:*</exclude>
       </excludes>
       <outputDirectory>WEB-INF/lib</outputDirectory>
       <useTransitiveFiltering>true</useTransitiveFiltering>


### PR DESCRIPTION
resolving compilation errors after batik upgrade by https://github.com/kiegroup/droolsjbpm-build-bootstrap/commit/45522ac393753e93c6ba3d3350ce41c7240d5b5a

@mbiarnes @tsurdilo could you please have a look?