### PR TITLE
DROOLS-845 - @KSession throws exception when using kmodule in separate jar

### DIFF
--- a/kie-spring/src/main/java/org/kie/spring/annotations/AnnotationsPostProcessor.java
+++ b/kie-spring/src/main/java/org/kie/spring/annotations/AnnotationsPostProcessor.java
@@ -255,7 +255,7 @@ class AnnotationsPostProcessor implements InstantiationAwareBeanPostProcessor,
                 }
                 return kieContainer.getKieBase();
             }
-            if( getReleaseId().equals(AnnotationsPostProcessor.this.getReleaseId())) {
+            if( getReleaseId() == null || getReleaseId().equals(AnnotationsPostProcessor.this.getReleaseId())) {
                 return beanFactory.getBean(name);
             } else {
                 KieContainer kieContainer = kieContainerMap.get(getReleaseId());
@@ -282,7 +282,7 @@ class AnnotationsPostProcessor implements InstantiationAwareBeanPostProcessor,
         }
 
         protected Object getResourceToInject(Object target, String requestingBeanName) {
-            if( getReleaseId().equals(AnnotationsPostProcessor.this.getReleaseId())) {
+            if( getReleaseId() == null || getReleaseId().equals(AnnotationsPostProcessor.this.getReleaseId())) {
                 return beanFactory.getBean(name);
             } else {
                 KieContainer kieContainer = kieContainerMap.get(getReleaseId());


### PR DESCRIPTION
KSession and KBase annotations were both assuming that a ReleaseId was provided, resulting in a NPE when only annotation value was present.

If ReleaseId is null just delegates to Spring Bean Factory to create the named bean.