### PR TITLE
[7.2.x] RHBRMS-2874: Start/stop container buttons should be enabled/disabled only when the operation finished

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
@@ -116,7 +116,7 @@ public class KieServerInstanceManager {
     }
 
 
-    public List<Container> startContainer(ServerTemplate serverTemplate, final ContainerSpec containerSpec) {
+    public synchronized List<Container> startContainer(ServerTemplate serverTemplate, final ContainerSpec containerSpec) {
 
         return callRemoteKieServerOperation(serverTemplate, containerSpec, new RemoteKieServerOperation<Void>(){
             @Override
@@ -182,7 +182,7 @@ public class KieServerInstanceManager {
         });
     }
 
-    public List<Container> stopContainer(ServerTemplate serverTemplate, final ContainerSpec containerSpec) {
+    public synchronized List<Container> stopContainer(ServerTemplate serverTemplate, final ContainerSpec containerSpec) {
 
         return callRemoteKieServerOperation(serverTemplate, containerSpec, new RemoteKieServerOperation<Void>(){
             @Override


### PR DESCRIPTION
Cherry picked from https://github.com/kiegroup/droolsjbpm-integration/pull/1073

---

Part of an ensemble:
- https://github.com/kiegroup/kie-wb-common/pull/1002
- https://github.com/kiegroup/droolsjbpm-integration/pull/1082
