### PR TITLE
Revert "PLANNER-865: Workbench: ScoreHolder support in GuidedDecision…

### DIFF
--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -202,29 +202,6 @@
     </dependency>
     <dependency>
       <groupId>org.optaplanner</groupId>
-      <artifactId>optaplanner-wb-guided-rule-editor-api</artifactId>
-      <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.uberfire</groupId>
-          <artifactId>uberfire-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.uberfire</groupId>
-          <artifactId>uberfire-project-datamodel-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jboss.errai</groupId>
-          <artifactId>errai-bus</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.jboss.errai</groupId>
-          <artifactId>errai-common</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.optaplanner</groupId>
       <artifactId>optaplanner-core</artifactId>
       <scope>runtime</scope>
     </dependency>


### PR DESCRIPTION
…Tables causes error in server log (#1193)"

This reverts commit 1c549eba9311500bc9030fb14d6ecfa40f791d23 - since kieAllBuild master fails because of an circular dependency to aptaplanner-wb