### PR TITLE
AF-540: adapted to use appformer generic java model

### DIFF
--- a/kie-eap-integration/kie-eap-distribution/pom.xml
+++ b/kie-eap-integration/kie-eap-distribution/pom.xml
@@ -42,6 +42,16 @@
   </build>
 
   <dependencies>
+    <!-- appformer workbench models -->
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-project-datamodel-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-project-datamodel-commons</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-api</artifactId>

--- a/kie-eap-integration/kie-eap-distribution/src/main/assembly/assembly.xml
+++ b/kie-eap-integration/kie-eap-distribution/src/main/assembly/assembly.xml
@@ -69,6 +69,9 @@
     <componentDescriptor>${project.basedir}/src/main/filtered-resources/org/springframework/web/assembly-component.xml</componentDescriptor>
     <componentDescriptor>${project.basedir}/src/main/filtered-resources/org/springframework/tx/assembly-component.xml</componentDescriptor>
     <componentDescriptor>${project.basedir}/src/main/filtered-resources/org/tukaani/assembly-component.xml</componentDescriptor>
+    <componentDescriptor>${project.basedir}/src/main/filtered-resources/org/uberfire/commons/assembly-component.xml</componentDescriptor>
+    <componentDescriptor>${project.basedir}/src/main/filtered-resources/org/uberfire/project-datamodel-api/assembly-component.xml</componentDescriptor>
+    <componentDescriptor>${project.basedir}/src/main/filtered-resources/org/uberfire/project-datamodel-commons/assembly-component.xml</componentDescriptor>
     <componentDescriptor>${project.basedir}/src/main/filtered-resources/org/uberfire/maven-support/assembly-component.xml</componentDescriptor>
     <componentDescriptor>${project.basedir}/src/main/filtered-resources/org/uberfire/maven-integration/assembly-component.xml</componentDescriptor>
     <componentDescriptor>${project.basedir}/src/main/filtered-resources/org/wildfly/extras/config/plugin/bpms/assembly-component.xml</componentDescriptor>

--- a/kie-eap-integration/kie-eap-distribution/src/main/filtered-resources/org/drools/module.xml
+++ b/kie-eap-integration/kie-eap-distribution/src/main/filtered-resources/org/drools/module.xml
@@ -48,5 +48,7 @@
     <module name="org.slf4j" slot="main" services="import"/>
     <module name="org.eclipse.jdt.core.compiler"/>
     <module name="org.uberfire.maven-support" slot="main" services="import"/>
+    <module name="org.uberfire.project-datamodel-api" slot="main" services="import"/>
+    <module name="org.uberfire.project-datamodel-commons" slot="main" services="import"/>
   </dependencies>
 </module>

--- a/kie-eap-integration/kie-eap-distribution/src/main/filtered-resources/org/uberfire/commons/assembly-component.xml
+++ b/kie-eap-integration/kie-eap-distribution/src/main/filtered-resources/org/uberfire/commons/assembly-component.xml
@@ -17,17 +17,17 @@
 
   <files>
     <file>
-      <source>${project.build.outputDirectory}/org/uberfire/maven-integration/module.xml</source>
-      <outputDirectory>modules/system/layers/bpms/org/uberfire/maven-integration/main</outputDirectory>
+      <source>${project.build.outputDirectory}/org/uberfire/commons/module.xml</source>
+      <outputDirectory>modules/system/layers/bpms/org/uberfire/commons/main</outputDirectory>
     </file>
   </files>
   <dependencySets>
     <dependencySet>
       <useTransitiveDependencies>false</useTransitiveDependencies>
       <includes>
-        <include>org.uberfire:uberfire-maven-integration</include>
+        <include>org.uberfire:uberfire-commons</include>
       </includes>
-      <outputDirectory>modules/system/layers/bpms/org/uberfire/maven-integration/main</outputDirectory>
+      <outputDirectory>modules/system/layers/bpms/org/uberfire/commons/main</outputDirectory>
       <outputFileNameMapping>${artifact.artifactId}-${version.org.uberfire}.${artifact.extension}</outputFileNameMapping>
     </dependencySet>
   </dependencySets>

--- a/kie-eap-integration/kie-eap-distribution/src/main/filtered-resources/org/uberfire/commons/module.xml
+++ b/kie-eap-integration/kie-eap-distribution/src/main/filtered-resources/org/uberfire/commons/module.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.3" name="org.uberfire.commons" slot="main">
+
+  <resources>
+    <resource-root path="uberfire-commons-${version.org.uberfire}.jar"/>
+  </resources>
+
+  <dependencies>
+    <module name="javax.api" slot="main" services="import"/>
+    <module name="javax.ejb.api" slot="main" services="import"/>
+    <module name="javax.enterprise.cdi" slot="main" services="import"/>
+    <module name="org.slf4j" slot="main" services="import"/>
+  </dependencies>
+</module>

