### PR TITLE
[7.2.x] JBPM-6027: Advanced Search API shows error code 500 instead of 400

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm-search/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm-search/pom.xml
@@ -52,7 +52,12 @@
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-services-api</artifactId>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-dataset-api</artifactId>
+    </dependency>
+        
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm-search/src/main/java/org/kie/server/remote/rest/jbpm/search/ProcessInstanceSearchResource.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm-search/src/main/java/org/kie/server/remote/rest/jbpm/search/ProcessInstanceSearchResource.java
@@ -38,6 +38,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.dashbuilder.dataset.exception.DataSetLookupException;
 import org.kie.server.api.model.instance.ProcessInstanceList;
 import org.kie.server.common.rest.HttpStatusCodeException;
 import org.kie.server.remote.rest.common.Header;
@@ -93,7 +94,7 @@ public class ProcessInstanceSearchResource {
                                          conversationIdHeader );
         } catch ( Exception e ) {
             Throwable root = ExceptionUtils.getRootCause( e );
-            if ( HttpStatusCodeException.BAD_REQUEST.contains( root.getClass() ) ) {
+            if ( HttpStatusCodeException.BAD_REQUEST.contains( root.getClass() ) || e instanceof DataSetLookupException) {
 
                 logger.error( "{}",
                               MessageFormat.format( BAD_REQUEST,

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm-search/src/main/java/org/kie/server/remote/rest/jbpm/search/TaskSearchResource.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm-search/src/main/java/org/kie/server/remote/rest/jbpm/search/TaskSearchResource.java
@@ -38,6 +38,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.dashbuilder.dataset.exception.DataSetLookupException;
 import org.kie.server.api.model.instance.TaskInstanceList;
 import org.kie.server.common.rest.HttpStatusCodeException;
 import org.kie.server.remote.rest.common.Header;
@@ -93,7 +94,7 @@ public class TaskSearchResource {
 
         } catch ( Exception e ) {
             Throwable root = ExceptionUtils.getRootCause( e );
-            if (HttpStatusCodeException.BAD_REQUEST.contains( root.getClass() ) ) {
+            if ( HttpStatusCodeException.BAD_REQUEST.contains( root.getClass() ) || e instanceof DataSetLookupException ) {
 
                 logger.error( "{}",
                               MessageFormat.format( BAD_REQUEST,

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/pom.xml
@@ -101,6 +101,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.dashbuilder</groupId>
+      <artifactId>dashbuilder-dataset-api</artifactId>
+    </dependency>
+    
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/main/java/org/kie/server/remote/rest/jbpm/QueryDataResource.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/main/java/org/kie/server/remote/rest/jbpm/QueryDataResource.java
@@ -16,6 +16,8 @@
 package org.kie.server.remote.rest.jbpm;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.dashbuilder.dataset.exception.DataSetLookupException;
+
 import static org.kie.server.api.rest.RestURI.CREATE_QUERY_DEF_POST_URI;
 import static org.kie.server.api.rest.RestURI.DROP_QUERY_DEF_DELETE_URI;
 import static org.kie.server.api.rest.RestURI.QUERY_DEF_GET_URI;
@@ -320,7 +322,7 @@ public class QueryDataResource {
                                          conversationIdHeader );
         } catch ( Exception e ) {
             Throwable root = ExceptionUtils.getRootCause( e );
-            if ( HttpStatusCodeException.BAD_REQUEST.contains( root.getClass() ) ) {
+            if ( HttpStatusCodeException.BAD_REQUEST.contains( root.getClass() ) || e instanceof DataSetLookupException) {
 
                 logger.error( "{}",
                               MessageFormat.format( BAD_REQUEST,


### PR DESCRIPTION
@domhanak one more attempt.  I did not test against the various DBs but  DataSetLookupException is what is thrown when the BAD REQUESTs are encountered.  Please test and let me know.