### PR TITLE
RHBRMS-2772: Missing jta-1.1.jar in jboss-brms-engine.zip

### DIFF
--- a/droolsjbpm-bpms-distribution/pom.xml
+++ b/droolsjbpm-bpms-distribution/pom.xml
@@ -272,6 +272,10 @@
       <artifactId>quartz-weblogic</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jboss.narayana.jta</groupId>
+      <artifactId>narayana-jta</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.spec.javax.security.jacc</groupId>
       <artifactId>jboss-jacc-api_1.5_spec</artifactId>
     </dependency>

--- a/droolsjbpm-brms-distribution/pom.xml
+++ b/droolsjbpm-brms-distribution/pom.xml
@@ -112,6 +112,10 @@
       <artifactId>slf4j-jdk14</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jboss.narayana.jta</groupId>
+      <artifactId>narayana-jta</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.spec.javax.security.jacc</groupId>
       <artifactId>jboss-jacc-api_1.5_spec</artifactId>
     </dependency>


### PR DESCRIPTION
*Add in org.jboss.narayana.jta dependency in the pom of brms distribution
*Explicitly defined the org.jboss.narayana.jta dependency in the pom of bpms distibution