### PR TITLE
Add CXF dependency to Wildfly/EAP deployable

### DIFF
--- a/kie-server-parent/kie-server-wars/kie-server/src/main/shared-ee6-ee7-resources/WEB-INF/jboss-deployment-structure.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/shared-ee6-ee7-resources/WEB-INF/jboss-deployment-structure.xml
@@ -26,6 +26,7 @@
            the WAR depends on private modules. -->
       <!-- Keep the alphabetical order! -->
       <module name="org.apache.xerces"/>
+      <module name="org.apache.cxf"/>
     </dependencies>
   </deployment>
 </jboss-deployment-structure>


### PR DESCRIPTION
To return cxf-rt-ws-policy excluded by https://github.com/kiegroup/droolsjbpm-integration/pull/885