### PR TITLE
Change test artifact id for empty kjar

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/EmptyContainerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/EmptyContainerIntegrationTest.java
@@ -33,10 +33,10 @@ import org.kie.server.integrationtests.shared.KieServerDeployer;
 
 public class EmptyContainerIntegrationTest extends JbpmKieServerBaseIntegrationTest {
 
-    private static final ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "definition-project",
+    private static final ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "empty-container",
             "1.0.0.Final");
 
-    private static final String CONTAINER_ID = "definition-project";
+    private static final String CONTAINER_ID = "empty-container";
 
     @BeforeClass
     public static void buildAndDeployArtifacts() {


### PR DESCRIPTION
KJar deployed to repository using KieServices can interfere with KJars deployed using Maven CLI in case they have same GAV.
Changing artifact id of empty test KJar to prevent this.