### PR TITLE
[8.0.x] JBPM-6456: Unable to open tasks that contain subforms.

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
@@ -137,4 +137,7 @@ public class KieServerConstants {
     public static final String CFG_KIE_SERVER_JMS_SESSION_TX = "org.kie.server.jms.session.tx";
     public static final String CFG_KIE_SERVER_JMS_SESSION_ACK = "org.kie.server.jms.session.ack";
 
+    // System variable to store the enabled packages for the XStreamMarshaller
+    public static final String SYSTEM_XSTREAM_ENABLED_PACKAGES = "org.kie.server.xstream.enabled.packages";
+
 }


### PR DESCRIPTION
Adding package security to XStreamMarshaller to avoid `com.thoughtworks.xstream.security.ForbiddenClassException` when unmarshalling java objects comming from kie-server.

Added ability to configure a list of allowed packages using a comma separated list on the `org.kie.server.xstream.enabled.packages` system property. Like `-Dorg.kie.server.xstream.enabled.packages=packageone.**,packagetwo.**`

@jsoltes  @mswiderski could you please review? (Sorry for all the format changes)