### PR TITLE
Remove duplicated dependencies

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
@@ -62,10 +62,6 @@
       <artifactId>kie-ci</artifactId>
       <!--<scope>runtime</scope>-->
     </dependency>
-    <dependency>
-      <groupId>org.kie.server</groupId>
-      <artifactId>kie-server-common</artifactId>
-    </dependency>
     <!-- needed for ruleflow processes -->
     <dependency>
       <groupId>org.jbpm</groupId>

--- a/kie-spring/pom.xml
+++ b/kie-spring/pom.xml
@@ -282,11 +282,6 @@
 
     <dependency>
       <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
       <artifactId>jaxb-core</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Fixing the following warnings

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.kie:kie-spring:bundle:7.5.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: com.sun.xml.bind:jaxb-impl:jar -> duplicate declaration of version (?) @ org.kie:kie-spring:[unknown-version], /home/hrk/Devel/github.com/jhrcek/droolsjbpm-integration/kie-spring/pom.xml, line 283, column 17
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.kie.server:kie-server-services-common:jar:7.5.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.kie.server:kie-server-common:jar -> duplicate declaration of version (?) @ org.kie.server:kie-server-services-common:[unknown-version], /home/hrk/Devel/github.com/jhrcek/droolsjbpm-integration/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml, line 65, column 17
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```

The `jaxb-impl` is already declared as `<scope>provided</scope>, which according to maven documentation is "is only available on the compilation and test classpath, and is not transitive." -> the test extra test-scoped dependency declaration is not needed.