### PR TITLE
[6.5.x] kie-performance-kit: Redirect standard error stream to standard output stream

### DIFF
--- a/kie-performance-kit/src/main/java/org/kie/perf/Executor.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/Executor.java
@@ -126,6 +126,7 @@ public class Executor {
                     continue;
                 }
                 ProcessBuilder processBuilder = new ProcessBuilder(tc.getStartScriptLocation(), c.getSimpleName());
+                processBuilder.redirectErrorStream(true);
                 try {
                     Process process = processBuilder.start();
                     InputStreamReader isr = new InputStreamReader(process.getInputStream());


### PR DESCRIPTION
Hi,

just a minor tweak for kie-performance-kit. Similar PRs will follow for 7.3 and master.

Thanks,

Marian
