### PR TITLE
[7.3.x] RHBPMS-4943: New ad-hoc job can't be created

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/JobServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/JobServicesClientImpl.java
@@ -55,10 +55,13 @@ public class JobServicesClientImpl extends AbstractKieServicesClientImpl impleme
         if( config.isRest() ) {
 
             Map<String, Object> valuesMap = new HashMap<String, Object>();
-            valuesMap.put(CONTAINER_ID, containerId);
+            String queryString = "";
+            if (containerId != null && !containerId.isEmpty()) {
+                queryString = "?containerId=" + containerId;
+            }
 
             result = makeHttpPostRequestAndCreateCustomResponse(
-                    build(loadBalancer.getUrl(), JOB_URI, valuesMap) + "?containerId="+containerId, jobRequest,
+                    build(loadBalancer.getUrl(), JOB_URI, valuesMap) + queryString, jobRequest,
                     Object.class);
 
         } else {


### PR DESCRIPTION
Adding check over the containerId to add it as a parameter, allowing ad-hoc creation 