--- a/kie-eap-integration/kie-eap-distribution/src/main/filtered-resources/org/uberfire/maven-support/assembly-component.xml
+++ b/kie-eap-integration/kie-eap-distribution/src/main/filtered-resources/org/uberfire/maven-support/assembly-component.xml
@@ -1,5 +1,5 @@
 <!--
- - Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ - Copyright 2017 Red Hat, Inc. and/or its affiliates.
  - 
  - Licensed under the Apache License, Version 2.0 (the "License");
  - you may not use this file except in compliance with the License.

--- a/kie-eap-integration/kie-eap-distribution/src/main/filtered-resources/org/uberfire/project-datamodel-api/assembly-component.xml
+++ b/kie-eap-integration/kie-eap-distribution/src/main/filtered-resources/org/uberfire/project-datamodel-api/assembly-component.xml
@@ -17,17 +17,17 @@
 
   <files>
     <file>
-      <source>${project.build.outputDirectory}/org/uberfire/maven-integration/module.xml</source>
-      <outputDirectory>modules/system/layers/bpms/org/uberfire/maven-integration/main</outputDirectory>
+      <source>${project.build.outputDirectory}/org/uberfire/project-datamodel-api/module.xml</source>
+      <outputDirectory>modules/system/layers/bpms/org/uberfire/project-datamodel-api/main</outputDirectory>
     </file>
   </files>
   <dependencySets>
     <dependencySet>
       <useTransitiveDependencies>false</useTransitiveDependencies>
       <includes>
-        <include>org.uberfire:uberfire-maven-integration</include>
+        <include>org.uberfire:uberfire-project-datamodel-api</include>
       </includes>
-      <outputDirectory>modules/system/layers/bpms/org/uberfire/maven-integration/main</outputDirectory>
+      <outputDirectory>modules/system/layers/bpms/org/uberfire/project-datamodel-api/main</outputDirectory>
       <outputFileNameMapping>${artifact.artifactId}-${version.org.uberfire}.${artifact.extension}</outputFileNameMapping>
     </dependencySet>
   </dependencySets>

--- a/kie-eap-integration/kie-eap-distribution/src/main/filtered-resources/org/uberfire/project-datamodel-api/module.xml
+++ b/kie-eap-integration/kie-eap-distribution/src/main/filtered-resources/org/uberfire/project-datamodel-api/module.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.3" name="org.uberfire.project-datamodel-api" slot="main">
+
+  <resources>
+    <resource-root path="uberfire-project-datamodel-api-${version.org.uberfire}.jar"/>
+  </resources>
+
+  <dependencies>
+    <module name="javax.api" slot="main" services="import"/>
+    <module name="org.uberfire.commons" slot="main" services="import"/>
+  </dependencies>
+</module>

--- a/kie-eap-integration/kie-eap-distribution/src/main/filtered-resources/org/uberfire/project-datamodel-commons/assembly-component.xml
+++ b/kie-eap-integration/kie-eap-distribution/src/main/filtered-resources/org/uberfire/project-datamodel-commons/assembly-component.xml
@@ -17,17 +17,17 @@
 
   <files>
     <file>
-      <source>${project.build.outputDirectory}/org/uberfire/maven-integration/module.xml</source>
-      <outputDirectory>modules/system/layers/bpms/org/uberfire/maven-integration/main</outputDirectory>
+      <source>${project.build.outputDirectory}/org/uberfire/project-datamodel-commons/module.xml</source>
+      <outputDirectory>modules/system/layers/bpms/org/uberfire/project-datamodel-commons/main</outputDirectory>
     </file>
   </files>
   <dependencySets>
     <dependencySet>
       <useTransitiveDependencies>false</useTransitiveDependencies>
       <includes>
-        <include>org.uberfire:uberfire-maven-integration</include>
+        <include>org.uberfire:uberfire-project-datamodel-commons</include>
       </includes>
-      <outputDirectory>modules/system/layers/bpms/org/uberfire/maven-integration/main</outputDirectory>
+      <outputDirectory>modules/system/layers/bpms/org/uberfire/project-datamodel-commons/main</outputDirectory>
       <outputFileNameMapping>${artifact.artifactId}-${version.org.uberfire}.${artifact.extension}</outputFileNameMapping>
     </dependencySet>
   </dependencySets>

--- a/kie-eap-integration/kie-eap-distribution/src/main/filtered-resources/org/uberfire/project-datamodel-commons/module.xml
+++ b/kie-eap-integration/kie-eap-distribution/src/main/filtered-resources/org/uberfire/project-datamodel-commons/module.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module xmlns="urn:jboss:module:1.3" name="org.uberfire.project-datamodel-commons" slot="main">
+
+  <resources>
+    <resource-root path="uberfire-project-datamodel-commons-${version.org.uberfire}.jar"/>
+  </resources>
+
+  <dependencies>
+    <module name="javax.api" slot="main" services="import"/>
+    <module name="org.uberfire.commons" slot="main" services="import"/>
+  </dependencies>
+</module>

