### PR TITLE
RHBPMS-4862, RHBPMS-4863: Container started by upgrade doesn't contain process configuration / Start/stop container buttons are in wrong state after Process Configuration change

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
@@ -45,10 +45,8 @@ public class KieServerInstanceManager {
 
     private static final Logger logger = LoggerFactory.getLogger(KieServerInstanceManager.class);
     private static final String CONTAINERS_URI_PART = "/containers/";
-
-    private List<KieServicesClientProvider> clientProviders = new ArrayList<>();
-
     private static KieServerInstanceManager INSTANCE = new KieServerInstanceManager();
+    private List<KieServicesClientProvider> clientProviders = new ArrayList<>();
 
     public KieServerInstanceManager() {
         ServiceLoader<KieServicesClientProvider> loader = ServiceLoader.load(KieServicesClientProvider.class);
@@ -150,83 +148,113 @@ public class KieServerInstanceManager {
                                             });
     }
 
-    public synchronized List<Container> startContainer(ServerTemplate serverTemplate,
+    public synchronized List<Container> startContainer(final ServerTemplate serverTemplate,
                                                        final ContainerSpec containerSpec) {
 
-        return callRemoteKieServerOperation(serverTemplate,
-                                            containerSpec,
-                                            new RemoteKieServerOperation<Void>() {
-                                                @Override
-                                                public Void doOperation(KieServicesClient client,
-                                                                        Container container) {
-                                                    KieContainerResource containerResource = new KieContainerResource(containerSpec.getId(),
-                                                                                                                      containerSpec.getReleasedId(),
-                                                                                                                      container.getResolvedReleasedId(),
-                                                                                                                      container.getStatus());
-                                                    containerResource.setContainerAlias(containerSpec.getContainerName());
-                                                    containerResource.setMessages((List<Message>) container.getMessages());
+        final RemoteKieServerOperation<Void> startContainerOperation = makeStartContainerOperation(containerSpec);
 
-                                                    if (containerSpec.getConfigs() != null) {
-                                                        // cover scanner and rules config
-                                                        ContainerConfig containerConfig = containerSpec.getConfigs().get(Capability.RULE);
-                                                        if (containerConfig != null) {
-                                                            RuleConfig ruleConfig = (RuleConfig) containerConfig;
+        return callRemoteKieServerOperation(serverTemplate, containerSpec, startContainerOperation);
+    }
 
-                                                            KieScannerResource scannerResource = new KieScannerResource();
-                                                            scannerResource.setPollInterval(ruleConfig.getPollInterval());
-                                                            scannerResource.setStatus(ruleConfig.getScannerStatus());
+    RemoteKieServerOperation<Void> makeStartContainerOperation(final ContainerSpec containerSpec) {
+        return new RemoteKieServerOperation<Void>() {
+            @Override
+            public Void doOperation(final KieServicesClient client,
+                                    final Container container) {
 
-                                                            containerResource.setScanner(scannerResource);
-                                                        }
-                                                        // cover process config
-                                                        containerConfig = containerSpec.getConfigs().get(Capability.PROCESS);
-                                                        if (containerConfig != null) {
-                                                            ProcessConfig processConfig = (ProcessConfig) containerConfig;
+                final KieContainerResource resource = makeContainerResource(container, containerSpec);
+                final ServiceResponse<KieContainerResource> response = client.createContainer(containerSpec.getId(), resource);
 
-                                                            KieServerConfigItem configItem = new KieServerConfigItem();
-                                                            configItem.setType(KieServerConstants.CAPABILITY_BPM);
-                                                            configItem.setName(KieServerConstants.PCFG_KIE_BASE);
-                                                            configItem.setValue(processConfig.getKBase());
+                if (response.getType() != ServiceResponse.ResponseType.SUCCESS) {
+                    log("Container {} failed to start on server instance {} due to {}", container, response, containerSpec);
+                }
 
-                                                            containerResource.addConfigItem(configItem);
+                collectContainerInfo(containerSpec, client, container);
 
-                                                            configItem = new KieServerConfigItem();
-                                                            configItem.setType(KieServerConstants.CAPABILITY_BPM);
-                                                            configItem.setName(KieServerConstants.PCFG_KIE_SESSION);
-                                                            configItem.setValue(processConfig.getKSession());
+                return null;
+            }
+        };
+    }
 
-                                                            containerResource.addConfigItem(configItem);
+    void log(final String message,
+             final Object... objects) {
+        logger.debug(message, objects);
+    }
 
-                                                            configItem = new KieServerConfigItem();
-                                                            configItem.setType(KieServerConstants.CAPABILITY_BPM);
-                                                            configItem.setName(KieServerConstants.PCFG_MERGE_MODE);
-                                                            configItem.setValue(processConfig.getMergeMode());
+    KieContainerResource makeContainerResource(final Container container,
+                                               final ContainerSpec containerSpec) {
 
-                                                            containerResource.addConfigItem(configItem);
+        final KieContainerResource containerResource = new KieContainerResource(containerSpec.getId(),
+                                                                                containerSpec.getReleasedId(),
+                                                                                container.getResolvedReleasedId(),
+                                                                                container.getStatus());
 
-                                                            configItem = new KieServerConfigItem();
-                                                            configItem.setType(KieServerConstants.CAPABILITY_BPM);
-                                                            configItem.setName(KieServerConstants.PCFG_RUNTIME_STRATEGY);
-                                                            configItem.setValue(processConfig.getRuntimeStrategy());
+        containerResource.setContainerAlias(containerSpec.getContainerName());
+        containerResource.setMessages((List<Message>) container.getMessages());
 
-                                                            containerResource.addConfigItem(configItem);
-                                                        }
-                                                    }
+        if (containerSpec.getConfigs() != null) {
+            setRuleConfigAttributes(containerSpec, containerResource);
+            setProcessConfigAttributes(containerSpec, containerResource);
+        }
 
-                                                    ServiceResponse<KieContainerResource> response = client.createContainer(containerSpec.getId(),
-                                                                                                                            containerResource);
-                                                    if (!response.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
-                                                        logger.debug("Container {} failed to start on server instance {} due to {}",
-                                                                     containerSpec.getId(),
-                                                                     container.getUrl(),
-                                                                     response.getMsg());
-                                                    }
-                                                    collectContainerInfo(containerSpec,
-                                                                         client,
-                                                                         container);
-                                                    return null;
-                                                }
-                                            });
+        return containerResource;
+    }
+
+    KieServerConfigItem makeKieServerConfigItem(final String type,
+                                                final String name,
+                                                final String value) {
+
+        final KieServerConfigItem configItem = new KieServerConfigItem();
+
+        configItem.setType(type);
+        configItem.setName(name);
+        configItem.setValue(value);
+
+        return configItem;
+    }
+
+    void setRuleConfigAttributes(final ContainerSpec containerSpec,
+                                 final KieContainerResource containerResource) {
+
+        final ContainerConfig containerConfig = containerSpec.getConfigs().get(Capability.RULE);
+
+        if (containerConfig != null) {
+
+            final RuleConfig ruleConfig = (RuleConfig) containerConfig;
+            final KieScannerResource scannerResource = new KieScannerResource();
+
+            scannerResource.setPollInterval(ruleConfig.getPollInterval());
+            scannerResource.setStatus(ruleConfig.getScannerStatus());
+
+            containerResource.setScanner(scannerResource);
+        }
+    }
+
+    void setProcessConfigAttributes(final ContainerSpec containerSpec,
+                                    final KieContainerResource containerResource) {
+
+        final ContainerConfig containerConfig = containerSpec.getConfigs().get(Capability.PROCESS);
+
+        if (containerConfig != null) {
+
+            final ProcessConfig processConfig = (ProcessConfig) containerConfig;
+
+            containerResource.addConfigItem(makeKieServerConfigItem(KieServerConstants.CAPABILITY_BPM,
+                                                                    KieServerConstants.PCFG_KIE_BASE,
+                                                                    processConfig.getKBase()));
+
+            containerResource.addConfigItem(makeKieServerConfigItem(KieServerConstants.CAPABILITY_BPM,
+                                                                    KieServerConstants.PCFG_KIE_SESSION,
+                                                                    processConfig.getKSession()));
+
+            containerResource.addConfigItem(makeKieServerConfigItem(KieServerConstants.CAPABILITY_BPM,
+                                                                    KieServerConstants.PCFG_MERGE_MODE,
+                                                                    processConfig.getMergeMode()));
+
+            containerResource.addConfigItem(makeKieServerConfigItem(KieServerConstants.CAPABILITY_BPM,
+                                                                    KieServerConstants.PCFG_RUNTIME_STRATEGY,
+                                                                    processConfig.getRuntimeStrategy()));
+        }
     }
 
     public synchronized List<Container> stopContainer(ServerTemplate serverTemplate,
@@ -254,30 +282,63 @@ public class KieServerInstanceManager {
                                             });
     }
 
