### PR TITLE
Initial test support for WildFly11

### DIFF
--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -51,6 +51,7 @@
 
     <version.tomcat8>8.5.12</version.tomcat8>
     <version.wildfly10>10.1.0.Final</version.wildfly10>
+    <version.wildfly11>11.0.0.Final</version.wildfly11>
     <!-- The EAP 7 binary can't be anonymously downloaded because of the license. It can be downloaded manually
          and for free (e.g. from http://jbossas.jboss.org/downloads.html) and the zip location needs to be specified
          here or via system property when running the build (don't forget to use the `file://` prefix when
@@ -638,6 +639,64 @@
           <scope>test</scope>
         </dependency>
       </dependencies>
+    </profile>
+    <profile>
+      <id>wildfly11</id>
+      <properties>
+<!--         <kie.server.remoting.url>http-remoting://${container.hostname}:${container.port}</kie.server.remoting.url> -->
+        <org.kie.server.persistence.ds>java:jboss/datasources/ExampleDS</org.kie.server.persistence.ds>
+        <cargo.container.id>wildfly10x</cargo.container.id>
+        <failsafe.excluded.groups>org.kie.server.integrationtests.category.JMSOnly</failsafe.excluded.groups>
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.cargo</groupId>
+              <artifactId>cargo-maven2-plugin</artifactId>
+              <configuration>
+                <container>
+                  <type>installed</type>
+                  <artifactInstaller>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-dist</artifactId>
+                    <version>${version.wildfly11}</version>
+                  </artifactInstaller>
+                  <systemProperties>
+                    <!-- disable JMS support for executor to use same tests for all containers for jbpm executor -->
+                    <org.kie.executor.jms>false</org.kie.executor.jms>
+                    <org.kie.server.sync.deploy>true</org.kie.server.sync.deploy>
+                    <org.kie.mail.session>java:/mail/Session</org.kie.mail.session>
+                  </systemProperties>
+                </container>
+                <configuration>
+                  <properties>
+                    <cargo.jboss.configuration>standalone-full</cargo.jboss.configuration>
+                    <cargo.jvmargs>-Xmx1024m</cargo.jvmargs>
+                    <cargo.resource.resource.mail>
+                       cargo.resource.name=mail/Session|
+                       cargo.resource.type=javax.mail.Session|
+                       cargo.resource.id=mail|
+                       cargo.resource.parameters=mail.smtp.host=localhost;mail.smtp.port=2525;mail.smtp.from=kie-server-test@domain.com
+                    </cargo.resource.resource.mail>
+                  </properties>
+                </configuration>
+              </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-failsafe-plugin</artifactId>
+              <configuration>
+                <systemPropertyVariables>
+                  <!-- Reuse yoda user for deploying and undeploying Kie server from within the test -->
+                  <cargo.remote.username>yoda</cargo.remote.username>
+                  <cargo.remote.password>usetheforce123@</cargo.remote.password>
+                </systemPropertyVariables>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
     </profile>
     <profile>
       <id>eap7</id>


### PR DESCRIPTION
JMS tests are currently disabled as they require alignment of test artifacts to WildFly11.