### PR TITLE
kie-performance-kit:Init scenario in concurrent load suite

### DIFF
--- a/kie-performance-kit/src/main/java/org/kie/perf/suite/ConcurrentLoadSuite.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/suite/ConcurrentLoadSuite.java
@@ -45,6 +45,7 @@ public class ConcurrentLoadSuite implements ITestSuite {
             IPerfTest scenario = scenarios.iterator().next().newInstance();
 
             exec.initMetrics(scenario);
+            scenario.init();
             if (tc.isWarmUp()) {
                 exec.performWarmUp(scenario);
             }


### PR DESCRIPTION
Hi, @mswiderski,

this is only a fix for a bug in kie-performance-kit. Scenario wasn't initialized for warmUp.