-    public List<Container> upgradeContainer(ServerTemplate serverTemplate,
+    public List<Container> upgradeContainer(final ServerTemplate serverTemplate,
                                             final ContainerSpec containerSpec) {
 
         return callRemoteKieServerOperation(serverTemplate,
                                             containerSpec,
-                                            new RemoteKieServerOperation<Void>() {
-                                                @Override
-                                                public Void doOperation(KieServicesClient client,
-                                                                        Container container) {
+                                            makeUpgradeContainerOperation(containerSpec));
+    }
 
-                                                    ServiceResponse<ReleaseId> response = client.updateReleaseId(containerSpec.getId(),
-                                                                                                                 containerSpec.getReleasedId());
-                                                    if (!response.getType().equals(ServiceResponse.ResponseType.SUCCESS)) {
-                                                        logger.debug("Container {} failed to upgrade on server instance {} due to {}",
-                                                                     containerSpec.getId(),
-                                                                     container.getUrl(),
-                                                                     response.getMsg());
-                                                    }
-                                                    collectContainerInfo(containerSpec,
-                                                                         client,
-                                                                         container);
-                                                    return null;
-                                                }
-                                            });
+    public List<Container> upgradeAndStartContainer(final ServerTemplate serverTemplate,
+                                                    final ContainerSpec containerSpec) {
+
+        return callRemoteKieServerOperation(serverTemplate,
+                                            containerSpec,
+                                            makeUpgradeAndStartContainerOperation(containerSpec));
+    }
+
+    RemoteKieServerOperation<Void> makeUpgradeContainerOperation(final ContainerSpec containerSpec) {
+        return new RemoteKieServerOperation<Void>() {
+            @Override
+            public Void doOperation(final KieServicesClient client,
+                                    final Container container) {
+
+                remoteUpgradeContainer(client, container, containerSpec);
+
+                return null;
+            }
+        };
+    }
+
+    RemoteKieServerOperation<Void> makeUpgradeAndStartContainerOperation(final ContainerSpec containerSpec) {
+        return new RemoteKieServerOperation<Void>() {
+            @Override
+            public Void doOperation(final KieServicesClient client,
+                                    final Container container) {
+
+                final KieContainerResource containerResource = makeContainerResource(container, containerSpec);
+
+                remoteCreateContainer(client, containerResource, containerSpec);
+                remoteUpgradeContainer(client, container, containerSpec);
+
+                return null;
+            }
+        };
+    }
+
+    private void remoteCreateContainer(final KieServicesClient client, final KieContainerResource containerResource, final ContainerSpec containerSpec) {
+        client.createContainer(containerSpec.getId(), containerResource);
+    }
+
+    private void remoteUpgradeContainer(final KieServicesClient client, final Container container, final ContainerSpec containerSpec) {
+        final ServiceResponse<ReleaseId> response = client.updateReleaseId(containerSpec.getId(), containerSpec.getReleasedId());
+
+        if (response.getType() != ServiceResponse.ResponseType.SUCCESS) {
+            log("Container {} failed to upgrade on server instance {} due to {}", containerSpec.getId(), container.getUrl(), response.getMsg());
+        }
+
+        collectContainerInfo(containerSpec, client, container);
     }
 
     public List<Container> getContainers(final ServerTemplate serverTemplate,
@@ -434,5 +495,4 @@ public class KieServerInstanceManager {
             return null;
         }
     }
-
 }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/RuleCapabilitiesServiceImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/RuleCapabilitiesServiceImpl.java
@@ -134,12 +134,18 @@ public class RuleCapabilitiesServiceImpl implements RuleCapabilitiesService {
             releaseId.setArtifactId(containerSpec.getReleasedId().getArtifactId());
         }
 
+        final List<Container> containers;
+
         containerSpec.setReleasedId(releaseId);
+
+        if (containerSpec.getStatus() == KieContainerStatus.STARTED) {
+            containers = kieServerInstanceManager.upgradeContainer(serverTemplate, containerSpec);
+        } else {
+            containers = kieServerInstanceManager.startContainer(serverTemplate, containerSpec);
+        }
+
         containerSpec.setStatus(KieContainerStatus.STARTED);
         templateStorage.update(serverTemplate);
