### PR TITLE
RHBRMS-2772: Missing jta jar in jboss-brms-engine.zip

### DIFF
--- a/droolsjbpm-bpms-distribution/pom.xml
+++ b/droolsjbpm-bpms-distribution/pom.xml
@@ -254,6 +254,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.jboss.narayana.jta</groupId>
+      <artifactId>narayana-jta</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.quartz-scheduler</groupId>
       <artifactId>quartz</artifactId>
       <exclusions>

--- a/droolsjbpm-brms-distribution/pom.xml
+++ b/droolsjbpm-brms-distribution/pom.xml
@@ -115,6 +115,10 @@
       <groupId>org.jboss.spec.javax.security.jacc</groupId>
       <artifactId>jboss-jacc-api_1.5_spec</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.narayana.jta</groupId>
+      <artifactId>narayana-jta</artifactId>
+    </dependency>
 
     <!-- The old assembly also included this optional dependency -->
     <dependency>


### PR DESCRIPTION
*Add in org.jboss.narayana.jta dependency in the pom of brms distribution
*Explicitly defined the org.jboss.narayana.jta dependency in the pom of bpms distribution