### PR TITLE
Prevent @After method failures

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerManagementBaseTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerManagementBaseTest.java
@@ -17,8 +17,8 @@ package org.kie.server.integrationtests.controller;
 
 import org.junit.After;
 import org.junit.Before;
-import org.kie.server.integrationtests.controller.client.KieServerMgmtControllerClient;
 import org.kie.server.integrationtests.config.TestConfig;
+import org.kie.server.integrationtests.controller.client.KieServerMgmtControllerClient;
 import org.kie.server.integrationtests.shared.basetests.RestOnlyBaseIntegrationTest;
 
 public abstract class KieControllerManagementBaseTest extends RestOnlyBaseIntegrationTest {
@@ -45,7 +45,8 @@ public abstract class KieControllerManagementBaseTest extends RestOnlyBaseIntegr
 
     @After
     public void closeControllerClient() {
-        mgmtControllerClient.close();
+        if (mgmtControllerClient != null) {
+            mgmtControllerClient.close();
+        }
     }
-
 }


### PR DESCRIPTION
@sutaakar this `@After` method causes hundreds of failures if the client creation in the `@Before` method fails (e.g. incorrect server url).