-
-        List<Container> containers = kieServerInstanceManager.upgradeContainer(serverTemplate,
-                                                                               containerSpec);
 
         notificationService.notify(serverTemplate,
                                    containerSpec,

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/SpecManagementServiceImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/SpecManagementServiceImpl.java
@@ -48,60 +48,60 @@ import org.slf4j.LoggerFactory;
 
 public class SpecManagementServiceImpl implements SpecManagementService {
 
+    private static Logger logger = LoggerFactory.getLogger(SpecManagementServiceImpl.class);
     private KieServerInstanceManager kieServerInstanceManager = KieServerInstanceManager.getInstance();
     private KieServerTemplateStorage templateStorage = InMemoryKieServerTemplateStorage.getInstance();
     private NotificationService notificationService = LoggingNotificationService.getInstance();
-    private static Logger logger = LoggerFactory.getLogger(SpecManagementServiceImpl.class);
 
     @Override
-    public synchronized void saveContainerSpec( String serverTemplateId,
-                                   ContainerSpec containerSpec ) {
-        ServerTemplate serverTemplate = templateStorage.load( serverTemplateId );
-        if ( serverTemplate == null ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + serverTemplateId );
+    public synchronized void saveContainerSpec(String serverTemplateId,
+                                               ContainerSpec containerSpec) {
+        ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
+        if (serverTemplate == null) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + serverTemplateId);
         }
 
         if (serverTemplate.hasContainerSpec(containerSpec.getId())) {
-            throw new KieServerControllerException( "Server template with id " + serverTemplateId + " associated already with container " + containerSpec.getId());
+            throw new KieServerControllerException("Server template with id " + serverTemplateId + " associated already with container " + containerSpec.getId());
         }
         // make sure correct server template is set
         containerSpec.setServerTemplateKey(new ServerTemplateKey(serverTemplate.getId(), serverTemplate.getName()));
 
-        serverTemplate.addContainerSpec( containerSpec );
+        serverTemplate.addContainerSpec(containerSpec);
 
-        templateStorage.update( serverTemplate );
+        templateStorage.update(serverTemplate);
 
-        notificationService.notify( new ServerTemplateUpdated( serverTemplate ) );
+        notificationService.notify(new ServerTemplateUpdated(serverTemplate));
 
         if (containerSpec.getStatus().equals(KieContainerStatus.STARTED)) {
-            List<Container> containers = kieServerInstanceManager.startContainer( serverTemplate, containerSpec );
-            notificationService.notify( serverTemplate, containerSpec, containers );
+            List<Container> containers = kieServerInstanceManager.startContainer(serverTemplate, containerSpec);
+            notificationService.notify(serverTemplate, containerSpec, containers);
         }
     }
 
     @Override
-    public synchronized void updateContainerSpec( String serverTemplateId, ContainerSpec containerSpec ) {
+    public synchronized void updateContainerSpec(String serverTemplateId, ContainerSpec containerSpec) {
         updateContainerSpec(serverTemplateId, containerSpec.getId(), containerSpec);
     }
 
     @Override
     public synchronized void updateContainerSpec(final String serverTemplateId, final String containerId, final ContainerSpec containerSpec) {
-        ServerTemplate serverTemplate = templateStorage.load( serverTemplateId );
+        ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
 
-        if ( serverTemplate == null ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + serverTemplateId );
+        if (serverTemplate == null) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + serverTemplateId);
         }
 
-        if( !containerSpec.getId().equals(containerId)) {
-            throw new KieServerControllerException( "Cannot update container " + containerSpec.getId() + " on container " + containerId );
+        if (!containerSpec.getId().equals(containerId)) {
+            throw new KieServerControllerException("Cannot update container " + containerSpec.getId() + " on container " + containerId);
         }
 
         if (!serverTemplate.hasContainerSpec(containerSpec.getId())) {
-            throw new KieServerControllerNotFoundException( "Server template with id " + serverTemplateId + " has no container with id " + containerSpec.getId());
+            throw new KieServerControllerNotFoundException("Server template with id " + serverTemplateId + " has no container with id " + containerSpec.getId());
         }
 
-        if(!serverTemplate.hasMatchingId( containerSpec.getServerTemplateKey() )) {
-            throw new KieServerControllerException( "Cannot change container template key during update.");
+        if (!serverTemplate.hasMatchingId(containerSpec.getServerTemplateKey())) {
+            throw new KieServerControllerException("Cannot change container template key during update.");
         }
 
         // make sure correct server template is set
@@ -112,41 +112,41 @@ public class SpecManagementServiceImpl implements SpecManagementService {
         serverTemplate.deleteContainerSpec(currentVersion.getId());
         serverTemplate.addContainerSpec(containerSpec);
 
-        templateStorage.update( serverTemplate );
+        templateStorage.update(serverTemplate);
 
-        notificationService.notify( new ServerTemplateUpdated( serverTemplate ) );
+        notificationService.notify(new ServerTemplateUpdated(serverTemplate));
         // in case container was started before it was update or update comes with status started update container in running servers
         if (currentVersion.getStatus().equals(KieContainerStatus.STARTED) || containerSpec.getStatus().equals(KieContainerStatus.STARTED)) {
-            List<Container> containers = kieServerInstanceManager.upgradeContainer(serverTemplate, containerSpec);
+            List<Container> containers = kieServerInstanceManager.upgradeAndStartContainer(serverTemplate, containerSpec);
             notificationService.notify(serverTemplate, containerSpec, containers);
         }
     }
 
     @Override
-    public synchronized void saveServerTemplate( ServerTemplate serverTemplate ) {
-        if ( templateStorage.exists( serverTemplate.getId() ) ) {
-            templateStorage.update( serverTemplate );
+    public synchronized void saveServerTemplate(ServerTemplate serverTemplate) {
+        if (templateStorage.exists(serverTemplate.getId())) {
+            templateStorage.update(serverTemplate);
         } else {
 
-            templateStorage.store( serverTemplate );
+            templateStorage.store(serverTemplate);
         }
 
-        notificationService.notify( new ServerTemplateUpdated( serverTemplate ) );
+        notificationService.notify(new ServerTemplateUpdated(serverTemplate));
 
         Collection<ContainerSpec> containerSpecs = serverTemplate.getContainersSpec();
         if (containerSpecs != null && !containerSpecs.isEmpty()) {
             for (ContainerSpec containerSpec : containerSpecs) {
                 if (containerSpec.getStatus().equals(KieContainerStatus.STARTED)) {
-                    List<Container> containers = kieServerInstanceManager.startContainer( serverTemplate, containerSpec );
-                    notificationService.notify( serverTemplate, containerSpec, containers );
+                    List<Container> containers = kieServerInstanceManager.startContainer(serverTemplate, containerSpec);
+                    notificationService.notify(serverTemplate, containerSpec, containers);
                 }
             }
         }
     }
 
     @Override
-    public ServerTemplate getServerTemplate( String serverTemplateId ) {
-        return templateStorage.load( serverTemplateId );
+    public ServerTemplate getServerTemplate(String serverTemplateId) {
+        return templateStorage.load(serverTemplateId);
     }
 
     @Override
@@ -160,23 +160,23 @@ public class SpecManagementServiceImpl implements SpecManagementService {
     }
 
     @Override
-    public Collection<ContainerSpec> listContainerSpec( String serverTemplateId ) {
-        ServerTemplate serverTemplate = templateStorage.load( serverTemplateId );
-        if ( serverTemplate == null ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + serverTemplateId );
+    public Collection<ContainerSpec> listContainerSpec(String serverTemplateId) {
+        ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
+        if (serverTemplate == null) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + serverTemplateId);
         }
 
         return serverTemplate.getContainersSpec();
     }
 
     @Override
-    public synchronized void deleteContainerSpec( String serverTemplateId,
-                                     String containerSpecId ) {
-        ServerTemplate serverTemplate = templateStorage.load( serverTemplateId );
-        if ( serverTemplate == null ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + serverTemplateId );
+    public synchronized void deleteContainerSpec(String serverTemplateId,
+                                                 String containerSpecId) {
+        ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
+        if (serverTemplate == null) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + serverTemplateId);
         }
-        
+
         if (serverTemplate.hasContainerSpec(containerSpecId)) {
             ContainerSpec containerSpec = serverTemplate.getContainerSpec(containerSpecId);
             kieServerInstanceManager.stopContainer(serverTemplate, containerSpec);
@@ -191,186 +191,228 @@ public class SpecManagementServiceImpl implements SpecManagementService {
     }
 
     @Override
-    public synchronized void deleteServerTemplate( String serverTemplateId ) {
-        if ( !templateStorage.exists( serverTemplateId ) ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + serverTemplateId );
+    public synchronized void deleteServerTemplate(String serverTemplateId) {
+        if (!templateStorage.exists(serverTemplateId)) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + serverTemplateId);
         }
 
-        templateStorage.delete( serverTemplateId );
+        templateStorage.delete(serverTemplateId);
 
-        notificationService.notify( new ServerTemplateDeleted( serverTemplateId ) );
+        notificationService.notify(new ServerTemplateDeleted(serverTemplateId));
     }
 
     @Override
-    public synchronized void copyServerTemplate( String serverTemplateId,
-                                    String newServerTemplateId,
-                                    String newServerTemplateName ) {
-        final ServerTemplate serverTemplate = templateStorage.load( serverTemplateId );
-        if ( serverTemplate == null ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + serverTemplateId );
+    public synchronized void copyServerTemplate(String serverTemplateId,
+                                                String newServerTemplateId,
+                                                String newServerTemplateName) {
+        final ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
+        if (serverTemplate == null) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + serverTemplateId);
         }
 
-        final Map<Capability, ServerConfig> configMap = new HashMap<Capability, ServerConfig>( serverTemplate.getConfigs().size() );
-        for ( final Map.Entry<Capability, ServerConfig> entry : serverTemplate.getConfigs().entrySet() ) {
-            configMap.put( entry.getKey(), copy( entry.getValue() ) );
+        final Map<Capability, ServerConfig> configMap = new HashMap<Capability, ServerConfig>(serverTemplate.getConfigs().size());
+        for (final Map.Entry<Capability, ServerConfig> entry : serverTemplate.getConfigs().entrySet()) {
+            configMap.put(entry.getKey(), copy(entry.getValue()));
         }
 
-        final Collection<ContainerSpec> containerSpecs = new ArrayList<ContainerSpec>( serverTemplate.getContainersSpec().size() );
-        for ( final ContainerSpec entry : serverTemplate.getContainersSpec() ) {
-            containerSpecs.add( copy( entry, newServerTemplateId, newServerTemplateName ) );
+        final Collection<ContainerSpec> containerSpecs = new ArrayList<ContainerSpec>(serverTemplate.getContainersSpec().size());
+        for (final ContainerSpec entry : serverTemplate.getContainersSpec()) {
+            containerSpecs.add(copy(entry, newServerTemplateId, newServerTemplateName));
         }
 
-        final ServerTemplate copy = new ServerTemplate( newServerTemplateId,
-                                                        newServerTemplateName,
-                                                        serverTemplate.getCapabilities(),
-                                                        configMap,
-                                                        containerSpecs );
+        final ServerTemplate copy = new ServerTemplate(newServerTemplateId,
+                                                       newServerTemplateName,
+                                                       serverTemplate.getCapabilities(),
+                                                       configMap,
+                                                       containerSpecs);
 
-        templateStorage.store( copy );
+        templateStorage.store(copy);
     }
 
-    private ContainerSpec copy( final ContainerSpec origin,
-                                final String newServerTemplateId,
-                                final String newServerTemplateName ) {
+    private ContainerSpec copy(final ContainerSpec origin,
+                               final String newServerTemplateId,
+                               final String newServerTemplateName) {
         final Map<Capability, ContainerConfig> configMap = origin.getConfigs();
-        for ( Map.Entry<Capability, ContainerConfig> entry : origin.getConfigs().entrySet() ) {
-            configMap.put( entry.getKey(), copy( entry.getValue() ) );
+        for (Map.Entry<Capability, ContainerConfig> entry : origin.getConfigs().entrySet()) {
+            configMap.put(entry.getKey(), copy(entry.getValue()));
         }
-        return new ContainerSpec( origin.getId(),
-                                  origin.getContainerName(),
-                                  new ServerTemplateKey( newServerTemplateId, newServerTemplateName ),
-                                  new ReleaseId( origin.getReleasedId() ),
-                                  origin.getStatus(),
-                                  configMap );
+        return new ContainerSpec(origin.getId(),
+                                 origin.getContainerName(),
+                                 new ServerTemplateKey(newServerTemplateId, newServerTemplateName),
+                                 new ReleaseId(origin.getReleasedId()),
+                                 origin.getStatus(),
+                                 configMap);
     }
 
-    private ContainerConfig copy( final ContainerConfig _value ) {
-        if ( _value instanceof RuleConfig ) {
+    private ContainerConfig copy(final ContainerConfig _value) {
+        if (_value instanceof RuleConfig) {
             final RuleConfig value = (RuleConfig) _value;
-            return new RuleConfig( value.getPollInterval(), value.getScannerStatus() );
-        } else if ( _value instanceof ProcessConfig ) {
+            return new RuleConfig(value.getPollInterval(), value.getScannerStatus());
+        } else if (_value instanceof ProcessConfig) {
             final ProcessConfig value = (ProcessConfig) _value;
-            return new ProcessConfig( value.getRuntimeStrategy(), value.getKBase(), value.getKSession(), value.getMergeMode() );
+            return new ProcessConfig(value.getRuntimeStrategy(), value.getKBase(), value.getKSession(), value.getMergeMode());
         }
         return null;
     }
 
-    private ServerConfig copy( final ServerConfig value ) {
+    private ServerConfig copy(final ServerConfig value) {
         return new ServerConfig();
     }
 
     @Override
-    public synchronized void updateContainerConfig( String serverTemplateId,
-                                       String containerSpecId,
-                                       Capability capability,
-                                       ContainerConfig containerConfig ) {
-        ServerTemplate serverTemplate = templateStorage.load( serverTemplateId );
-        if ( serverTemplate == null ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + serverTemplateId );
+    public synchronized void updateContainerConfig(final String serverTemplateId,
+                                                   final String containerSpecId,
+                                                   final Capability capability,
+                                                   final ContainerConfig containerConfig) {
+
+        final ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
+        if (serverTemplate == null) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + serverTemplateId);
         }
 
-        ContainerSpec containerSpec = serverTemplate.getContainerSpec( containerSpecId );
-        if ( containerSpec == null ) {
-            throw new KieServerControllerNotFoundException( "No container spec found for id " + containerSpecId + " within server template with id " + serverTemplateId );
+        final ContainerSpec containerSpec = serverTemplate.getContainerSpec(containerSpecId);
+        if (containerSpec == null) {
+            throw new KieServerControllerNotFoundException("No container spec found for id " + containerSpecId + " within server template with id " + serverTemplateId);
         }
-        List<Container> affectedContainers = null;
+
+        final List<Container> affectedContainers = updateContainerConfig(capability, containerConfig, serverTemplate, containerSpec);
+
+        if (affectedContainers.isEmpty()) {
+            logInfo("Update of container configuration resulted in no changes to containers running on kie-servers");
+        }
+
+        affectedContainers.forEach(ac -> {
+            logDebug("Container {} on server {} was affected by a change in the scanner", ac.getContainerSpecId(), ac.getServerInstanceKey());
+        });
+
+        containerSpec.getConfigs().put(capability, containerConfig);
+
+        templateStorage.update(serverTemplate);
+
+        notificationService.notify(new ServerTemplateUpdated(serverTemplate));
+    }
+
+    void logInfo(final String message) {
+        logger.info(message);
+    }
+
+    void logDebug(final String message,
+                  final Object... objects) {
+        logger.debug(message, objects);
+    }
+
+    List<Container> updateContainerConfig(final Capability capability,
+                                          final ContainerConfig containerConfig,
+                                          final ServerTemplate serverTemplate,
+                                          final ContainerSpec containerSpec) {
+
         if (containerConfig instanceof RuleConfig) {
-            RuleConfig rc = (RuleConfig)containerConfig;
-            long interval = rc.getPollInterval();
-            KieScannerStatus status = rc.getScannerStatus();
-            if (status == KieScannerStatus.STARTED) {
-                affectedContainers = kieServerInstanceManager.startScanner(serverTemplate, containerSpec, interval);
-            } else if (status == KieScannerStatus.STOPPED) {
-                affectedContainers = kieServerInstanceManager.stopScanner(serverTemplate, containerSpec);
-            }
+
+            final RuleConfig ruleConfig = (RuleConfig) containerConfig;
+
+            return updateContainerRuleConfig(ruleConfig, serverTemplate, containerSpec);
         } else if (containerConfig instanceof ProcessConfig) {
-            ProcessConfig pc = (ProcessConfig)containerConfig;
-            kieServerInstanceManager.stopContainer(serverTemplate, containerSpec);
-            containerSpec.getConfigs().put(capability, pc);
-            affectedContainers = kieServerInstanceManager.startContainer(serverTemplate, containerSpec);
-        }
-        if (affectedContainers == null) {
-            logger.info("Update of container configuration resulted in no changes to containers running on kie-servers");
+
+            final ProcessConfig processConfig = (ProcessConfig) containerConfig;
+
+            return updateContainerProcessConfig(processConfig, capability, serverTemplate, containerSpec);
         } else {
-            affectedContainers.forEach(ac -> {
-                logger.debug("Container {} on server {} was affected by a change in the scanner"
-                        ,ac.getContainerSpecId()
-                        ,ac.getServerInstanceKey());
-            });
+            return new ArrayList<>();
         }
+    }
 
-        containerSpec.getConfigs().put( capability, containerConfig );
+    List<Container> updateContainerProcessConfig(final ProcessConfig processConfig,
+                                                 final Capability capability,
+                                                 final ServerTemplate serverTemplate,
+                                                 final ContainerSpec containerSpec) {
 
-        templateStorage.update( serverTemplate );
+        containerSpec.getConfigs().put(capability, processConfig);
 
-        notificationService.notify( new ServerTemplateUpdated( serverTemplate ) );
+        return kieServerInstanceManager.upgradeContainer(serverTemplate, containerSpec);
+    }
+
+    List<Container> updateContainerRuleConfig(final RuleConfig ruleConfig,
+                                              final ServerTemplate serverTemplate,
+                                              final ContainerSpec containerSpec) {
+
+        final Long interval = ruleConfig.getPollInterval();
+        final KieScannerStatus status = ruleConfig.getScannerStatus();
+
+        switch (status) {
+            case STARTED:
+                return kieServerInstanceManager.startScanner(serverTemplate, containerSpec, interval);
+            case STOPPED:
+                return kieServerInstanceManager.stopScanner(serverTemplate, containerSpec);
+            default:
+                return new ArrayList<>();
+        }
     }
 
     @Override
-    public synchronized void updateServerTemplateConfig( String serverTemplateId,
-                                            Capability capability,
-                                            ServerConfig serverTemplateConfig ) {
-        ServerTemplate serverTemplate = templateStorage.load( serverTemplateId );
-        if ( serverTemplate == null ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + serverTemplateId );
+    public synchronized void updateServerTemplateConfig(String serverTemplateId,
+                                                        Capability capability,
+                                                        ServerConfig serverTemplateConfig) {
+        ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
+        if (serverTemplate == null) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + serverTemplateId);
         }
 
         Map<Capability, ServerConfig> configs = serverTemplate.getConfigs();
-        configs.put( capability, serverTemplateConfig );
-        serverTemplate.setConfigs( configs );
+        configs.put(capability, serverTemplateConfig);
+        serverTemplate.setConfigs(configs);
 
-        templateStorage.update( serverTemplate );
+        templateStorage.update(serverTemplate);
 
-        notificationService.notify( new ServerTemplateUpdated( serverTemplate ) );
+        notificationService.notify(new ServerTemplateUpdated(serverTemplate));
     }
 
     @Override
-    public synchronized void startContainer( ContainerSpecKey containerSpecKey ) {
-        ServerTemplate serverTemplate = templateStorage.load( containerSpecKey.getServerTemplateKey().getId() );
-        if ( serverTemplate == null ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + containerSpecKey.getServerTemplateKey().getId() );
+    public synchronized void startContainer(ContainerSpecKey containerSpecKey) {
+        ServerTemplate serverTemplate = templateStorage.load(containerSpecKey.getServerTemplateKey().getId());
+        if (serverTemplate == null) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + containerSpecKey.getServerTemplateKey().getId());
         }
 
-        final ContainerSpec containerSpec = serverTemplate.getContainerSpec( containerSpecKey.getId() );
-        if ( containerSpec == null ) {
-            throw new KieServerControllerNotFoundException( "No container spec found for id " + containerSpecKey.getId()
-                    + " within server template with id " + serverTemplate.getId() );
+        final ContainerSpec containerSpec = serverTemplate.getContainerSpec(containerSpecKey.getId());
+        if (containerSpec == null) {
+            throw new KieServerControllerNotFoundException("No container spec found for id " + containerSpecKey.getId()
+                                                                   + " within server template with id " + serverTemplate.getId());
         }
-        containerSpec.setStatus( KieContainerStatus.STARTED );
+        containerSpec.setStatus(KieContainerStatus.STARTED);
 
-        templateStorage.update( serverTemplate );
+        templateStorage.update(serverTemplate);
 
-        List<Container> containers = kieServerInstanceManager.startContainer( serverTemplate, containerSpec );
+        List<Container> containers = kieServerInstanceManager.startContainer(serverTemplate, containerSpec);
 
-        notificationService.notify( serverTemplate, containerSpec, containers );
+        notificationService.notify(serverTemplate, containerSpec, containers);
     }
 
     @Override
-    public synchronized void stopContainer( ContainerSpecKey containerSpecKey ) {
+    public synchronized void stopContainer(ContainerSpecKey containerSpecKey) {
 
-        ServerTemplate serverTemplate = templateStorage.load( containerSpecKey.getServerTemplateKey().getId() );
-        if ( serverTemplate == null ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + containerSpecKey.getServerTemplateKey().getId() );
+        ServerTemplate serverTemplate = templateStorage.load(containerSpecKey.getServerTemplateKey().getId());
+        if (serverTemplate == null) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + containerSpecKey.getServerTemplateKey().getId());
         }
 
-        ContainerSpec containerSpec = serverTemplate.getContainerSpec( containerSpecKey.getId() );
-        if ( containerSpec == null ) {
-            throw new KieServerControllerNotFoundException( "No container spec found for id " + containerSpecKey.getId() + " within server template with id " + serverTemplate.getId() );
+        ContainerSpec containerSpec = serverTemplate.getContainerSpec(containerSpecKey.getId());
+        if (containerSpec == null) {
+            throw new KieServerControllerNotFoundException("No container spec found for id " + containerSpecKey.getId() + " within server template with id " + serverTemplate.getId());
         }
-        containerSpec.setStatus( KieContainerStatus.STOPPED );
+        containerSpec.setStatus(KieContainerStatus.STOPPED);
 
-        templateStorage.update( serverTemplate );
+        templateStorage.update(serverTemplate);
 
-        List<Container> containers = kieServerInstanceManager.stopContainer( serverTemplate, containerSpec );
+        List<Container> containers = kieServerInstanceManager.stopContainer(serverTemplate, containerSpec);
 
-        notificationService.notify( serverTemplate, containerSpec, containers );
+        notificationService.notify(serverTemplate, containerSpec, containers);
     }
 
     public KieServerTemplateStorage getTemplateStorage() {
         return templateStorage;
     }
 
-    public void setTemplateStorage( KieServerTemplateStorage templateStorage ) {
+    public void setTemplateStorage(KieServerTemplateStorage templateStorage) {
         this.templateStorage = templateStorage;
     }
 
@@ -378,7 +420,7 @@ public class SpecManagementServiceImpl implements SpecManagementService {
         return notificationService;
     }
 
-    public void setNotificationService( NotificationService notificationService ) {
+    public void setNotificationService(NotificationService notificationService) {
         this.notificationService = notificationService;
     }
 
@@ -386,7 +428,7 @@ public class SpecManagementServiceImpl implements SpecManagementService {
         return kieServerInstanceManager;
     }
 
-    public void setKieServerInstanceManager( KieServerInstanceManager kieServerInstanceManager ) {
+    public void setKieServerInstanceManager(KieServerInstanceManager kieServerInstanceManager) {
         this.kieServerInstanceManager = kieServerInstanceManager;
     }
 }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/KieServerInstanceManagerTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/KieServerInstanceManagerTest.java
@@ -16,18 +16,35 @@
 
 package org.kie.server.controller.impl;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.api.model.KieScannerResource;
+import org.kie.server.api.model.KieScannerStatus;
+import org.kie.server.api.model.KieServerConfigItem;
+import org.kie.server.api.model.Message;
+import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.controller.api.model.runtime.Container;
+import org.kie.server.controller.api.model.spec.Capability;
 import org.kie.server.controller.api.model.spec.ContainerSpec;
+import org.kie.server.controller.api.model.spec.ProcessConfig;
+import org.kie.server.controller.api.model.spec.RuleConfig;
 import org.kie.server.controller.api.model.spec.ServerTemplate;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -49,6 +66,9 @@ public class KieServerInstanceManagerTest {
     private ServiceResponse<?> response;
 
     @Mock
+    private KieServerInstanceManager.RemoteKieServerOperation operation;
+
+    @Mock
     private KieContainerResource containerResource;
 
     private KieServerInstanceManager instanceManager;
@@ -60,7 +80,6 @@ public class KieServerInstanceManagerTest {
 
     @Test
     public void testGetContainers() {
-        final KieServerInstanceManager.RemoteKieServerOperation<?> operation = mock(KieServerInstanceManager.RemoteKieServerOperation.class);
 
         doReturn(operation).when(instanceManager).getContainersRemoteOperation(serverTemplate,
                                                                                containerSpec);
@@ -75,6 +94,7 @@ public class KieServerInstanceManagerTest {
 
     @Test
     public void testGetContainersRemoteOperationWhenResponseTypeIsSUCCESS() {
+
         doReturn(containerResource).when(response).getResult();
         doReturn(response).when(client).getContainerInfo(any());
         doReturn(ServiceResponse.ResponseType.SUCCESS).when(response).getType();
@@ -95,6 +115,7 @@ public class KieServerInstanceManagerTest {
 
     @Test
     public void testGetContainersRemoteOperationWhenResponseTypeIsNotSUCCESS() {
+
         doReturn(containerResource).when(response).getResult();
         doReturn(response).when(client).getContainerInfo(any());
         doReturn(ServiceResponse.ResponseType.FAILURE).when(response).getType();
@@ -117,5 +138,344 @@ public class KieServerInstanceManagerTest {
                never()).setStatus(any());
         verify(container,
                never()).setMessages(any());
+    }
+
+    @Test
+    public void testMakeContainerResourceWhenConfigsIsNull() {
+
+        final String id = "id";
+        final ReleaseId releaseId = mock(ReleaseId.class);
+        final ReleaseId resolvedReleasedId = mock(ReleaseId.class);
+        final KieContainerStatus status = KieContainerStatus.CREATING;
+        final String containerName = "containerName";
+        final Collection<Message> messages = new ArrayList<>();
+
+        doReturn(id).when(containerSpec).getId();
+        doReturn(releaseId).when(containerSpec).getReleasedId();
+        doReturn(resolvedReleasedId).when(container).getResolvedReleasedId();
+        doReturn(status).when(container).getStatus();
+        doReturn(containerName).when(containerSpec).getContainerName();
+        doReturn(messages).when(container).getMessages();
+        doReturn(null).when(containerSpec).getConfigs();
+
+        final KieContainerResource resource = instanceManager.makeContainerResource(container, containerSpec);
+
+        assertEquals(id, resource.getContainerId());
+        assertEquals(releaseId, resource.getReleaseId());
+        assertEquals(resolvedReleasedId, resource.getResolvedReleaseId());
+        assertEquals(status, resource.getStatus());
+        assertEquals(containerName, resource.getContainerAlias());
+        assertEquals(messages, resource.getMessages());
+
+        verify(instanceManager, never()).setRuleConfigAttributes(any(), any());
+        verify(instanceManager, never()).setProcessConfigAttributes(any(), any());
+    }
+
+    @Test
+    public void testStartContainer() {
+
+        final List<?> expectedContainers = mock(List.class);
+
+        doReturn(operation).when(instanceManager).makeStartContainerOperation(containerSpec);
+        doReturn(expectedContainers).when(instanceManager).callRemoteKieServerOperation(serverTemplate, containerSpec, operation);
+
+        final List<Container> actualContainers = instanceManager.startContainer(serverTemplate, containerSpec);
+
+        verify(instanceManager).callRemoteKieServerOperation(serverTemplate, containerSpec, operation);
+
+        assertEquals(expectedContainers, actualContainers);
+    }
+
+    @Test
+    public void testMakeStartContainerOperationWhenResponseTypeIsSuccess() {
+
+        final ServiceResponse.ResponseType responseType = ServiceResponse.ResponseType.SUCCESS;
+        final String containerId = "id";
+
+        doReturn(containerId).when(containerSpec).getId();
+        doReturn(containerResource).when(instanceManager).makeContainerResource(container, containerSpec);
+        doReturn(response).when(client).createContainer(containerId, containerResource);
+        doReturn(responseType).when(response).getType();
+        doNothing().when(instanceManager).collectContainerInfo(containerSpec, client, container);
+
+        instanceManager.makeStartContainerOperation(containerSpec).doOperation(client, container);
+
+        verify(client).createContainer(containerId, containerResource);
+        verify(instanceManager).collectContainerInfo(containerSpec, client, container);
+        verify(instanceManager, never()).log(any(), any(), any(), any());
+    }
+
+    @Test
+    public void testMakeStartContainerOperationWhenResponseTypeIsNotSuccess() {
+
+        final ServiceResponse.ResponseType responseType = ServiceResponse.ResponseType.FAILURE;
+        final String containerId = "id";
+
+        doReturn(containerId).when(containerSpec).getId();
+        doReturn(containerResource).when(instanceManager).makeContainerResource(container, containerSpec);
+        doReturn(response).when(client).createContainer(containerId, containerResource);
+        doReturn(responseType).when(response).getType();
+        doNothing().when(instanceManager).collectContainerInfo(containerSpec, client, container);
+
+        instanceManager.makeStartContainerOperation(containerSpec).doOperation(client, container);
+
+        verify(client).createContainer(containerId, containerResource);
+        verify(instanceManager).collectContainerInfo(containerSpec, client, container);
+        verify(instanceManager).log("Container {} failed to start on server instance {} due to {}", container, response, containerSpec);
+    }
+
+    @Test
+    public void testMakeUpgradeContainerOperationWhenResponseTypeIsSuccess() {
+
+        final ServiceResponse.ResponseType responseType = ServiceResponse.ResponseType.SUCCESS;
+        final String containerId = "id";
+        final ReleaseId releaseId = mock(ReleaseId.class);
+
+        doReturn(containerId).when(containerSpec).getId();
+        doReturn(releaseId).when(containerSpec).getReleasedId();
+        doReturn(containerResource).when(instanceManager).makeContainerResource(container, containerSpec);
+        doReturn(response).when(client).updateReleaseId(containerId, releaseId);
+        doReturn(responseType).when(response).getType();
+        doNothing().when(instanceManager).collectContainerInfo(containerSpec, client, container);
+
+        instanceManager.makeUpgradeContainerOperation(containerSpec).doOperation(client, container);
+
+        verify(client, never()).createContainer(anyString(), any(KieContainerResource.class));
+        verify(client).updateReleaseId(containerId, releaseId);
+        verify(instanceManager).collectContainerInfo(containerSpec, client, container);
+        verify(instanceManager, never()).log(any(), any(), any(), any());
+    }
+
+    @Test
+    public void testMakeUpgradeContainerOperationWhenResponseTypeIsNotSuccess() {
+
+        final ServiceResponse.ResponseType responseType = ServiceResponse.ResponseType.FAILURE;
+        final String containerId = "id";
+        final String url = "url";
+        final String msg = "msg";
+        final ReleaseId releaseId = mock(ReleaseId.class);
+
+        doReturn(containerId).when(containerSpec).getId();
+        doReturn(releaseId).when(containerSpec).getReleasedId();
+        doReturn(containerResource).when(instanceManager).makeContainerResource(container, containerSpec);
+        doReturn(response).when(client).updateReleaseId(containerId, releaseId);
+        doReturn(responseType).when(response).getType();
+        doReturn(msg).when(response).getMsg();
+        doReturn(url).when(container).getUrl();
+        doNothing().when(instanceManager).collectContainerInfo(containerSpec, client, container);
+
+        instanceManager.makeUpgradeContainerOperation(containerSpec).doOperation(client, container);
+
+        verify(client, never()).createContainer(anyString(), any(KieContainerResource.class));
+        verify(client).updateReleaseId(containerId, releaseId);
+        verify(instanceManager).collectContainerInfo(containerSpec, client, container);
+        verify(instanceManager).log("Container {} failed to upgrade on server instance {} due to {}", containerId, url, msg);
+    }
+
+    @Test
+    public void testMakeUpgradeAndStartContainerOperationWhenResponseTypeIsSuccess() {
+
+        final ServiceResponse.ResponseType responseType = ServiceResponse.ResponseType.SUCCESS;
+        final String containerId = "id";
+        final ReleaseId releaseId = mock(ReleaseId.class);
+
+        doReturn(containerId).when(containerSpec).getId();
+        doReturn(releaseId).when(containerSpec).getReleasedId();
+        doReturn(containerResource).when(instanceManager).makeContainerResource(container, containerSpec);
+        doReturn(response).when(client).updateReleaseId(containerId, releaseId);
+        doReturn(responseType).when(response).getType();
+        doNothing().when(instanceManager).collectContainerInfo(containerSpec, client, container);
+
+        instanceManager.makeUpgradeAndStartContainerOperation(containerSpec).doOperation(client, container);
+
+        verify(client).createContainer(containerId, containerResource);
+        verify(client).updateReleaseId(containerId, releaseId);
+        verify(instanceManager).collectContainerInfo(containerSpec, client, container);
+        verify(instanceManager, never()).log(any(), any(), any(), any());
+    }
+
+    @Test
+    public void testMakeUpgradeAndStartContainerOperationWhenResponseTypeIsNotSuccess() {
+
+        final ServiceResponse.ResponseType responseType = ServiceResponse.ResponseType.FAILURE;
+        final String containerId = "id";
+        final String url = "url";
+        final String msg = "msg";
+        final ReleaseId releaseId = mock(ReleaseId.class);
+
+        doReturn(containerId).when(containerSpec).getId();
+        doReturn(releaseId).when(containerSpec).getReleasedId();
+        doReturn(containerResource).when(instanceManager).makeContainerResource(container, containerSpec);
+        doReturn(response).when(client).updateReleaseId(containerId, releaseId);
+        doReturn(responseType).when(response).getType();
+        doReturn(msg).when(response).getMsg();
+        doReturn(url).when(container).getUrl();
+        doNothing().when(instanceManager).collectContainerInfo(containerSpec, client, container);
+
+        instanceManager.makeUpgradeAndStartContainerOperation(containerSpec).doOperation(client, container);
+
+        verify(client).createContainer(containerId, containerResource);
+        verify(client).updateReleaseId(containerId, releaseId);
+        verify(instanceManager).collectContainerInfo(containerSpec, client, container);
+        verify(instanceManager).log("Container {} failed to upgrade on server instance {} due to {}", containerId, url, msg);
+    }
+
+    @Test
+    public void testMakeContainerResourceWhenConfigsIsNotNull() {
+
+        final String id = "id";
+        final ReleaseId releaseId = mock(ReleaseId.class);
+        final ReleaseId resolvedReleasedId = mock(ReleaseId.class);
+        final KieContainerStatus status = KieContainerStatus.CREATING;
+        final String containerName = "containerName";
+        final Collection<Message> messages = new ArrayList<>();
+        final Map<?, ?> configs = mock(Map.class);
+
+        doReturn(id).when(containerSpec).getId();
+        doReturn(releaseId).when(containerSpec).getReleasedId();
+        doReturn(resolvedReleasedId).when(container).getResolvedReleasedId();
+        doReturn(status).when(container).getStatus();
+        doReturn(containerName).when(containerSpec).getContainerName();
+        doReturn(messages).when(container).getMessages();
+        doReturn(configs).when(containerSpec).getConfigs();
+
+        final KieContainerResource resource = instanceManager.makeContainerResource(container, containerSpec);
+
+        assertEquals(id, resource.getContainerId());
+        assertEquals(releaseId, resource.getReleaseId());
+        assertEquals(resolvedReleasedId, resource.getResolvedReleaseId());
+        assertEquals(status, resource.getStatus());
+        assertEquals(containerName, resource.getContainerAlias());
+        assertEquals(messages, resource.getMessages());
+
+        verify(instanceManager).setRuleConfigAttributes(containerSpec, resource);
+        verify(instanceManager).setProcessConfigAttributes(containerSpec, resource);
+    }
+
+    @Test
+    public void testMakeKieServerConfigItem() {
+
+        final String type = "type";
+        final String name = "name";
+        final String value = "value";
+
+        final KieServerConfigItem configItem = instanceManager.makeKieServerConfigItem(type, name, value);
+
+        assertEquals(type, configItem.getType());
+        assertEquals(name, configItem.getName());
+        assertEquals(value, configItem.getValue());
+    }
+
+    @Test
+    public void testSetRuleConfigAttributesWhenRuleConfigIsNotNull() {
+
+        final Map<?, ?> configs = mock(Map.class);
+        final RuleConfig containerConfig = mock(RuleConfig.class);
+        final ArgumentCaptor<KieScannerResource> scannerResourceCaptor = ArgumentCaptor.forClass(KieScannerResource.class);
+        final Long pollInterval = 1L;
+        final KieScannerStatus scannerStatus = KieScannerStatus.CREATED;
+
+        doReturn(pollInterval).when(containerConfig).getPollInterval();
+        doReturn(scannerStatus).when(containerConfig).getScannerStatus();
+        doReturn(containerConfig).when(configs).get(Capability.RULE);
+        doReturn(configs).when(containerSpec).getConfigs();
+
+        instanceManager.setRuleConfigAttributes(containerSpec, containerResource);
+
+        verify(containerResource).setScanner(scannerResourceCaptor.capture());
+
+        final KieScannerResource scannerResource = scannerResourceCaptor.getValue();
+
+        assertEquals(pollInterval, scannerResource.getPollInterval());
+        assertEquals(scannerStatus, scannerResource.getStatus());
+    }
+
+    @Test
+    public void testSetRuleConfigAttributesWhenRuleConfigIsNull() {
+
+        final Map<?, ?> configs = mock(Map.class);
+
+        doReturn(null).when(configs).get(Capability.RULE);
+        doReturn(configs).when(containerSpec).getConfigs();
+
+        instanceManager.setRuleConfigAttributes(containerSpec, containerResource);
+
+        verify(containerResource, never()).setScanner(any());
+    }
+
+    @Test
+    public void testSetProcessConfigAttributesWhenProcessConfigIsNotNull() {
+
+        final Map<?, ?> configs = mock(Map.class);
+        final ProcessConfig processConfig = new ProcessConfig("runtimeStrategy", "kBase", "kSession", "mergeMode");
+        final KieContainerResource containerResource = spy(new KieContainerResource());
+        final List<KieServerConfigItem> actualConfigItems = containerResource.getConfigItems();
+        final KieServerConfigItem expectedConfigItem0 = configItem(KieServerConstants.CAPABILITY_BPM,
+                                                                   KieServerConstants.PCFG_KIE_BASE,
+                                                                   processConfig.getKBase());
+        final KieServerConfigItem expectedConfigItem1 = configItem(KieServerConstants.CAPABILITY_BPM,
+                                                                   KieServerConstants.PCFG_KIE_SESSION,
+                                                                   processConfig.getKSession());
+        final KieServerConfigItem expectedConfigItem2 = configItem(KieServerConstants.CAPABILITY_BPM,
+                                                                   KieServerConstants.PCFG_MERGE_MODE,
+                                                                   processConfig.getMergeMode());
+        final KieServerConfigItem expectedConfigItem3 = configItem(KieServerConstants.CAPABILITY_BPM,
+                                                                   KieServerConstants.PCFG_RUNTIME_STRATEGY,
+                                                                   processConfig.getRuntimeStrategy());
+
+        doReturn(processConfig).when(configs).get(Capability.PROCESS);
+        doReturn(configs).when(containerSpec).getConfigs();
+
+        instanceManager.setProcessConfigAttributes(containerSpec, containerResource);
+
+        assertEquals(expectedConfigItem0, actualConfigItems.get(0));
+        assertEquals(expectedConfigItem1, actualConfigItems.get(1));
+        assertEquals(expectedConfigItem2, actualConfigItems.get(2));
+        assertEquals(expectedConfigItem3, actualConfigItems.get(3));
+        assertEquals(4, actualConfigItems.size());
+    }
+
+    @Test
+    public void testSetProcessConfigAttributesWhenProcessConfigIsNull() {
+
+        final Map<?, ?> configs = mock(Map.class);
+        final KieContainerResource containerResource = spy(new KieContainerResource());
+        final List<KieServerConfigItem> actualConfigItems = containerResource.getConfigItems();
+
+        doReturn(null).when(configs).get(Capability.PROCESS);
+        doReturn(configs).when(containerSpec).getConfigs();
+
+        instanceManager.setProcessConfigAttributes(containerSpec, containerResource);
+
+        assertEquals(0, actualConfigItems.size());
+    }
+
+    @Test
+    public void testUpgradeContainer() {
+
+        doReturn(operation).when(instanceManager).makeUpgradeContainerOperation(containerSpec);
+
+        instanceManager.upgradeContainer(serverTemplate, containerSpec);
+
+        verify(instanceManager).callRemoteKieServerOperation(serverTemplate, containerSpec, operation);
+    }
+
+    @Test
+    public void testUpgradeAndStartContainer() {
+
+        doReturn(operation).when(instanceManager).makeUpgradeAndStartContainerOperation(containerSpec);
+
+        instanceManager.upgradeAndStartContainer(serverTemplate, containerSpec);
+
+        verify(instanceManager).callRemoteKieServerOperation(serverTemplate, containerSpec, operation);
+    }
+
+    private KieServerConfigItem configItem(final String capabilityBpm,
+                                           final String pcfgKieBase,
+                                           final String kBase) {
+
+        return instanceManager.makeKieServerConfigItem(capabilityBpm,
+                                                       pcfgKieBase,
+                                                       kBase);
     }
 }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/RuleCapabilitiesServiceImplTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/RuleCapabilitiesServiceImplTest.java
@@ -145,41 +145,70 @@ public class RuleCapabilitiesServiceImplTest extends AbstractServiceImplTest {
     }
 
     @Test
-    public void testUpgradeContainer() {
+    public void testUpgradeContainerWhenContainerSpecStatusIsStarted() {
 
-        List<Container> fakeResult = new ArrayList<Container>();
-        fakeResult.add(container);
-        when(kieServerInstanceManager.upgradeContainer(any(ServerTemplate.class),
-                                                       any(ContainerSpec.class))).thenReturn(fakeResult);
+        final List<Container> fakeResult = new ArrayList<Container>() {{
+            add(container);
+        }};
 
-        ReleaseId initial = containerSpec.getReleasedId();
-        ReleaseId upgradeTo = new ReleaseId("org.kie",
-                                            "kie-server-kjar",
-                                            "2.0");
+        doReturn(fakeResult).when(kieServerInstanceManager).upgradeContainer(any(ServerTemplate.class), any(ContainerSpec.class));
 
-        ruleCapabilitiesService.upgradeContainer(containerSpec,
-                                                 upgradeTo);
+        containerSpec.setStatus(KieContainerStatus.STARTED);
 
-        verify(kieServerInstanceManager,
-               times(1)).upgradeContainer(any(ServerTemplate.class),
-                                          any(ContainerSpec.class));
+        final ReleaseId initial = containerSpec.getReleasedId();
+        final ReleaseId upgradeTo = new ReleaseId("org.kie", "kie-server-kjar", "2.0");
 
-        ServerTemplate updated = specManagementService.getServerTemplate(serverTemplate.getId());
+        ruleCapabilitiesService.upgradeContainer(containerSpec, upgradeTo);
 
-        Collection<ContainerSpec> containerSpecs = updated.getContainersSpec();
+        verify(kieServerInstanceManager).upgradeContainer(any(ServerTemplate.class), any(ContainerSpec.class));
+
+        final ServerTemplate updated = specManagementService.getServerTemplate(serverTemplate.getId());
+
+        final Collection<ContainerSpec> containerSpecs = updated.getContainersSpec();
+
         assertNotNull(containerSpecs);
-        assertEquals(1,
-                     containerSpecs.size());
+        assertEquals(1, containerSpecs.size());
 
         ContainerSpec updatedContainer = containerSpecs.iterator().next();
         assertNotNull(updatedContainer);
 
         assertNotNull(updatedContainer.getReleasedId());
-        assertNotEquals(initial,
-                        updatedContainer.getReleasedId());
-        assertEquals(upgradeTo,
-                     updatedContainer.getReleasedId());
-        assertEquals(updatedContainer.getStatus(),
-                     KieContainerStatus.STARTED);
+        assertNotEquals(initial, updatedContainer.getReleasedId());
+        assertEquals(upgradeTo, updatedContainer.getReleasedId());
+        assertEquals(updatedContainer.getStatus(), KieContainerStatus.STARTED);
+    }
+
+    @Test
+    public void testUpgradeContainerWhenContainerSpecStatusIsStopped() {
+
+        final List<Container> fakeResult = new ArrayList<Container>() {{
+            add(container);
+        }};
+
+        doReturn(fakeResult).when(kieServerInstanceManager).startContainer(any(ServerTemplate.class), any(ContainerSpec.class));
+
+        containerSpec.setStatus(KieContainerStatus.STOPPED);
+
+        final ReleaseId initial = containerSpec.getReleasedId();
+        final ReleaseId upgradeTo = new ReleaseId("org.kie", "kie-server-kjar", "2.0");
+
+        ruleCapabilitiesService.upgradeContainer(containerSpec, upgradeTo);
+
+        verify(kieServerInstanceManager).startContainer(any(ServerTemplate.class), any(ContainerSpec.class));
+
+        final ServerTemplate updated = specManagementService.getServerTemplate(serverTemplate.getId());
+
+        final Collection<ContainerSpec> containerSpecs = updated.getContainersSpec();
+
+        assertNotNull(containerSpecs);
+        assertEquals(1, containerSpecs.size());
+
+        ContainerSpec updatedContainer = containerSpecs.iterator().next();
+        assertNotNull(updatedContainer);
+
+        assertNotNull(updatedContainer.getReleasedId());
+        assertNotEquals(initial, updatedContainer.getReleasedId());
+        assertEquals(upgradeTo, updatedContainer.getReleasedId());
+        assertEquals(updatedContainer.getStatus(), KieContainerStatus.STARTED);
     }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
@@ -79,20 +79,18 @@ public class KieServerImpl implements KieServer {
     private static final ServiceLoader<KieServerExtension> serverExtensions = ServiceLoader.load(KieServerExtension.class);
 
     private static final ServiceLoader<KieServerController> kieControllers = ServiceLoader.load(KieServerController.class);
-    // TODO figure out how to get actual URL of the kie server
-    private String kieServerLocation = System.getProperty(KieServerConstants.KIE_SERVER_LOCATION, "http://localhost:8230/kie-server/services/rest/server");
-
     private final KieServerRegistry context;
     private final PolicyManager policyManager;
-
     private final KieServerStateRepository repository;
+    // TODO figure out how to get actual URL of the kie server
+    private String kieServerLocation = System.getProperty(KieServerConstants.KIE_SERVER_LOCATION, "http://localhost:8230/kie-server/services/rest/server");
     private volatile AtomicBoolean kieServerActive = new AtomicBoolean(false);
 
     private List<Message> serverMessages = new ArrayList<Message>();
     private Map<String, List<Message>> containerMessages = new ConcurrentHashMap<String, List<Message>>();
 
     private KieServerEventSupport eventSupport = new KieServerEventSupport();
-    
+
     private KieServices ks = KieServices.Factory.get();
 
     public KieServerImpl() {
@@ -123,7 +121,7 @@ public class KieServerImpl implements KieServer {
 
                 this.context.registerServerExtension(extension);
 
-                if(extension.isInitialized()) {
+                if (extension.isInitialized()) {
                     logger.info("{} has been successfully registered as server extension", extension);
                 } else {
                     logger.warn("{} has not been registered as server extension", extension);
@@ -232,7 +230,6 @@ public class KieServerImpl implements KieServer {
         }
 
         return new KieServerInfo(serverId, serverName, versionStr, capabilities, kieServerLocation);
-
     }
 
     public ServiceResponse<KieServerInfo> getInfo() {
@@ -268,7 +265,7 @@ public class KieServerImpl implements KieServer {
                 if (previous == null) {
                     try {
                         eventSupport.fireBeforeContainerStarted(this, ci);
-                        
+
                         InternalKieContainer kieContainer = (InternalKieContainer) ks.newKieContainer(containerId, releaseId);
                         if (kieContainer != null) {
                             ci.setKieContainer(kieContainer);
@@ -304,17 +301,16 @@ public class KieServerImpl implements KieServer {
 
                             repository.store(KieServerEnvironment.getServerId(), currentState);
                             // add successful message only when there are no errors
-                            if (!messages.stream().filter(m-> m.getSeverity().equals(Severity.ERROR)).findAny().isPresent()) {
+                            if (!messages.stream().filter(m -> m.getSeverity().equals(Severity.ERROR)).findAny().isPresent()) {
                                 messages.add(new Message(Severity.INFO, "Container " + containerId + " successfully created with module " + releaseId + "."));
                                 eventSupport.fireAfterContainerStarted(this, ci);
 
                                 return new ServiceResponse<KieContainerResource>(ServiceResponse.ResponseType.SUCCESS, "Container " + containerId + " successfully deployed with module " + releaseId + ".", ci.getResource());
                             } else {
                                 ci.getResource().setStatus(KieContainerStatus.FAILED);
-                                ci.getResource().setReleaseId(releaseId);                                
+                                ci.getResource().setReleaseId(releaseId);
                                 return new ServiceResponse<KieContainerResource>(ServiceResponse.ResponseType.FAILURE, "Failed to create container " + containerId + " with module " + releaseId + ".");
                             }
-
                         } else {
                             messages.add(new Message(Severity.ERROR, "KieContainer could not be found for release id " + releaseId));
                             ci.getResource().setStatus(KieContainerStatus.FAILED);
@@ -341,7 +337,6 @@ public class KieServerImpl implements KieServer {
         } finally {
             this.containerMessages.put(containerId, messages);
         }
-
     }
 
     public ServiceResponse<KieContainerResourceList> listContainers(KieContainerResourceFilter containerFilter) {
@@ -410,12 +405,11 @@ public class KieServerImpl implements KieServer {
                                 logger.debug("Container {} (for release id {}) {} shutdown: DONE", containerId, kci.getResource().getReleaseId(), extension);
                                 disposedExtensions.add(extension);
                             }
-
                         } catch (Exception e) {
                             logger.warn("Dispose of container {} failed, putting it back to started state by recreating container on {}", containerId, disposedExtensions);
 
                             // since the dispose fail rollback must take place to put it back to running state
-                            
+
                             Map<String, Object> parameters = getContainerParameters(releaseId, messages);
                             for (KieServerExtension extension : disposedExtensions) {
                                 extension.createContainer(containerId, kci, parameters);
@@ -443,7 +437,7 @@ public class KieServerImpl implements KieServer {
 
                         List<KieContainerResource> containers = new ArrayList<KieContainerResource>();
                         for (KieContainerResource containerResource : currentState.getContainers()) {
-                            if ( !containerId.equals(containerResource.getContainerId()) ) {
+                            if (!containerId.equals(containerResource.getContainerId())) {
                                 containers.add(containerResource);
                             }
                         }
@@ -480,11 +474,11 @@ public class KieServerImpl implements KieServer {
         try {
             KieContainerInstanceImpl kci = context.getContainer(id);
             if (kci != null && kci.getKieContainer() != null) {
-                KieScannerResource info = getScannerResource( kci );
+                KieScannerResource info = getScannerResource(kci);
                 return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.SUCCESS, "Scanner info successfully retrieved", info);
             } else {
                 return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.FAILURE,
-                        "Unknown container " + id + ".");
+                                                               "Unknown container " + id + ".");
             }
         } catch (Exception e) {
             logger.error("Error retrieving scanner info for container '" + id + "'.", e);
@@ -513,7 +507,7 @@ public class KieServerImpl implements KieServer {
                 }
             } else {
                 return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.FAILURE,
-                        "Unknown container " + id + ".");
+                                                               "Unknown container " + id + ".");
             }
         } catch (Exception e) {
             logger.error("Error updating scanner for container '" + id + "': " + resource, e);
@@ -546,7 +540,7 @@ public class KieServerImpl implements KieServer {
             default:
                 // error
                 result = new ServiceResponse<KieScannerResource>(ResponseType.FAILURE,
-                        "Unknown status '" + scannerStatus + "' for scanner on container " + containerId + ".");
+                                                                 "Unknown status '" + scannerStatus + "' for scanner on container " + containerId + ".");
                 break;
         }
         kci.getResource().setScanner(result.getResult());
@@ -555,7 +549,6 @@ public class KieServerImpl implements KieServer {
 
     /**
      * Stores (persists) new scanner state for the specified KIE container.
-     *
      * @param containerId container ID to update the scanner for
      * @param scannerState new scanner state
      */
@@ -585,23 +578,23 @@ public class KieServerImpl implements KieServer {
 
             messages.add(new Message(Severity.INFO, "Kie scanner successfully started with interval " + scannerPollInterval));
             return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.SUCCESS,
-                    "Kie scanner successfully created.",
-                    getScannerResource(kci));
+                                                           "Kie scanner successfully created.",
+                                                           getScannerResource(kci));
         } else if (!KieScannerStatus.STOPPED.equals(scannerStatus)) {
             messages.add(new Message(Severity.WARN, "Invalid kie scanner status: " + scannerStatus));
             return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.FAILURE,
-                    "Invalid kie scanner status: " + scannerStatus,
-                    getScannerResource(kci));
+                                                           "Invalid kie scanner status: " + scannerStatus,
+                                                           getScannerResource(kci));
         } else if (scannerPollInterval == null) {
             messages.add(new Message(Severity.WARN, "Invalid polling interval: null"));
             return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.FAILURE,
-                    "Invalid polling interval: null",
-                    getScannerResource(kci));
+                                                           "Invalid polling interval: null",
+                                                           getScannerResource(kci));
         }
         messages.add(new Message(Severity.ERROR, "Unknown error starting scanner. Scanner was not started."));
         return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.FAILURE,
-                "Unknown error starting scanner. Scanner was not started.",
-                getScannerResource(kci));
+                                                       "Unknown error starting scanner. Scanner was not started.",
+                                                       getScannerResource(kci));
     }
 
     private ServiceResponse<KieScannerResource> stopScanner(String id, KieContainerInstanceImpl kci) {
@@ -609,22 +602,22 @@ public class KieServerImpl implements KieServer {
         messages.clear();
         if (kci.getScanner() == null) {
             return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.SUCCESS,
-                    "Scanner is not started. ",
-                    getScannerResource(kci));
+                                                           "Scanner is not started. ",
+                                                           getScannerResource(kci));
         }
         if (KieScannerStatus.STARTED.equals(mapScannerStatus(kci)) ||
                 KieScannerStatus.SCANNING.equals(mapScannerStatus(kci))) {
             kci.stopScanner();
             messages.add(new Message(Severity.INFO, "Kie scanner successfully stopped."));
             return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.SUCCESS,
-                    "Kie scanner successfully stopped.",
-                    getScannerResource(kci));
+                                                           "Kie scanner successfully stopped.",
+                                                           getScannerResource(kci));
         } else {
             KieScannerStatus scannerStatus = mapScannerStatus(kci);
             messages.add(new Message(Severity.WARN, "Invalid kie scanner status: " + scannerStatus));
             return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.FAILURE,
-                    "Invalid kie scanner status: " + scannerStatus,
-                    getScannerResource(kci));
+                                                           "Invalid kie scanner status: " + scannerStatus,
+                                                           getScannerResource(kci));
         }
     }
 
@@ -632,20 +625,20 @@ public class KieServerImpl implements KieServer {
         List<Message> messages = getMessagesForContainer(id);
         messages.clear();
         if (kci.getScanner() == null) {
-            createScanner( id, kci );
+            createScanner(id, kci);
         }
         KieScannerStatus scannerStatus = mapScannerStatus(kci);
-        if (KieScannerStatus.STOPPED.equals( scannerStatus ) || KieScannerStatus.CREATED.equals( scannerStatus ) || KieScannerStatus.STARTED.equals( scannerStatus )) {
+        if (KieScannerStatus.STOPPED.equals(scannerStatus) || KieScannerStatus.CREATED.equals(scannerStatus) || KieScannerStatus.STARTED.equals(scannerStatus)) {
             kci.scanNow();
             messages.add(new Message(Severity.INFO, "Kie scanner successfully invoked."));
             return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.SUCCESS,
-                    "Scan successfully executed.",
-                    getScannerResource(kci));
+                                                           "Scan successfully executed.",
+                                                           getScannerResource(kci));
         } else {
-            messages.add(new Message(Severity.WARN,  "Invalid kie scanner status: " + scannerStatus));
+            messages.add(new Message(Severity.WARN, "Invalid kie scanner status: " + scannerStatus));
             return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.FAILURE,
-                    "Invalid kie scanner status: " + scannerStatus,
-                    getScannerResource(kci));
+                                                           "Invalid kie scanner status: " + scannerStatus,
+                                                           getScannerResource(kci));
         }
     }
 
@@ -654,8 +647,8 @@ public class KieServerImpl implements KieServer {
         messages.clear();
         if (kci.getScanner() == null) {
             return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.SUCCESS,
-                    "Invalid call. Scanner already disposed.",
-                    getScannerResource(kci));
+                                                           "Invalid call. Scanner already disposed.",
+                                                           getScannerResource(kci));
         }
         if (KieScannerStatus.STARTED.equals(mapScannerStatus(kci)) ||
                 KieScannerStatus.SCANNING.equals(mapScannerStatus(kci))) {
@@ -667,8 +660,8 @@ public class KieServerImpl implements KieServer {
         kci.disposeScanner();
         messages.add(new Message(Severity.INFO, "Kie scanner successfully disposed (shut down)."));
         return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.SUCCESS,
-                "Kie scanner successfully disposed (shut down).",
-                getScannerResource(kci));
+                                                       "Kie scanner successfully disposed (shut down).",
+                                                       getScannerResource(kci));
     }
 
     private KieScannerStatus mapScannerStatus(KieContainerInstanceImpl kieContainerInstance) {
@@ -682,12 +675,11 @@ public class KieServerImpl implements KieServer {
             kci.createScanner();
             messages.add(new Message(Severity.INFO, "Kie scanner successfully created."));
             return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.SUCCESS,
-                    "Kie scanner successfully created.",
-                    getScannerResource(kci));
+                                                           "Kie scanner successfully created.",
+                                                           getScannerResource(kci));
         } else {
             return new ServiceResponse<KieScannerResource>(ServiceResponse.ResponseType.FAILURE,
-                    "Error creating the scanner for container " + id + ". Scanner already exists.");
-
+                                                           "Error creating the scanner for container " + id + ". Scanner already exists.");
         }
     }
 
@@ -706,7 +698,7 @@ public class KieServerImpl implements KieServer {
     }
 
     public ServiceResponse<ReleaseId> updateContainerReleaseId(String id, ReleaseId releaseId) {
-        if( releaseId == null ) {
+        if (releaseId == null) {
             logger.error("Error updating releaseId for container '" + id + "'. ReleaseId is null.");
             return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.FAILURE, "Error updating releaseId for container " + id + ". ReleaseId is null. ");
         }
@@ -725,7 +717,7 @@ public class KieServerImpl implements KieServer {
                 for (KieServerExtension extension : extensions) {
                     boolean allowed = extension.isUpdateContainerAllowed(id, kci, parameters);
                     if (!allowed) {
-                        String message = (String)parameters.get(KieServerConstants.FAILURE_REASON_PROP);
+                        String message = (String) parameters.get(KieServerConstants.FAILURE_REASON_PROP);
                         logger.warn("Container {} (for release id {}) on {} cannot be updated due to {}", id, releaseId, extension, message);
                         if (messages != null) {
                             messages.add(new Message(Severity.WARN, message));
@@ -744,7 +736,7 @@ public class KieServerImpl implements KieServer {
                 updateExtensions(kci, releaseId, messages);
 
                 // If extension update fails then restore previous container
-                if (messages.stream().anyMatch(m-> m.getSeverity().equals(Severity.ERROR))) {
+                if (messages.stream().anyMatch(m -> m.getSeverity().equals(Severity.ERROR))) {
                     logger.warn("Update of container {} (for release id {}) failed, putting it back to original release id {}", id, releaseId, originalReleaseId);
 
                     updateMessage = updateKieContainerToVersion(kci, originalReleaseId);
@@ -763,7 +755,7 @@ public class KieServerImpl implements KieServer {
 
                 List<KieContainerResource> containers = new ArrayList<KieContainerResource>();
                 for (KieContainerResource containerResource : currentState.getContainers()) {
-                    if ( id.equals(containerResource.getContainerId()) ) {
+                    if (id.equals(containerResource.getContainerId())) {
                         containerResource.setReleaseId(releaseId);
                         containerResource.setResolvedReleaseId(new ReleaseId(kci.getKieContainer().getContainerReleaseId()));
                     }
@@ -778,20 +770,11 @@ public class KieServerImpl implements KieServer {
                 messages.add(new Message(Severity.INFO, "Release id successfully updated for container " + id));
                 return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.SUCCESS, "Release id successfully updated.", kci.getResource().getReleaseId());
             } else {
-                // no container yet, attempt to create it
-                KieContainerResource containerResource = new KieContainerResource(id, releaseId, KieContainerStatus.STARTED);
-
-                ServiceResponse<KieContainerResource> response = createContainer(id, containerResource);
-                if (response.getType().equals(ResponseType.SUCCESS)) {
-                    kci = context.getContainer(id);
-                    return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.SUCCESS, "Release id successfully updated.", kci.getResource().getReleaseId());
-                } else {
-                    return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.FAILURE, "Container " + id + " is not instantiated.");
-                }
+                return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.FAILURE, "Container " + id + " is not instantiated.");
             }
         } catch (Exception e) {
             if (messages != null) {
-                messages.add(new Message(Severity.WARN, "Error updating releaseId for container '" + id + "' due to "+ e.getMessage()));
+                messages.add(new Message(Severity.WARN, "Error updating releaseId for container '" + id + "' due to " + e.getMessage()));
             }
             logger.error("Error updating releaseId for container '" + id + "'", e);
             return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.FAILURE, "Error updating releaseId for container " + id + ": " +
@@ -840,7 +823,7 @@ public class KieServerImpl implements KieServer {
             KieServerState currentState = repository.load(KieServerEnvironment.getServerId());
             KieServerStateInfo state = new KieServerStateInfo(currentState.getControllers(), currentState.getConfiguration(), currentState.getContainers());
             return new ServiceResponse<KieServerStateInfo>(ServiceResponse.ResponseType.SUCCESS,
-                    "Successfully loaded server state for server id " + KieServerEnvironment.getServerId(), state);
+                                                           "Successfully loaded server state for server id " + KieServerEnvironment.getServerId(), state);
         } catch (Exception e) {
             logger.error("Error when loading server state due to {}", e.getMessage(), e);
             return new ServiceResponse<KieServerStateInfo>(ResponseType.FAILURE, "Error when loading server state due to " + e.getMessage());
@@ -862,7 +845,7 @@ public class KieServerImpl implements KieServer {
             Iterator<KieServerController> it = kieControllers.iterator();
             if (it != null && it.hasNext()) {
                 controller = it.next();
-                
+
                 if (controller instanceof KieServerRegistryAware) {
                     ((KieServerRegistryAware) controller).setRegistry(context);
                 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerContainerCRUDIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerContainerCRUDIntegrationTest.java
@@ -151,18 +151,12 @@ public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseInte
 
     @Test
     public void testUpdateReleaseIdForNotExistingContainer() throws Exception {
-        ServiceResponse<ReleaseId> reply = client.updateReleaseId("update-releaseId", releaseId2);
-        KieServerAssert.assertSuccess(reply);
-        Assert.assertEquals(releaseId2, reply.getResult());
 
-        ServiceResponse<KieContainerResourceList> replyList = client.listContainers();
-        KieServerAssert.assertSuccess(replyList);
-        List<KieContainerResource> containers = replyList.getResult().getContainers();
-        Assert.assertEquals("Number of listed containers!", 1, containers.size());
-        assertContainsContainer(containers, "update-releaseId");
+        final String updateErrorMessage = "Container update-releaseId is not instantiated.";
+        final ServiceResponse<ReleaseId> reply = client.updateReleaseId("update-releaseId", releaseId2);
 
-        ServiceResponse<Void> disposeReply = client.disposeContainer("update-releaseId");
-        KieServerAssert.assertSuccess(disposeReply);
+        KieServerAssert.assertFailure(reply);
+        Assertions.assertThat(reply.getMsg()).contains(updateErrorMessage);
     }
 
     @Test

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerManagementIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerManagementIntegrationTest.java
@@ -908,14 +908,23 @@ public class KieControllerManagementIntegrationTest extends KieControllerManagem
         KieServerSynchronization.waitForKieServerSynchronization(client, 1);
         checkContainerConfigAgainstServer(processConfig,ruleConfig);
 
-        // Update the container configuration, turning off the scanner
+        // Update the rule configuration, turning off the scanner
         ruleConfig.setScannerStatus(KieScannerStatus.STOPPED);
         mgmtControllerClient.updateContainerConfig(kieServerInfo.getServerId(), CONTAINER_ID, Capability.RULE, ruleConfig);
+
+        // Check the rule configuration
         KieServerSynchronization.waitForKieServerScannerStatus(client, CONTAINER_ID, KieScannerStatus.STOPPED);
         checkContainerConfigAgainstServer(ruleConfig);
 
+        // Update the configuration
         processConfig = new ProcessConfig("SINGLETON", "defaultKieBase", "defaultKieSession", "OVERRIDE_ALL");
         mgmtControllerClient.updateContainerConfig(kieServerInfo.getServerId(), CONTAINER_ID, Capability.PROCESS, processConfig);
+
+        // Reset the container, since the update process should not do that by itself
+        mgmtControllerClient.stopContainer(kieServerInfo.getServerId(), CONTAINER_ID);
+        mgmtControllerClient.startContainer(kieServerInfo.getServerId(), CONTAINER_ID);
+
+        // Update the process configuration
         KieServerSynchronization.waitForKieServerConfig(client, CONTAINER_ID, KieServerConstants.PCFG_MERGE_MODE, "OVERRIDE_ALL");
         checkContainerConfigAgainstServer(processConfig);
 


### PR DESCRIPTION
See:
- https://issues.jboss.org/browse/RHBPMS-4862
- https://issues.jboss.org/browse/RHBPMS-4863

![demo](https://user-images.githubusercontent.com/1079279/30596168-c1011000-9d29-11e7-82fb-5c6dbaec3140.gif)
