### PR TITLE
Skip JMS tests using Maven property

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
@@ -78,6 +78,8 @@ public class TestConfig {
 
     private static final StringTestParameter WEBLOGIC_HOME = new StringTestParameter("weblogic.home");
 
+    private static final StringTestParameter JMS_SKIP = new StringTestParameter("jms.skip");
+
     /**
      * Property holding datasource driver class FQCN to determine which DB the tests are currently run with
      */
@@ -212,6 +214,9 @@ public class TestConfig {
     public static boolean skipJMS() {
         if (TestConfig.class.getResource("/jms.skip") != null) {
             return true;
+        } else if (JMS_SKIP.isParameterConfigured()) {
+            String jmsSkip = JMS_SKIP.getParameterValue();
+            return Boolean.parseBoolean(jmsSkip);
         }
 
         return false;

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -46,6 +46,8 @@
     <failsafe.excluded.groups/>
     <!-- Sybase driver leaks its Timestamp implementation. To correctly handle it we need to add driver as additional test classpath. -->
     <maven.jdbc.driver.jar/>
+    <!-- Set to true if you want to skip JMS tests even for containers with available JMS. -->
+    <jms.skip>false</jms.skip>
 
     <version.tomcat8>8.5.12</version.tomcat8>
     <version.wildfly10>10.1.0.Final</version.wildfly10>
@@ -300,6 +302,7 @@
                 </additionalClasspathElements>
                 <systemPropertyVariables>
                   <kie.server.server.deployment.settings.xml>${kie.server.server.deployment.settings.xml}</kie.server.server.deployment.settings.xml>
+                  <jms.skip>${jms.skip}</jms.skip>
                 </systemPropertyVariables>
               </configuration>
             </execution>


### PR DESCRIPTION
Useful for example for testing WildFly with Keycloak.