### PR TITLE
[6.5.x] RHBPMS-4862, RHBPMS-4863: Container started by upgrade doesn't contain process configuration / Start/stop container buttons are in wrong state after Process Configuration change

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/RuleCapabilitiesServiceImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/RuleCapabilitiesServiceImpl.java
@@ -35,7 +35,8 @@ import org.kie.server.controller.impl.storage.InMemoryKieServerTemplateStorage;
 
 public class RuleCapabilitiesServiceImpl implements RuleCapabilitiesService {
 
-    private KieServerTemplateStorage templateStorage = InMemoryKieServerTemplateStorage.getInstance();;
+    private KieServerTemplateStorage templateStorage = InMemoryKieServerTemplateStorage.getInstance();
+    ;
     private KieServerInstanceManager kieServerInstanceManager = KieServerInstanceManager.getInstance();
     private NotificationService notificationService = LoggingNotificationService.getInstance();
 
@@ -115,15 +116,22 @@ public class RuleCapabilitiesServiceImpl implements RuleCapabilitiesService {
         if (releaseId.getGroupId() == null) {
             releaseId.setGroupId(containerSpec.getReleasedId().getGroupId());
         }
-        if (releaseId.getArtifactId()== null) {
+        if (releaseId.getArtifactId() == null) {
             releaseId.setArtifactId(containerSpec.getReleasedId().getArtifactId());
         }
 
+        final List<Container> containers;
+
         containerSpec.setReleasedId(releaseId);
+
+        if (containerSpec.getStatus() == KieContainerStatus.STARTED) {
+            containers = kieServerInstanceManager.upgradeContainer(serverTemplate, containerSpec);
+        } else {
+            containers = kieServerInstanceManager.startContainer(serverTemplate, containerSpec);
+        }
+
         containerSpec.setStatus(KieContainerStatus.STARTED);
         templateStorage.update(serverTemplate);
-
-        List<Container> containers = kieServerInstanceManager.upgradeContainer(serverTemplate, containerSpec);
 
         notificationService.notify(serverTemplate, containerSpec, containers);
     }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/SpecManagementServiceImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/SpecManagementServiceImpl.java
@@ -48,51 +48,51 @@ import org.slf4j.LoggerFactory;
 
 public class SpecManagementServiceImpl implements SpecManagementService {
 
+    private static Logger logger = LoggerFactory.getLogger(SpecManagementServiceImpl.class);
     private KieServerInstanceManager kieServerInstanceManager = KieServerInstanceManager.getInstance();
     private KieServerTemplateStorage templateStorage = InMemoryKieServerTemplateStorage.getInstance();
     private NotificationService notificationService = LoggingNotificationService.getInstance();
-    private static Logger logger = LoggerFactory.getLogger(SpecManagementServiceImpl.class);
 
     @Override
-    public void saveContainerSpec( String serverTemplateId,
-                                   ContainerSpec containerSpec ) {
-        ServerTemplate serverTemplate = templateStorage.load( serverTemplateId );
-        if ( serverTemplate == null ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + serverTemplateId );
+    public void saveContainerSpec(String serverTemplateId,
+                                  ContainerSpec containerSpec) {
+        ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
+        if (serverTemplate == null) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + serverTemplateId);
         }
 
         if (serverTemplate.hasContainerSpec(containerSpec.getId())) {
-            throw new KieServerControllerException( "Server template with id " + serverTemplateId + " associated already with container " + containerSpec.getId());
+            throw new KieServerControllerException("Server template with id " + serverTemplateId + " associated already with container " + containerSpec.getId());
         }
         // make sure correct server template is set
         containerSpec.setServerTemplateKey(new ServerTemplateKey(serverTemplate.getId(), serverTemplate.getName()));
 
-        serverTemplate.addContainerSpec( containerSpec );
+        serverTemplate.addContainerSpec(containerSpec);
 
-        templateStorage.update( serverTemplate );
+        templateStorage.update(serverTemplate);
 
-        notificationService.notify( new ServerTemplateUpdated( serverTemplate ) );
+        notificationService.notify(new ServerTemplateUpdated(serverTemplate));
         if (containerSpec.getStatus().equals(KieContainerStatus.STARTED)) {
-            List<Container> containers = kieServerInstanceManager.startContainer( serverTemplate, containerSpec );
-            notificationService.notify( serverTemplate, containerSpec, containers );
+            List<Container> containers = kieServerInstanceManager.startContainer(serverTemplate, containerSpec);
+            notificationService.notify(serverTemplate, containerSpec, containers);
         }
     }
 
     @Override
-    public void saveServerTemplate( ServerTemplate serverTemplate ) {
-        if ( templateStorage.exists( serverTemplate.getId() ) ) {
-            templateStorage.update( serverTemplate );
+    public void saveServerTemplate(ServerTemplate serverTemplate) {
+        if (templateStorage.exists(serverTemplate.getId())) {
+            templateStorage.update(serverTemplate);
         } else {
 
-            templateStorage.store( serverTemplate );
+            templateStorage.store(serverTemplate);
         }
 
-        notificationService.notify( new ServerTemplateUpdated( serverTemplate ) );
+        notificationService.notify(new ServerTemplateUpdated(serverTemplate));
     }
 
     @Override
-    public ServerTemplate getServerTemplate( String serverTemplateId ) {
-        return templateStorage.load( serverTemplateId );
+    public ServerTemplate getServerTemplate(String serverTemplateId) {
+        return templateStorage.load(serverTemplateId);
     }
 
     @Override
@@ -106,26 +106,26 @@ public class SpecManagementServiceImpl implements SpecManagementService {
     }
 
     @Override
-    public Collection<ContainerSpec> listContainerSpec( String serverTemplateId ) {
-        ServerTemplate serverTemplate = templateStorage.load( serverTemplateId );
-        if ( serverTemplate == null ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + serverTemplateId );
+    public Collection<ContainerSpec> listContainerSpec(String serverTemplateId) {
+        ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
+        if (serverTemplate == null) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + serverTemplateId);
         }
 
         return serverTemplate.getContainersSpec();
     }
 
     @Override
-    public void deleteContainerSpec( String serverTemplateId,
-                                     String containerSpecId ) {
-        ServerTemplate serverTemplate = templateStorage.load( serverTemplateId );
-        if ( serverTemplate == null ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + serverTemplateId );
+    public void deleteContainerSpec(String serverTemplateId,
+                                    String containerSpecId) {
+        ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
+        if (serverTemplate == null) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + serverTemplateId);
         }
 
         if (serverTemplate.hasContainerSpec(containerSpecId)) {
-            ContainerSpec containerSpec = serverTemplate.getContainerSpec( containerSpecId );
-            kieServerInstanceManager.stopContainer( serverTemplate, containerSpec );
+            ContainerSpec containerSpec = serverTemplate.getContainerSpec(containerSpecId);
+            kieServerInstanceManager.stopContainer(serverTemplate, containerSpec);
             serverTemplate.deleteContainerSpec(containerSpecId);
 
             templateStorage.update(serverTemplate);
@@ -137,183 +137,225 @@ public class SpecManagementServiceImpl implements SpecManagementService {
     }
 
     @Override
-    public void deleteServerTemplate( String serverTemplateId ) {
-        if ( !templateStorage.exists( serverTemplateId ) ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + serverTemplateId );
+    public void deleteServerTemplate(String serverTemplateId) {
+        if (!templateStorage.exists(serverTemplateId)) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + serverTemplateId);
         }
 
-        templateStorage.delete( serverTemplateId );
+        templateStorage.delete(serverTemplateId);
 
-        notificationService.notify( new ServerTemplateDeleted( serverTemplateId ) );
+        notificationService.notify(new ServerTemplateDeleted(serverTemplateId));
     }
 
     @Override
-    public void copyServerTemplate( String serverTemplateId,
-                                    String newServerTemplateId,
-                                    String newServerTemplateName ) {
-        final ServerTemplate serverTemplate = templateStorage.load( serverTemplateId );
-        if ( serverTemplate == null ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + serverTemplateId );
+    public void copyServerTemplate(String serverTemplateId,
+                                   String newServerTemplateId,
+                                   String newServerTemplateName) {
+        final ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
+        if (serverTemplate == null) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + serverTemplateId);
         }
 
-        final Map<Capability, ServerConfig> configMap = new HashMap<Capability, ServerConfig>( serverTemplate.getConfigs().size() );
-        for ( final Map.Entry<Capability, ServerConfig> entry : serverTemplate.getConfigs().entrySet() ) {
-            configMap.put( entry.getKey(), copy( entry.getValue() ) );
+        final Map<Capability, ServerConfig> configMap = new HashMap<Capability, ServerConfig>(serverTemplate.getConfigs().size());
+        for (final Map.Entry<Capability, ServerConfig> entry : serverTemplate.getConfigs().entrySet()) {
+            configMap.put(entry.getKey(), copy(entry.getValue()));
         }
 
-        final Collection<ContainerSpec> containerSpecs = new ArrayList<ContainerSpec>( serverTemplate.getContainersSpec().size() );
-        for ( final ContainerSpec entry : serverTemplate.getContainersSpec() ) {
-            containerSpecs.add( copy( entry, newServerTemplateId, newServerTemplateName ) );
+        final Collection<ContainerSpec> containerSpecs = new ArrayList<ContainerSpec>(serverTemplate.getContainersSpec().size());
+        for (final ContainerSpec entry : serverTemplate.getContainersSpec()) {
+            containerSpecs.add(copy(entry, newServerTemplateId, newServerTemplateName));
         }
 
-        final ServerTemplate copy = new ServerTemplate( newServerTemplateId,
-                                                        newServerTemplateName,
-                                                        serverTemplate.getCapabilities(),
-                                                        configMap,
-                                                        containerSpecs );
+        final ServerTemplate copy = new ServerTemplate(newServerTemplateId,
+                                                       newServerTemplateName,
+                                                       serverTemplate.getCapabilities(),
+                                                       configMap,
+                                                       containerSpecs);
 
-        templateStorage.store( copy );
+        templateStorage.store(copy);
     }
 
-    private ContainerSpec copy( final ContainerSpec origin,
-                                final String newServerTemplateId,
-                                final String newServerTemplateName ) {
+    private ContainerSpec copy(final ContainerSpec origin,
+                               final String newServerTemplateId,
+                               final String newServerTemplateName) {
         final Map<Capability, ContainerConfig> configMap = origin.getConfigs();
-        for ( Map.Entry<Capability, ContainerConfig> entry : origin.getConfigs().entrySet() ) {
-            configMap.put( entry.getKey(), copy( entry.getValue() ) );
+        for (Map.Entry<Capability, ContainerConfig> entry : origin.getConfigs().entrySet()) {
+            configMap.put(entry.getKey(), copy(entry.getValue()));
         }
-        return new ContainerSpec( origin.getId(),
-                                  origin.getContainerName(),
-                                  new ServerTemplateKey( newServerTemplateId, newServerTemplateName ),
-                                  new ReleaseId( origin.getReleasedId() ),
-                                  origin.getStatus(),
-                                  configMap );
+        return new ContainerSpec(origin.getId(),
+                                 origin.getContainerName(),
+                                 new ServerTemplateKey(newServerTemplateId, newServerTemplateName),
+                                 new ReleaseId(origin.getReleasedId()),
+                                 origin.getStatus(),
+                                 configMap);
     }
 
-    private ContainerConfig copy( final ContainerConfig _value ) {
-        if ( _value instanceof RuleConfig ) {
+    private ContainerConfig copy(final ContainerConfig _value) {
+        if (_value instanceof RuleConfig) {
             final RuleConfig value = (RuleConfig) _value;
-            return new RuleConfig( value.getPollInterval(), value.getScannerStatus() );
-        } else if ( _value instanceof ProcessConfig ) {
+            return new RuleConfig(value.getPollInterval(), value.getScannerStatus());
+        } else if (_value instanceof ProcessConfig) {
             final ProcessConfig value = (ProcessConfig) _value;
-            return new ProcessConfig( value.getRuntimeStrategy(), value.getKBase(), value.getKSession(), value.getMergeMode() );
+            return new ProcessConfig(value.getRuntimeStrategy(), value.getKBase(), value.getKSession(), value.getMergeMode());
         }
         return null;
     }
 
-    private ServerConfig copy( final ServerConfig value ) {
+    private ServerConfig copy(final ServerConfig value) {
         return new ServerConfig();
     }
 
     @Override
-    public void updateContainerConfig( String serverTemplateId,
-                                       String containerSpecId,
-                                       Capability capability,
-                                       ContainerConfig containerConfig ) {
-        ServerTemplate serverTemplate = templateStorage.load( serverTemplateId );
-        if ( serverTemplate == null ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + serverTemplateId );
+    public synchronized void updateContainerConfig(final String serverTemplateId,
+                                                   final String containerSpecId,
+                                                   final Capability capability,
+                                                   final ContainerConfig containerConfig) {
+
+        final ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
+        if (serverTemplate == null) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + serverTemplateId);
         }
 
-        ContainerSpec containerSpec = serverTemplate.getContainerSpec( containerSpecId );
-        if ( containerSpec == null ) {
-            throw new KieServerControllerNotFoundException( "No container spec found for id " + containerSpecId + " within server template with id " + serverTemplateId );
+        final ContainerSpec containerSpec = serverTemplate.getContainerSpec(containerSpecId);
+        if (containerSpec == null) {
+            throw new KieServerControllerNotFoundException("No container spec found for id " + containerSpecId + " within server template with id " + serverTemplateId);
         }
-        List<Container> affectedContainers = null;
-        if ( containerConfig instanceof RuleConfig ) {
-            RuleConfig rc = (RuleConfig)containerConfig;
-            long interval = rc.getPollInterval();
-            KieScannerStatus status = rc.getScannerStatus();
-            if ( status == KieScannerStatus.STARTED ) {
-                affectedContainers = kieServerInstanceManager.startScanner( serverTemplate, containerSpec, interval );
-            } else if ( status == KieScannerStatus.STOPPED ) {
-                affectedContainers = kieServerInstanceManager.stopScanner( serverTemplate, containerSpec );
-            }
+
+        final List<Container> affectedContainers = updateContainerConfig(capability, containerConfig, serverTemplate, containerSpec);
+
+        if (affectedContainers.isEmpty()) {
+            logInfo("Update of container configuration resulted in no changes to containers running on kie-servers");
+        }
+
+        for (Container ac : affectedContainers) {
+            logDebug("Container {} on server {} was affected by a change in the scanner", ac.getContainerSpecId(), ac.getServerInstanceKey());
+        }
+
+        containerSpec.getConfigs().put(capability, containerConfig);
+
+        templateStorage.update(serverTemplate);
+
+        notificationService.notify(new ServerTemplateUpdated(serverTemplate));
+    }
+
+    void logInfo(final String message) {
+        logger.info(message);
+    }
+
+    void logDebug(final String message,
+                  final Object... objects) {
+        logger.debug(message, objects);
+    }
+
+    List<Container> updateContainerConfig(final Capability capability,
+                                          final ContainerConfig containerConfig,
+                                          final ServerTemplate serverTemplate,
+                                          final ContainerSpec containerSpec) {
+
+        if (containerConfig instanceof RuleConfig) {
+
+            final RuleConfig ruleConfig = (RuleConfig) containerConfig;
+
+            return updateContainerRuleConfig(ruleConfig, serverTemplate, containerSpec);
         } else if (containerConfig instanceof ProcessConfig) {
-            ProcessConfig pc = (ProcessConfig)containerConfig;
-            kieServerInstanceManager.stopContainer(serverTemplate, containerSpec);
-            containerSpec.getConfigs().put(capability, pc);
-            affectedContainers = kieServerInstanceManager.startContainer(serverTemplate, containerSpec);
-        }
-        if (affectedContainers == null) {
-            logger.info("Update of container configuration resulted in no changes to containers running on kie-servers");
+
+            final ProcessConfig processConfig = (ProcessConfig) containerConfig;
+
+            return updateContainerProcessConfig(processConfig, capability, serverTemplate, containerSpec);
         } else {
-            for ( Container ac: affectedContainers ) {
-                logger.debug("Container {} on server {} was affected by a change in the scanner"
-                        ,ac.getContainerSpecId()
-                        ,ac.getServerInstanceKey());
-            }
+            return new ArrayList<>();
         }
+    }
 
-        containerSpec.getConfigs().put( capability, containerConfig );
+    List<Container> updateContainerProcessConfig(final ProcessConfig processConfig,
+                                                 final Capability capability,
+                                                 final ServerTemplate serverTemplate,
+                                                 final ContainerSpec containerSpec) {
 
-        templateStorage.update( serverTemplate );
+        containerSpec.getConfigs().put(capability, processConfig);
 
-        notificationService.notify( new ServerTemplateUpdated( serverTemplate ) );
+        return kieServerInstanceManager.upgradeContainer(serverTemplate, containerSpec);
+    }
+
+    List<Container> updateContainerRuleConfig(final RuleConfig ruleConfig,
+                                              final ServerTemplate serverTemplate,
+                                              final ContainerSpec containerSpec) {
+
+        final Long interval = ruleConfig.getPollInterval();
+        final KieScannerStatus status = ruleConfig.getScannerStatus();
+
+        switch (status) {
+            case STARTED:
+                return kieServerInstanceManager.startScanner(serverTemplate, containerSpec, interval);
+            case STOPPED:
+                return kieServerInstanceManager.stopScanner(serverTemplate, containerSpec);
+            default:
+                return new ArrayList<>();
+        }
     }
 
     @Override
-    public void updateServerTemplateConfig( String serverTemplateId,
-                                            Capability capability,
-                                            ServerConfig serverTemplateConfig ) {
-        ServerTemplate serverTemplate = templateStorage.load( serverTemplateId );
-        if ( serverTemplate == null ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + serverTemplateId );
+    public void updateServerTemplateConfig(String serverTemplateId,
+                                           Capability capability,
+                                           ServerConfig serverTemplateConfig) {
+        ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
+        if (serverTemplate == null) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + serverTemplateId);
         }
 
-        serverTemplate.getConfigs().put( capability, serverTemplateConfig );
+        serverTemplate.getConfigs().put(capability, serverTemplateConfig);
 
-        templateStorage.update( serverTemplate );
+        templateStorage.update(serverTemplate);
 
-        notificationService.notify( new ServerTemplateUpdated( serverTemplate ) );
+        notificationService.notify(new ServerTemplateUpdated(serverTemplate));
     }
 
     @Override
-    public void startContainer( ContainerSpecKey containerSpecKey ) {
-        ServerTemplate serverTemplate = templateStorage.load( containerSpecKey.getServerTemplateKey().getId() );
-        if ( serverTemplate == null ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + containerSpecKey.getServerTemplateKey().getId() );
+    public void startContainer(ContainerSpecKey containerSpecKey) {
+        ServerTemplate serverTemplate = templateStorage.load(containerSpecKey.getServerTemplateKey().getId());
+        if (serverTemplate == null) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + containerSpecKey.getServerTemplateKey().getId());
         }
 
-        final ContainerSpec containerSpec = serverTemplate.getContainerSpec( containerSpecKey.getId() );
-        if ( containerSpec == null ) {
-            throw new KieServerControllerNotFoundException( "No container spec found for id " + containerSpecKey.getId()
-                    + " within server template with id " + serverTemplate.getId() );
+        final ContainerSpec containerSpec = serverTemplate.getContainerSpec(containerSpecKey.getId());
+        if (containerSpec == null) {
+            throw new KieServerControllerNotFoundException("No container spec found for id " + containerSpecKey.getId()
+                                                                   + " within server template with id " + serverTemplate.getId());
         }
-        containerSpec.setStatus( KieContainerStatus.STARTED );
+        containerSpec.setStatus(KieContainerStatus.STARTED);
 
-        templateStorage.update( serverTemplate );
+        templateStorage.update(serverTemplate);
 
-        List<Container> containers = kieServerInstanceManager.startContainer( serverTemplate, containerSpec );
+        List<Container> containers = kieServerInstanceManager.startContainer(serverTemplate, containerSpec);
 
-        notificationService.notify( serverTemplate, containerSpec, containers );
+        notificationService.notify(serverTemplate, containerSpec, containers);
     }
 
     @Override
-    public void stopContainer( ContainerSpecKey containerSpecKey ) {
-        ServerTemplate serverTemplate = templateStorage.load( containerSpecKey.getServerTemplateKey().getId() );
-        if ( serverTemplate == null ) {
-            throw new KieServerControllerNotFoundException( "No server template found for id " + containerSpecKey.getServerTemplateKey().getId() );
+    public void stopContainer(ContainerSpecKey containerSpecKey) {
+        ServerTemplate serverTemplate = templateStorage.load(containerSpecKey.getServerTemplateKey().getId());
+        if (serverTemplate == null) {
+            throw new KieServerControllerNotFoundException("No server template found for id " + containerSpecKey.getServerTemplateKey().getId());
         }
 
-        ContainerSpec containerSpec = serverTemplate.getContainerSpec( containerSpecKey.getId() );
-        if ( containerSpec == null ) {
-            throw new KieServerControllerNotFoundException( "No container spec found for id " + containerSpecKey.getId() + " within server template with id " + serverTemplate.getId() );
+        ContainerSpec containerSpec = serverTemplate.getContainerSpec(containerSpecKey.getId());
+        if (containerSpec == null) {
+            throw new KieServerControllerNotFoundException("No container spec found for id " + containerSpecKey.getId() + " within server template with id " + serverTemplate.getId());
         }
-        containerSpec.setStatus( KieContainerStatus.STOPPED );
+        containerSpec.setStatus(KieContainerStatus.STOPPED);
 
-        templateStorage.update( serverTemplate );
+        templateStorage.update(serverTemplate);
 
-        List<Container> containers = kieServerInstanceManager.stopContainer( serverTemplate, containerSpec );
+        List<Container> containers = kieServerInstanceManager.stopContainer(serverTemplate, containerSpec);
 
-        notificationService.notify( serverTemplate, containerSpec, containers );
+        notificationService.notify(serverTemplate, containerSpec, containers);
     }
 
     public KieServerTemplateStorage getTemplateStorage() {
         return templateStorage;
     }
 
-    public void setTemplateStorage( KieServerTemplateStorage templateStorage ) {
+    public void setTemplateStorage(KieServerTemplateStorage templateStorage) {
         this.templateStorage = templateStorage;
     }
 
@@ -321,7 +363,7 @@ public class SpecManagementServiceImpl implements SpecManagementService {
         return notificationService;
     }
 
-    public void setNotificationService( NotificationService notificationService ) {
+    public void setNotificationService(NotificationService notificationService) {
         this.notificationService = notificationService;
     }
 
@@ -329,7 +371,7 @@ public class SpecManagementServiceImpl implements SpecManagementService {
         return kieServerInstanceManager;
     }
 
-    public void setKieServerInstanceManager( KieServerInstanceManager kieServerInstanceManager ) {
+    public void setKieServerInstanceManager(KieServerInstanceManager kieServerInstanceManager) {
         this.kieServerInstanceManager = kieServerInstanceManager;
     }
 }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/KieServerInstanceManagerTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/KieServerInstanceManagerTest.java
@@ -1,0 +1,418 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.controller.impl;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.api.model.KieScannerResource;
+import org.kie.server.api.model.KieScannerStatus;
+import org.kie.server.api.model.KieServerConfigItem;
+import org.kie.server.api.model.Message;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.controller.api.model.runtime.Container;
+import org.kie.server.controller.api.model.spec.Capability;
+import org.kie.server.controller.api.model.spec.ContainerSpec;
+import org.kie.server.controller.api.model.spec.ProcessConfig;
+import org.kie.server.controller.api.model.spec.RuleConfig;
+import org.kie.server.controller.api.model.spec.ServerTemplate;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KieServerInstanceManagerTest {
+
+    @Mock
+    private ServerTemplate serverTemplate;
+
+    @Mock
+    private ContainerSpec containerSpec;
+
+    @Mock
+    private KieServicesClient client;
+
+    @Mock
+    private Container container;
+
+    @Mock
+    private ServiceResponse<?> response;
+
+    @Mock
+    private KieServerInstanceManager.RemoteKieServerOperation operation;
+
+    @Mock
+    private KieContainerResource containerResource;
+
+    private KieServerInstanceManager instanceManager;
+
+    @Before
+    public void setUp() {
+        instanceManager = spy(new KieServerInstanceManager());
+    }
+
+    @Test
+    public void testMakeContainerResourceWhenConfigsIsNull() {
+
+        final String id = "id";
+        final ReleaseId releaseId = mock(ReleaseId.class);
+        final ReleaseId resolvedReleasedId = mock(ReleaseId.class);
+        final KieContainerStatus status = KieContainerStatus.CREATING;
+        final String containerName = "containerName";
+        final Collection<Message> messages = new ArrayList<>();
+
+        doReturn(id).when(containerSpec).getId();
+        doReturn(releaseId).when(containerSpec).getReleasedId();
+        doReturn(resolvedReleasedId).when(container).getResolvedReleasedId();
+        doReturn(status).when(container).getStatus();
+        doReturn(containerName).when(containerSpec).getContainerName();
+        doReturn(messages).when(container).getMessages();
+        doReturn(null).when(containerSpec).getConfigs();
+
+        final KieContainerResource resource = instanceManager.makeContainerResource(container, containerSpec);
+
+        assertEquals(id, resource.getContainerId());
+        assertEquals(releaseId, resource.getReleaseId());
+        assertEquals(resolvedReleasedId, resource.getResolvedReleaseId());
+        assertEquals(status, resource.getStatus());
+        assertEquals(messages, resource.getMessages());
+
+        verify(instanceManager, never()).setRuleConfigAttributes(any(ContainerSpec.class), any(KieContainerResource.class));
+        verify(instanceManager, never()).setProcessConfigAttributes(any(ContainerSpec.class), any(KieContainerResource.class));
+    }
+
+    @Test
+    public void testStartContainer() {
+
+        final List<?> expectedContainers = mock(List.class);
+
+        doReturn(operation).when(instanceManager).makeStartContainerOperation(containerSpec);
+        doReturn(expectedContainers).when(instanceManager).callRemoteKieServerOperation(serverTemplate, containerSpec, operation);
+
+        final List<Container> actualContainers = instanceManager.startContainer(serverTemplate, containerSpec);
+
+        verify(instanceManager).callRemoteKieServerOperation(serverTemplate, containerSpec, operation);
+
+        assertEquals(expectedContainers, actualContainers);
+    }
+
+    @Test
+    public void testMakeStartContainerOperationWhenResponseTypeIsSuccess() {
+
+        final ServiceResponse.ResponseType responseType = ServiceResponse.ResponseType.SUCCESS;
+        final String containerId = "id";
+
+        doReturn(containerId).when(containerSpec).getId();
+        doReturn(containerResource).when(instanceManager).makeContainerResource(container, containerSpec);
+        doReturn(response).when(client).createContainer(containerId, containerResource);
+        doReturn(responseType).when(response).getType();
+        doNothing().when(instanceManager).collectContainerInfo(containerSpec, client, container);
+
+        instanceManager.makeStartContainerOperation(containerSpec).doOperation(client, container);
+
+        verify(client).createContainer(containerId, containerResource);
+        verify(instanceManager).collectContainerInfo(containerSpec, client, container);
+        verify(instanceManager, never()).log(anyString(), anyObject());
+    }
+
+    @Test
+    public void testMakeStartContainerOperationWhenResponseTypeIsNotSuccess() {
+
+        final ServiceResponse.ResponseType responseType = ServiceResponse.ResponseType.FAILURE;
+        final String containerId = "id";
+
+        doReturn(containerId).when(containerSpec).getId();
+        doReturn(containerResource).when(instanceManager).makeContainerResource(container, containerSpec);
+        doReturn(response).when(client).createContainer(containerId, containerResource);
+        doReturn(responseType).when(response).getType();
+        doNothing().when(instanceManager).collectContainerInfo(containerSpec, client, container);
+
+        instanceManager.makeStartContainerOperation(containerSpec).doOperation(client, container);
+
+        verify(client).createContainer(containerId, containerResource);
+        verify(instanceManager).collectContainerInfo(containerSpec, client, container);
+        verify(instanceManager).log("Container {} failed to start on server instance {} due to {}", container, response, containerSpec);
+    }
+
+    @Test
+    public void testMakeUpgradeContainerOperationWhenResponseTypeIsSuccess() {
+
+        final ServiceResponse.ResponseType responseType = ServiceResponse.ResponseType.SUCCESS;
+        final String containerId = "id";
+        final ReleaseId releaseId = mock(ReleaseId.class);
+
+        doReturn(containerId).when(containerSpec).getId();
+        doReturn(releaseId).when(containerSpec).getReleasedId();
+        doReturn(containerResource).when(instanceManager).makeContainerResource(container, containerSpec);
+        doReturn(response).when(client).updateReleaseId(containerId, releaseId);
+        doReturn(responseType).when(response).getType();
+        doNothing().when(instanceManager).collectContainerInfo(containerSpec, client, container);
+
+        instanceManager.makeUpgradeContainerOperation(containerSpec).doOperation(client, container);
+
+        verify(client, never()).createContainer(anyString(), any(KieContainerResource.class));
+        verify(client).updateReleaseId(containerId, releaseId);
+        verify(instanceManager).collectContainerInfo(containerSpec, client, container);
+        verify(instanceManager, never()).log(anyString(), anyObject());
+    }
+
+    @Test
+    public void testMakeUpgradeContainerOperationWhenResponseTypeIsNotSuccess() {
+
+        final ServiceResponse.ResponseType responseType = ServiceResponse.ResponseType.FAILURE;
+        final String containerId = "id";
+        final String url = "url";
+        final String msg = "msg";
+        final ReleaseId releaseId = mock(ReleaseId.class);
+
+        doReturn(containerId).when(containerSpec).getId();
+        doReturn(releaseId).when(containerSpec).getReleasedId();
+        doReturn(containerResource).when(instanceManager).makeContainerResource(container, containerSpec);
+        doReturn(response).when(client).updateReleaseId(containerId, releaseId);
+        doReturn(responseType).when(response).getType();
+        doReturn(msg).when(response).getMsg();
+        doReturn(url).when(container).getUrl();
+        doNothing().when(instanceManager).collectContainerInfo(containerSpec, client, container);
+
+        instanceManager.makeUpgradeContainerOperation(containerSpec).doOperation(client, container);
+
+        verify(client, never()).createContainer(anyString(), any(KieContainerResource.class));
+        verify(client).updateReleaseId(containerId, releaseId);
+        verify(instanceManager).collectContainerInfo(containerSpec, client, container);
+        verify(instanceManager).log("Container {} failed to upgrade on server instance {} due to {}", containerId, url, msg);
+    }
+
+    @Test
+    public void testMakeUpgradeAndStartContainerOperationWhenResponseTypeIsSuccess() {
+
+        final ServiceResponse.ResponseType responseType = ServiceResponse.ResponseType.SUCCESS;
+        final String containerId = "id";
+        final ReleaseId releaseId = mock(ReleaseId.class);
+
+        doReturn(containerId).when(containerSpec).getId();
+        doReturn(releaseId).when(containerSpec).getReleasedId();
+        doReturn(containerResource).when(instanceManager).makeContainerResource(container, containerSpec);
+        doReturn(response).when(client).updateReleaseId(containerId, releaseId);
+        doReturn(responseType).when(response).getType();
+        doNothing().when(instanceManager).collectContainerInfo(containerSpec, client, container);
+
+        instanceManager.makeUpgradeAndStartContainerOperation(containerSpec).doOperation(client, container);
+
+        verify(client).createContainer(containerId, containerResource);
+        verify(client).updateReleaseId(containerId, releaseId);
+        verify(instanceManager).collectContainerInfo(containerSpec, client, container);
+        verify(instanceManager, never()).log(anyString(), anyObject());
+    }
+
+    @Test
+    public void testMakeUpgradeAndStartContainerOperationWhenResponseTypeIsNotSuccess() {
+
+        final ServiceResponse.ResponseType responseType = ServiceResponse.ResponseType.FAILURE;
+        final String containerId = "id";
+        final String url = "url";
+        final String msg = "msg";
+        final ReleaseId releaseId = mock(ReleaseId.class);
+
+        doReturn(containerId).when(containerSpec).getId();
+        doReturn(releaseId).when(containerSpec).getReleasedId();
+        doReturn(containerResource).when(instanceManager).makeContainerResource(container, containerSpec);
+        doReturn(response).when(client).updateReleaseId(containerId, releaseId);
+        doReturn(responseType).when(response).getType();
+        doReturn(msg).when(response).getMsg();
+        doReturn(url).when(container).getUrl();
+        doNothing().when(instanceManager).collectContainerInfo(containerSpec, client, container);
+
+        instanceManager.makeUpgradeAndStartContainerOperation(containerSpec).doOperation(client, container);
+
+        verify(client).createContainer(containerId, containerResource);
+        verify(client).updateReleaseId(containerId, releaseId);
+        verify(instanceManager).collectContainerInfo(containerSpec, client, container);
+        verify(instanceManager).log("Container {} failed to upgrade on server instance {} due to {}", containerId, url, msg);
+    }
+
+    @Test
+    public void testMakeContainerResourceWhenConfigsIsNotNull() {
+
+        final String id = "id";
+        final ReleaseId releaseId = mock(ReleaseId.class);
+        final ReleaseId resolvedReleasedId = mock(ReleaseId.class);
+        final KieContainerStatus status = KieContainerStatus.CREATING;
+        final String containerName = "containerName";
+        final Collection<Message> messages = new ArrayList<>();
+        final Map<?, ?> configs = mock(Map.class);
+
+        doReturn(id).when(containerSpec).getId();
+        doReturn(releaseId).when(containerSpec).getReleasedId();
+        doReturn(resolvedReleasedId).when(container).getResolvedReleasedId();
+        doReturn(status).when(container).getStatus();
+        doReturn(containerName).when(containerSpec).getContainerName();
+        doReturn(messages).when(container).getMessages();
+        doReturn(configs).when(containerSpec).getConfigs();
+
+        final KieContainerResource resource = instanceManager.makeContainerResource(container, containerSpec);
+
+        assertEquals(id, resource.getContainerId());
+        assertEquals(releaseId, resource.getReleaseId());
+        assertEquals(resolvedReleasedId, resource.getResolvedReleaseId());
+        assertEquals(status, resource.getStatus());
+        assertEquals(messages, resource.getMessages());
+
+        verify(instanceManager).setRuleConfigAttributes(containerSpec, resource);
+        verify(instanceManager).setProcessConfigAttributes(containerSpec, resource);
+    }
+
+    @Test
+    public void testMakeKieServerConfigItem() {
+
+        final String type = "type";
+        final String name = "name";
+        final String value = "value";
+
+        final KieServerConfigItem configItem = instanceManager.makeKieServerConfigItem(type, name, value);
+
+        assertEquals(type, configItem.getType());
+        assertEquals(name, configItem.getName());
+        assertEquals(value, configItem.getValue());
+    }
+
+    @Test
+    public void testSetRuleConfigAttributesWhenRuleConfigIsNotNull() {
+
+        final Map<?, ?> configs = mock(Map.class);
+        final RuleConfig containerConfig = mock(RuleConfig.class);
+        final ArgumentCaptor<KieScannerResource> scannerResourceCaptor = ArgumentCaptor.forClass(KieScannerResource.class);
+        final Long pollInterval = 1L;
+        final KieScannerStatus scannerStatus = KieScannerStatus.CREATED;
+
+        doReturn(pollInterval).when(containerConfig).getPollInterval();
+        doReturn(scannerStatus).when(containerConfig).getScannerStatus();
+        doReturn(containerConfig).when(configs).get(Capability.RULE);
+        doReturn(configs).when(containerSpec).getConfigs();
+
+        instanceManager.setRuleConfigAttributes(containerSpec, containerResource);
+
+        verify(containerResource).setScanner(scannerResourceCaptor.capture());
+
+        final KieScannerResource scannerResource = scannerResourceCaptor.getValue();
+
+        assertEquals(pollInterval, scannerResource.getPollInterval());
+        assertEquals(scannerStatus, scannerResource.getStatus());
+    }
+
+    @Test
+    public void testSetRuleConfigAttributesWhenRuleConfigIsNull() {
+
+        final Map<?, ?> configs = mock(Map.class);
+
+        doReturn(null).when(configs).get(Capability.RULE);
+        doReturn(configs).when(containerSpec).getConfigs();
+
+        instanceManager.setRuleConfigAttributes(containerSpec, containerResource);
+
+        verify(containerResource, never()).setScanner(any(KieScannerResource.class));
+    }
+
+    @Test
+    public void testSetProcessConfigAttributesWhenProcessConfigIsNotNull() {
+
+        final Map<?, ?> configs = mock(Map.class);
+        final ProcessConfig processConfig = new ProcessConfig("runtimeStrategy", "kBase", "kSession", "mergeMode");
+        final KieContainerResource containerResource = spy(new KieContainerResource());
+        final List<KieServerConfigItem> actualConfigItems = containerResource.getConfigItems();
+        final KieServerConfigItem expectedConfigItem0 = configItem(KieServerConstants.CAPABILITY_BPM,
+                                                                   "KBase",
+                                                                   processConfig.getKBase());
+        final KieServerConfigItem expectedConfigItem1 = configItem(KieServerConstants.CAPABILITY_BPM,
+                                                                   "KSession",
+                                                                   processConfig.getKSession());
+        final KieServerConfigItem expectedConfigItem2 = configItem(KieServerConstants.CAPABILITY_BPM,
+                                                                   "MergeMode",
+                                                                   processConfig.getMergeMode());
+        final KieServerConfigItem expectedConfigItem3 = configItem(KieServerConstants.CAPABILITY_BPM,
+                                                                   "RuntimeStrategy",
+                                                                   processConfig.getRuntimeStrategy());
+
+        doReturn(processConfig).when(configs).get(Capability.PROCESS);
+        doReturn(configs).when(containerSpec).getConfigs();
+
+        instanceManager.setProcessConfigAttributes(containerSpec, containerResource);
+
+        assertEquals(expectedConfigItem0, actualConfigItems.get(0));
+        assertEquals(expectedConfigItem1, actualConfigItems.get(1));
+        assertEquals(expectedConfigItem2, actualConfigItems.get(2));
+        assertEquals(expectedConfigItem3, actualConfigItems.get(3));
+        assertEquals(4, actualConfigItems.size());
+    }
+
+    @Test
+    public void testSetProcessConfigAttributesWhenProcessConfigIsNull() {
+
+        final Map<?, ?> configs = mock(Map.class);
+        final KieContainerResource containerResource = spy(new KieContainerResource());
+        final List<KieServerConfigItem> actualConfigItems = containerResource.getConfigItems();
+
+        doReturn(null).when(configs).get(Capability.PROCESS);
+        doReturn(configs).when(containerSpec).getConfigs();
+
+        instanceManager.setProcessConfigAttributes(containerSpec, containerResource);
+
+        assertEquals(0, actualConfigItems.size());
+    }
+
+    @Test
+    public void testUpgradeContainer() {
+
+        doReturn(operation).when(instanceManager).makeUpgradeContainerOperation(containerSpec);
+
+        instanceManager.upgradeContainer(serverTemplate, containerSpec);
+
+        verify(instanceManager).callRemoteKieServerOperation(serverTemplate, containerSpec, operation);
+    }
+
+    @Test
+    public void testUpgradeAndStartContainer() {
+
+        doReturn(operation).when(instanceManager).makeUpgradeAndStartContainerOperation(containerSpec);
+
+        instanceManager.upgradeAndStartContainer(serverTemplate, containerSpec);
+
+        verify(instanceManager).callRemoteKieServerOperation(serverTemplate, containerSpec, operation);
+    }
+
+    private KieServerConfigItem configItem(final String capabilityBpm,
+                                           final String pcfgKieBase,
+                                           final String kBase) {
+
+        return instanceManager.makeKieServerConfigItem(capabilityBpm,
+                                                       pcfgKieBase,
+                                                       kBase);
+    }
+}

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/SpecManagementServiceImplTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/SpecManagementServiceImplTest.java
@@ -24,11 +24,17 @@ import java.util.UUID;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.KieScannerStatus;
 import org.kie.server.api.model.ReleaseId;
+import org.kie.server.controller.api.KieServerControllerNotFoundException;
+import org.kie.server.controller.api.model.events.ServerTemplateUpdated;
 import org.kie.server.controller.api.model.runtime.Container;
+import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
 import org.kie.server.controller.api.model.spec.Capability;
 import org.kie.server.controller.api.model.spec.ContainerConfig;
 import org.kie.server.controller.api.model.spec.ContainerSpec;
@@ -36,26 +42,42 @@ import org.kie.server.controller.api.model.spec.ProcessConfig;
 import org.kie.server.controller.api.model.spec.RuleConfig;
 import org.kie.server.controller.api.model.spec.ServerTemplate;
 import org.kie.server.controller.api.model.spec.ServerTemplateKey;
+import org.kie.server.controller.api.service.NotificationService;
+import org.kie.server.controller.api.storage.KieServerTemplateStorage;
 import org.kie.server.controller.impl.KieServerInstanceManager;
 import org.kie.server.controller.impl.storage.InMemoryKieServerTemplateStorage;
-import org.mockito.Mockito;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
+@RunWith(MockitoJUnitRunner.class)
 public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Mock
+    private KieServerTemplateStorage templateStorage;
+
+    @Mock
+    private KieServerInstanceManager kieServerInstanceManager;
+
+    @Mock
+    private NotificationService notificationService;
 
     @Before
     public void setup() {
         specManagementService = new SpecManagementServiceImpl();
-        kieServerInstanceManager = Mockito.mock(KieServerInstanceManager.class);
 
-        ((SpecManagementServiceImpl)specManagementService).setKieServerInstanceManager(kieServerInstanceManager);
+        final SpecManagementServiceImpl specManagementService = (SpecManagementServiceImpl) this.specManagementService;
 
+        specManagementService.setKieServerInstanceManager(kieServerInstanceManager);
     }
-
 
     @After
     public void cleanup() {
@@ -136,7 +158,6 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
         assertNotNull(container.getConfigs());
         assertEquals(containerSpec.getConfigs().size(), container.getConfigs().size());
 
-
         Collection<org.kie.server.controller.api.model.spec.ContainerSpec> specs = specManagementService.listContainerSpec(serverTemplate.getId());
         assertNotNull(specs);
         assertEquals(1, specs.size());
@@ -172,7 +193,6 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
         Collection<org.kie.server.controller.api.model.spec.ServerTemplate> allTemplates = specManagementService.listServerTemplates();
         assertNotNull(allTemplates);
         assertEquals(limit, allTemplates.size());
-
     }
 
     @Test
@@ -243,14 +263,13 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
         assertNotNull(createdServerTemplate.getContainersSpec());
         assertEquals(limit, createdServerTemplate.getContainersSpec().size());
 
-
         // remove first container with suffix 0
         specManagementService.deleteContainerSpec(serverTemplate.getId(), "test container " + 0);
 
         createdServerTemplate = specManagementService.getServerTemplate(serverTemplate.getId());
         assertNotNull(createdServerTemplate);
         assertNotNull(createdServerTemplate.getContainersSpec());
-        assertEquals(limit-1, createdServerTemplate.getContainersSpec().size());
+        assertEquals(limit - 1, createdServerTemplate.getContainersSpec().size());
     }
 
     @Test
@@ -389,8 +408,8 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
         ContainerConfig ruleConfigCurrent = containerSpec.getConfigs().get(Capability.RULE);
         assertNotNull(ruleConfigCurrent);
         assertTrue(ruleConfigCurrent instanceof org.kie.server.controller.api.model.spec.RuleConfig);
-        assertEquals(ruleConfig.getPollInterval(), ((org.kie.server.controller.api.model.spec.RuleConfig)ruleConfigCurrent).getPollInterval());
-        assertEquals(ruleConfig.getScannerStatus(), ((org.kie.server.controller.api.model.spec.RuleConfig)ruleConfigCurrent).getScannerStatus());
+        assertEquals(ruleConfig.getPollInterval(), ((org.kie.server.controller.api.model.spec.RuleConfig) ruleConfigCurrent).getPollInterval());
+        assertEquals(ruleConfig.getScannerStatus(), ((org.kie.server.controller.api.model.spec.RuleConfig) ruleConfigCurrent).getScannerStatus());
 
         ContainerConfig containerConfig = new RuleConfig();
         ((RuleConfig) containerConfig).setScannerStatus(KieScannerStatus.SCANNING);
@@ -416,9 +435,8 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
         ContainerConfig ruleConfigCurrent2 = containerSpec.getConfigs().get(Capability.RULE);
         assertNotNull(ruleConfigCurrent2);
         assertTrue(ruleConfigCurrent2 instanceof org.kie.server.controller.api.model.spec.RuleConfig);
-        assertEquals(((org.kie.server.controller.api.model.spec.RuleConfig)containerConfig).getPollInterval(), ((org.kie.server.controller.api.model.spec.RuleConfig)ruleConfigCurrent2).getPollInterval());
-        assertEquals(((org.kie.server.controller.api.model.spec.RuleConfig)containerConfig).getScannerStatus(), ((org.kie.server.controller.api.model.spec.RuleConfig)ruleConfigCurrent2).getScannerStatus());
-
+        assertEquals(((org.kie.server.controller.api.model.spec.RuleConfig) containerConfig).getPollInterval(), ((org.kie.server.controller.api.model.spec.RuleConfig) ruleConfigCurrent2).getPollInterval());
+        assertEquals(((org.kie.server.controller.api.model.spec.RuleConfig) containerConfig).getScannerStatus(), ((org.kie.server.controller.api.model.spec.RuleConfig) ruleConfigCurrent2).getScannerStatus());
     }
 
     @Test
@@ -459,6 +477,264 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
         assertNotNull(updatedContainer);
 
         assertEquals(KieContainerStatus.STOPPED, updatedContainer.getStatus());
+    }
+
+    @Test
+    public void testUpdateContainerConfigWhenContainerConfigIsARuleConfig() {
+
+        final SpecManagementServiceImpl specManagementService = spy((SpecManagementServiceImpl) this.specManagementService);
+        final Capability capability = Capability.RULE;
+        final RuleConfig ruleConfig = mock(RuleConfig.class);
+        final ServerTemplate serverTemplate = mock(ServerTemplate.class);
+        final ContainerSpec containerSpec = mock(ContainerSpec.class);
+
+        final List<?> expectedContainers = mock(List.class);
+
+        doReturn(expectedContainers).when(specManagementService).updateContainerRuleConfig(ruleConfig,
+                                                                                           serverTemplate,
+                                                                                           containerSpec);
+
+        final List<Container> actualContainers = specManagementService.updateContainerConfig(capability,
+                                                                                             ruleConfig,
+                                                                                             serverTemplate,
+                                                                                             containerSpec);
+        assertEquals(expectedContainers, actualContainers);
+    }
+
+    @Test
+    public void testUpdateContainerConfigWhenContainerConfigIsAProcessConfig() {
+
+        final SpecManagementServiceImpl specManagementService = spy((SpecManagementServiceImpl) this.specManagementService);
+        final Capability capability = Capability.PROCESS;
+        final ProcessConfig processConfig = mock(ProcessConfig.class);
+        final ServerTemplate serverTemplate = mock(ServerTemplate.class);
+        final ContainerSpec containerSpec = mock(ContainerSpec.class);
+
+        final List<?> expectedContainers = mock(List.class);
+
+        doReturn(expectedContainers).when(specManagementService).updateContainerProcessConfig(processConfig,
+                                                                                              capability,
+                                                                                              serverTemplate,
+                                                                                              containerSpec);
+
+        final List<Container> actualContainers = specManagementService.updateContainerConfig(capability,
+                                                                                             processConfig,
+                                                                                             serverTemplate,
+                                                                                             containerSpec);
+        assertEquals(expectedContainers, actualContainers);
+    }
+
+    @Test
+    public void testUpdateContainerConfigWhenServerTemplateIsNull() {
+
+        final SpecManagementServiceImpl specManagementService = (SpecManagementServiceImpl) this.specManagementService;
+        final String serverTemplateId = "serverTemplateId";
+        final String containerSpecId = "containerSpecId";
+        final Capability capability = Capability.PROCESS;
+        final ContainerConfig containerConfig = mock(ContainerConfig.class);
+
+        specManagementService.setTemplateStorage(templateStorage);
+
+        doReturn(null).when(templateStorage).load(serverTemplateId);
+
+        expectedException.expect(KieServerControllerNotFoundException.class);
+        expectedException.expectMessage("No server template found for id serverTemplateId");
+
+        specManagementService.updateContainerConfig(serverTemplateId, containerSpecId, capability, containerConfig);
+    }
+
+    @Test
+    public void testUpdateContainerConfigWhenContainerSpecIsNull() {
+
+        final SpecManagementServiceImpl specManagementService = (SpecManagementServiceImpl) this.specManagementService;
+        final String serverTemplateId = "serverTemplateId";
+        final String containerSpecId = "containerSpecId";
+        final Capability capability = Capability.PROCESS;
+        final ContainerConfig containerConfig = mock(ContainerConfig.class);
+        final ServerTemplate serverTemplate = mock(ServerTemplate.class);
+
+        specManagementService.setTemplateStorage(templateStorage);
+
+        doReturn(serverTemplate).when(templateStorage).load(serverTemplateId);
+        doReturn(null).when(serverTemplate).getContainersSpec();
+
+        expectedException.expect(KieServerControllerNotFoundException.class);
+        expectedException.expectMessage("No container spec found for id containerSpecId within server template with id serverTemplateId");
+
+        specManagementService.updateContainerConfig(serverTemplateId, containerSpecId, capability, containerConfig);
+    }
+
+    @Test
+    public void testUpdateContainerConfigWhenAffectedContainersIsEmpty() {
+
+        final SpecManagementServiceImpl specManagementService = spy((SpecManagementServiceImpl) this.specManagementService);
+        final String serverTemplateId = "serverTemplateId";
+        final String containerSpecId = "containerSpecId";
+        final Capability capability = Capability.PROCESS;
+        final ContainerConfig containerConfig = mock(ContainerConfig.class);
+        final ServerTemplate serverTemplate = mock(ServerTemplate.class);
+        final ContainerSpec containerSpec = mock(ContainerSpec.class);
+        final Map<Capability, ContainerConfig> configs = spy(new HashMap<Capability, ContainerConfig>());
+        final List<?> expectedContainers = new ArrayList<>();
+
+        specManagementService.setTemplateStorage(templateStorage);
+        specManagementService.setNotificationService(notificationService);
+
+        doReturn(serverTemplate).when(templateStorage).load(serverTemplateId);
+        doReturn(containerSpec).when(serverTemplate).getContainerSpec(containerSpecId);
+        doReturn(expectedContainers).when(specManagementService).updateContainerConfig(capability, containerConfig, serverTemplate, containerSpec);
+        doReturn(configs).when(containerSpec).getConfigs();
+
+        specManagementService.updateContainerConfig(serverTemplateId, containerSpecId, capability, containerConfig);
+
+        verify(specManagementService).logInfo("Update of container configuration resulted in no changes to containers running on kie-servers");
+        verify(specManagementService, never()).logDebug(anyString(), anyObject());
+        verify(configs).put(capability, containerConfig);
+        verify(templateStorage).update(serverTemplate);
+        verify(notificationService).notify(any(ServerTemplateUpdated.class));
+    }
+
+    @Test
+    public void testUpdateContainerConfigWhenAffectedContainersIsNotEmpty() {
+
+        final SpecManagementServiceImpl specManagementService = spy((SpecManagementServiceImpl) this.specManagementService);
+        final String serverTemplateId = "serverTemplateId";
+        final String containerSpecId = "containerSpecId";
+        final Capability capability = Capability.PROCESS;
+        final ContainerConfig containerConfig = mock(ContainerConfig.class);
+        final ServerTemplate serverTemplate = mock(ServerTemplate.class);
+        final ContainerSpec containerSpec = mock(ContainerSpec.class);
+        final Map<Capability, ContainerConfig> configs = spy(new HashMap<Capability, ContainerConfig>());
+        final Container container1 = makeContainer("1");
+        final Container container2 = makeContainer("2");
+        final List<Container> expectedContainers = new ArrayList<Container>() {{
+            add(container1);
+            add(container2);
+        }};
+
+        specManagementService.setTemplateStorage(templateStorage);
+        specManagementService.setNotificationService(notificationService);
+
+        doReturn(serverTemplate).when(templateStorage).load(serverTemplateId);
+        doReturn(containerSpec).when(serverTemplate).getContainerSpec(containerSpecId);
+        doReturn(expectedContainers).when(specManagementService).updateContainerConfig(capability, containerConfig, serverTemplate, containerSpec);
+        doReturn(configs).when(containerSpec).getConfigs();
+
+        specManagementService.updateContainerConfig(serverTemplateId, containerSpecId, capability, containerConfig);
+
+        verify(specManagementService).logDebug("Container {} on server {} was affected by a change in the scanner",
+                                               container1.getContainerSpecId(),
+                                               container1.getServerInstanceKey());
+        verify(specManagementService).logDebug("Container {} on server {} was affected by a change in the scanner",
+                                               container2.getContainerSpecId(),
+                                               container2.getServerInstanceKey());
+        verify(specManagementService, never()).logInfo(anyString());
+        verify(configs).put(capability, containerConfig);
+        verify(templateStorage).update(serverTemplate);
+        verify(notificationService).notify(any(ServerTemplateUpdated.class));
+    }
+
+    private Container makeContainer(final String seed) {
+
+        final Container container = mock(Container.class);
+
+        doReturn(seed).when(container).getContainerSpecId();
+        doReturn(mock(ServerInstanceKey.class)).when(container).getServerInstanceKey();
+
+        return container;
+    }
+
+    @Test
+    public void testUpdateContainerConfigWhenContainerConfigIsNotAProcessConfigNeitherARuleConfig() {
+
+        final SpecManagementServiceImpl specManagementService = spy((SpecManagementServiceImpl) this.specManagementService);
+        final Capability capability = Capability.PROCESS;
+        final ContainerConfig containerConfig = mock(ContainerConfig.class);
+        final ServerTemplate serverTemplate = mock(ServerTemplate.class);
+        final ContainerSpec containerSpec = mock(ContainerSpec.class);
+        final List<?> expectedContainers = new ArrayList<>();
+
+        final List<Container> actualContainers = specManagementService.updateContainerConfig(capability,
+                                                                                             containerConfig,
+                                                                                             serverTemplate,
+                                                                                             containerSpec);
+        assertEquals(expectedContainers, actualContainers);
+    }
+
+    @Test
+    public void testUpdateContainerProcessConfig() {
+
+        final SpecManagementServiceImpl specManagementService = (SpecManagementServiceImpl) this.specManagementService;
+        final ProcessConfig processConfig = mock(ProcessConfig.class);
+        final Capability capability = Capability.PROCESS;
+        final ServerTemplate serverTemplate = mock(ServerTemplate.class);
+        final ContainerSpec containerSpec = mock(ContainerSpec.class);
+        final Map<Capability, ProcessConfig> configs = spy(new HashMap<Capability, ProcessConfig>());
+        final List<?> expectedContainers = mock(List.class);
+
+        doReturn(configs).when(containerSpec).getConfigs();
+        doReturn(expectedContainers).when(kieServerInstanceManager).upgradeContainer(serverTemplate, containerSpec);
+
+        final List<Container> actualContainers = specManagementService.updateContainerProcessConfig(processConfig,
+                                                                                                    capability,
+                                                                                                    serverTemplate,
+                                                                                                    containerSpec);
+
+        assertEquals(expectedContainers, actualContainers);
+    }
+
+    @Test
+    public void testUpdateContainerRuleConfigWhenKieScannerStatusIsStarted() {
+
+        final SpecManagementServiceImpl specManagementService = (SpecManagementServiceImpl) this.specManagementService;
+        final RuleConfig ruleConfig = mock(RuleConfig.class);
+        final ServerTemplate serverTemplate = mock(ServerTemplate.class);
+        final ContainerSpec containerSpec = mock(ContainerSpec.class);
+        final Long interval = 1L;
+        final List<?> expectedContainers = mock(List.class);
+
+        doReturn(interval).when(ruleConfig).getPollInterval();
+        doReturn(KieScannerStatus.STARTED).when(ruleConfig).getScannerStatus();
+        doReturn(expectedContainers).when(kieServerInstanceManager).startScanner(serverTemplate, containerSpec, interval);
+
+        final List<Container> actualContainers = specManagementService.updateContainerRuleConfig(ruleConfig,
+                                                                                                 serverTemplate,
+                                                                                                 containerSpec);
+
+        assertEquals(expectedContainers, actualContainers);
+    }
+
+    @Test
+    public void testUpdateContainerRuleConfigWhenKieScannerStatusIsStopped() {
+
+        final SpecManagementServiceImpl specManagementService = (SpecManagementServiceImpl) this.specManagementService;
+        final RuleConfig ruleConfig = mock(RuleConfig.class);
+        final ServerTemplate serverTemplate = mock(ServerTemplate.class);
+        final ContainerSpec containerSpec = mock(ContainerSpec.class);
+        final List<?> expectedContainers = mock(List.class);
+
+        doReturn(KieScannerStatus.STOPPED).when(ruleConfig).getScannerStatus();
+        doReturn(expectedContainers).when(kieServerInstanceManager).stopScanner(serverTemplate, containerSpec);
+
+        final List<Container> actualContainers = specManagementService.updateContainerRuleConfig(ruleConfig, serverTemplate, containerSpec);
+
+        assertEquals(expectedContainers, actualContainers);
+    }
+
+    @Test
+    public void testUpdateContainerRuleConfigWhenKieScannerStatusIsNotStartedNeitherStopped() {
+
+        final SpecManagementServiceImpl specManagementService = (SpecManagementServiceImpl) this.specManagementService;
+        final RuleConfig ruleConfig = mock(RuleConfig.class);
+        final ServerTemplate serverTemplate = mock(ServerTemplate.class);
+        final ContainerSpec containerSpec = mock(ContainerSpec.class);
+        final List<?> expectedContainers = new ArrayList<>();
+
+        doReturn(KieScannerStatus.UNKNOWN).when(ruleConfig).getScannerStatus();
+
+        final List<Container> actualContainers = specManagementService.updateContainerRuleConfig(ruleConfig, serverTemplate, containerSpec);
+
+        assertEquals(expectedContainers, actualContainers);
     }
 
     protected int getRandomInt(int min, int max) {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerContainerCRUDIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerContainerCRUDIntegrationTest.java
@@ -15,6 +15,10 @@
 
 package org.kie.server.integrationtests.common;
 
+import java.util.List;
+import java.util.Set;
+
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -30,9 +34,6 @@ import org.kie.server.integrationtests.category.Smoke;
 import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.basetests.RestJmsSharedBaseIntegrationTest;
-
-import java.util.List;
-import java.util.Set;
 
 public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseIntegrationTest {
 
@@ -67,7 +68,6 @@ public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseInte
                                                                                                               "bar",
                                                                                                               "0.0.0")));
         KieServerAssert.assertFailure(reply);
-
     }
 
     @Test
@@ -148,18 +148,12 @@ public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseInte
 
     @Test
     public void testUpdateReleaseIdForNotExistingContainer() throws Exception {
-        ServiceResponse<ReleaseId> reply = client.updateReleaseId("update-releaseId", releaseId2);
-        KieServerAssert.assertSuccess(reply);
-        Assert.assertEquals(releaseId2, reply.getResult());
 
-        ServiceResponse<KieContainerResourceList> replyList = client.listContainers();
-        KieServerAssert.assertSuccess(replyList);
-        List<KieContainerResource> containers = replyList.getResult().getContainers();
-        Assert.assertEquals("Number of listed containers!", 1, containers.size());
-        assertContainsContainer(containers, "update-releaseId");
+        final String updateErrorMessage = "Container update-releaseId is not instantiated.";
+        final ServiceResponse<ReleaseId> reply = client.updateReleaseId("update-releaseId", releaseId2);
 
-        ServiceResponse<Void> disposeReply = client.disposeContainer("update-releaseId");
-        KieServerAssert.assertSuccess(disposeReply);
+        KieServerAssert.assertFailure(reply);
+        Assertions.assertThat(reply.getMsg()).contains(updateErrorMessage);
     }
 
     @Test
@@ -198,5 +192,4 @@ public class KieServerContainerCRUDIntegrationTest extends RestJmsSharedBaseInte
         Assert.fail(
                 "Container list " + containers + " does not contain expected container with id " + expectedContainerId);
     }
-
 }


### PR DESCRIPTION
Cherry-picked from https://github.com/kiegroup/droolsjbpm-integration/pull/1200