### PR TITLE
[DROOLS-1732] use correct plugin classloader for kie-maven-plugin

### DIFF
--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/BuildMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/BuildMojo.java
@@ -133,7 +133,7 @@ public class BuildMojo extends AbstractKieMojo {
             urls.add(outputDirectory.toURI().toURL());
 
             ClassLoader projectClassLoader = URLClassLoader.newInstance(urls.toArray(new URL[0]),
-                                                                        Thread.currentThread().getContextClassLoader());
+                                                                        getClass().getClassLoader());
 
             Thread.currentThread().setContextClassLoader(projectClassLoader);
         } catch (DependencyResolutionRequiredException e) {


### PR DESCRIPTION
Backport of #1191 