--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -181,6 +181,11 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-project-datamodel-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-workbench-models-guided-dtable</artifactId>
       <scope>runtime</scope>

--- a/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features.xml
+++ b/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features.xml
@@ -37,6 +37,9 @@
 
   <feature name="drools-wb-guided-decisiontables" description="Drools Workbench Guided Decision Tables" version="${project.version}">
      <feature version="${project.version}">drools-module</feature>
+     <bundle>mvn:org.uberfire/uberfire-commons/${version.org.uberfire}</bundle>
+     <bundle>mvn:org.uberfire/uberfire-project-datamodel-api/${version.org.uberfire}</bundle>
+     <bundle>mvn:org.uberfire/uberfire-project-datamodel-commons/${version.org.uberfire}</bundle>
      <bundle>mvn:org.drools/drools-workbench-models-datamodel-api/${version.org.kie}</bundle>
      <bundle>mvn:org.drools/drools-workbench-models-commons/${version.org.kie}</bundle>
      <bundle>mvn:org.apache.commons/commons-lang3/${version.org.apache.commons.lang3}</bundle>

--- a/kie-osgi/kie-osgi-platforms/osgi-platform-fuse-6.3/pom.xml
+++ b/kie-osgi/kie-osgi-platforms/osgi-platform-fuse-6.3/pom.xml
@@ -451,6 +451,39 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>org.uberfire</groupId>
+        <artifactId>uberfire-commons</artifactId>
+        <version>${version.org.uberfire}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.uberfire</groupId>
+        <artifactId>uberfire-project-datamodel-api</artifactId>
+        <version>${version.org.uberfire}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.uberfire</groupId>
+        <artifactId>uberfire-project-datamodel-commons</artifactId>
+        <version>${version.org.uberfire}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.uberfire</groupId>
+        <artifactId>uberfire-commons</artifactId>
+        <version>${version.org.uberfire}</version>
+        <classifier>tests</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.uberfire</groupId>
+        <artifactId>uberfire-project-datamodel-api</artifactId>
+        <version>${version.org.uberfire}</version>
+        <classifier>tests</classifier>
+      </dependency>
+      <dependency>
+        <groupId>org.uberfire</groupId>
+        <artifactId>uberfire-project-datamodel-commons</artifactId>
+        <version>${version.org.uberfire}</version>
+        <classifier>tests</classifier>
+      </dependency>
+      <dependency>
         <groupId>org.drools</groupId>
         <artifactId>drools-workbench-models-datamodel-api</artifactId>
         <version>${project.version}</version>
@@ -1610,6 +1643,14 @@
       <!--<scope>test</scope>-->
     <!--</dependency>-->
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-project-datamodel-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-workbench-models-datamodel-api</artifactId>
     </dependency>
@@ -1619,6 +1660,10 @@
       <!--<classifier>tests</classifier>-->
       <!--<scope>test</scope>-->
     <!--</dependency>-->
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-project-datamodel-commons</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-workbench-models-commons</artifactId>

--- a/kie-server-parent/kie-server-services/kie-server-services-drools/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-drools/pom.xml
@@ -51,6 +51,12 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <!-- appformer workbench models -->
+    <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-project-datamodel-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <!-- drools workbench models -->
     <dependency>
       <groupId>org.drools</groupId>

--- a/kie-spring/src/test/java/org/kie/spring/CodeVersion.java
+++ b/kie-spring/src/test/java/org/kie/spring/CodeVersion.java
@@ -18,6 +18,6 @@ package org.kie.spring;
 public class CodeVersion {
 
     // Do not modify this: this is automatically incremented by the maven replacer plugin
-    public final static String VERSION = "7.1.0-SNAPSHOT";
+    public final static String VERSION = "8.0.0-SNAPSHOT";
 
 }

--- a/kie-takari-plugin/pom.xml
+++ b/kie-takari-plugin/pom.xml
@@ -167,6 +167,11 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>org.uberfire</groupId>
+      <artifactId>uberfire-project-datamodel-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-workbench-models-guided-dtable</artifactId>
       <scope>runtime</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.uberfire</groupId>
+        <artifactId>uberfire-bom</artifactId>
+        <version>${version.org.uberfire}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
 
       <dependency>
         <groupId>org.kie</groupId>


### PR DESCRIPTION
This is a mandatory step before merging the repos to form AppFormer single repository.

Related PRs:
https://github.com/AppFormer/uberfire/pull/784
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/487
https://github.com/kiegroup/drools/pull/1397
https://github.com/kiegroup/droolsjbpm-integration/pull/1135
https://github.com/kiegroup/guvnor/pull/484
https://github.com/kiegroup/kie-wb-common/pull/1005
https://github.com/kiegroup/drools-wb/pull/560
https://github.com/kiegroup/optaplanner-wb/pull/205