### PR TITLE
JBPM-6085: Exclude jboss-jaxrs-api_2.0_spec

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-standalone/src/main/assembly/assembly-ee7-container.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-standalone/src/main/assembly/assembly-ee7-container.xml
@@ -46,6 +46,7 @@
     <dependencySet>
       <excludes>
         <exclude>org.jboss.resteasy:resteasy-jaxrs</exclude>
+        <exclude>org.jboss.spec.javax.ws.rs:*</exclude>
       </excludes>
       <includes>
         <include>org.kie.server:kie-server-controller-api</include>


### PR DESCRIPTION
Should fix the WAS 9 controller issue.