### PR TITLE
JBPM-6243 - Use model classes for serializing collections

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/build/revapi-config.json
@@ -14,7 +14,6 @@
       }
     }
   },
-
   "ignores": {
     "revapi": {
       "_comment": "Changes between 7.0.0.Final and the current branch. These changes are desired and thus ignored.",
@@ -36,6 +35,78 @@
           "methodName": "getContainerInfo",
           "elementKind": "method",
           "justification": "Allow to get container specification"
+        },
+        {
+          "code": "java.method.parameterTypeChanged",
+          "old": "parameter void org.kie.server.controller.api.service.RuleCapabilitiesService::startScanner(org.kie.server.controller.api.model.spec.ContainerSpecKey, ===long===)",
+          "new": "parameter void org.kie.server.controller.api.service.RuleCapabilitiesService::startScanner(org.kie.server.controller.api.model.spec.ContainerSpecKey, ===java.lang.Long===)",
+          "oldType": "long",
+          "newType": "java.lang.Long",
+          "package": "org.kie.server.controller.api.service",
+          "classSimpleName": "RuleCapabilitiesService",
+          "methodName": "startScanner",
+          "elementKind": "parameter",
+          "justification": "Use object type for serialization"
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method java.util.Collection<org.kie.server.controller.api.model.runtime.Container> org.kie.server.controller.api.service.RuntimeManagementService::getContainers(org.kie.server.controller.api.model.runtime.ServerInstanceKey)",
+          "new": "method org.kie.server.controller.api.model.runtime.ContainerList org.kie.server.controller.api.service.RuntimeManagementService::getContainers(org.kie.server.controller.api.model.runtime.ServerInstanceKey)",
+          "oldType": "java.util.Collection<org.kie.server.controller.api.model.runtime.Container>",
+          "newType": "org.kie.server.controller.api.model.runtime.ContainerList",
+          "package": "org.kie.server.controller.api.service",
+          "classSimpleName": "RuntimeManagementService",
+          "methodName": "getContainers",
+          "elementKind": "method",
+          "justification": "Use list object type for serialization"
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method java.util.Collection<org.kie.server.controller.api.model.runtime.ServerInstanceKey> org.kie.server.controller.api.service.RuntimeManagementService::getServerInstances(java.lang.String)",
+          "new": "method org.kie.server.controller.api.model.runtime.ServerInstanceKeyList org.kie.server.controller.api.service.RuntimeManagementService::getServerInstances(java.lang.String)",
+          "oldType": "java.util.Collection<org.kie.server.controller.api.model.runtime.ServerInstanceKey>",
+          "newType": "org.kie.server.controller.api.model.runtime.ServerInstanceKeyList",
+          "package": "org.kie.server.controller.api.service",
+          "classSimpleName": "RuntimeManagementService",
+          "methodName": "getServerInstances",
+          "elementKind": "method",
+          "justification": "Use list object type for serialization"
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method java.util.Collection<org.kie.server.controller.api.model.spec.ContainerSpec> org.kie.server.controller.api.service.SpecManagementService::listContainerSpec(java.lang.String)",
+          "new": "method org.kie.server.controller.api.model.spec.ContainerSpecList org.kie.server.controller.api.service.SpecManagementService::listContainerSpec(java.lang.String)",
+          "oldType": "java.util.Collection<org.kie.server.controller.api.model.spec.ContainerSpec>",
+          "newType": "org.kie.server.controller.api.model.spec.ContainerSpecList",
+          "package": "org.kie.server.controller.api.service",
+          "classSimpleName": "SpecManagementService",
+          "methodName": "listContainerSpec",
+          "elementKind": "method",
+          "justification": "Use list object type for serialization"
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method java.util.Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey> org.kie.server.controller.api.service.SpecManagementService::listServerTemplateKeys()",
+          "new": "method org.kie.server.controller.api.model.spec.ServerTemplateKeyList org.kie.server.controller.api.service.SpecManagementService::listServerTemplateKeys()",
+          "oldType": "java.util.Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey>",
+          "newType": "org.kie.server.controller.api.model.spec.ServerTemplateKeyList",
+          "package": "org.kie.server.controller.api.service",
+          "classSimpleName": "SpecManagementService",
+          "methodName": "listServerTemplateKeys",
+          "elementKind": "method",
+          "justification": "Use list object type for serialization"
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method java.util.Collection<org.kie.server.controller.api.model.spec.ServerTemplate> org.kie.server.controller.api.service.SpecManagementService::listServerTemplates()",
+          "new": "method org.kie.server.controller.api.model.spec.ServerTemplateList org.kie.server.controller.api.service.SpecManagementService::listServerTemplates()",
+          "oldType": "java.util.Collection<org.kie.server.controller.api.model.spec.ServerTemplate>",
+          "newType": "org.kie.server.controller.api.model.spec.ServerTemplateList",
+          "package": "org.kie.server.controller.api.service",
+          "classSimpleName": "SpecManagementService",
+          "methodName": "listServerTemplates",
+          "elementKind": "method",
+          "justification": "Use list object type for serialization"
         }
       ]
     }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/runtime/ContainerList.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/runtime/ContainerList.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.controller.api.model.runtime;
+
+import java.util.Collection;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name = "container-details-list")
+public class ContainerList {
+
+    @XmlElement(name = "container-details")
+    private Container[] containers;
+
+    public ContainerList() {
+    }
+
+    public ContainerList(Container[] containers) {
+        this.containers = containers;
+    }
+
+    public ContainerList(Collection<Container> containers) {
+        this.containers = containers.toArray(new Container[containers.size()]);
+    }
+
+    public Container[] getContainers() {
+        return containers;
+    }
+
+    public void setContainers(Container[] containers) {
+        this.containers = containers;
+    }
+}

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/runtime/ServerInstanceKeyList.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/runtime/ServerInstanceKeyList.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.controller.api.model.runtime;
+
+import java.util.Collection;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name = "server-instance-key-list")
+public class ServerInstanceKeyList {
+
+    @XmlElement(name = "server-instance-key")
+    private ServerInstanceKey[] serverInstanceKeys;
+
+    public ServerInstanceKeyList() {
+    }
+
+    public ServerInstanceKeyList(ServerInstanceKey[] serverInstanceKeys) {
+        this.serverInstanceKeys = serverInstanceKeys;
+    }
+
+    public ServerInstanceKeyList(Collection<ServerInstanceKey> serverInstanceKeys) {
+        this.serverInstanceKeys = serverInstanceKeys.toArray(new ServerInstanceKey[serverInstanceKeys.size()]);
+    }
+
+    public ServerInstanceKey[] getServerInstanceKeys() {
+        return serverInstanceKeys;
+    }
+
+    public void setServerInstanceKeys(ServerInstanceKey[] serverInstanceKeys) {
+        this.serverInstanceKeys = serverInstanceKeys;
+    }
+}

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/spec/ServerTemplateKeyList.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/spec/ServerTemplateKeyList.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.controller.api.model.spec;
+
+import java.util.Collection;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlRootElement(name = "server-template-key-list")
+public class ServerTemplateKeyList {
+
+    @XmlElement(name="server-template-key")
+    private ServerTemplateKey[] serverTemplates;
+
+    public ServerTemplateKeyList() {
+    }
+
+    public ServerTemplateKeyList(ServerTemplateKey[] serverTemplates) {
+        this.serverTemplates = serverTemplates;
+    }
+
+    public ServerTemplateKeyList(Collection<ServerTemplateKey> serverTemplates) {
+        this.serverTemplates = serverTemplates.toArray(new ServerTemplateKey[serverTemplates.size()]);
+    }
+
+    public ServerTemplateKey[] getServerTemplates() {
+        return serverTemplates;
+    }
+
+    public void setServerTemplates(ServerTemplateKey[] KieServerInstances) {
+        this.serverTemplates = KieServerInstances;
+    }
+
+}

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/service/RuleCapabilitiesService.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/service/RuleCapabilitiesService.java
@@ -20,12 +20,12 @@ import org.kie.server.controller.api.model.spec.ContainerSpecKey;
 
 public interface RuleCapabilitiesService {
 
-    void scanNow(final ContainerSpecKey containerSpecKey);
+    void scanNow(ContainerSpecKey containerSpecKey);
 
-    void startScanner(final ContainerSpecKey containerSpecKey, long interval);
+    void startScanner(ContainerSpecKey containerSpecKey, Long interval);
 
-    void stopScanner(final ContainerSpecKey containerSpecKey);
+    void stopScanner(ContainerSpecKey containerSpecKey);
 
-    void upgradeContainer(final ContainerSpecKey containerSpecKey, final ReleaseId releaseId);
+    void upgradeContainer(ContainerSpecKey containerSpecKey, ReleaseId releaseId);
 
 }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/service/RuntimeManagementService.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/service/RuntimeManagementService.java
@@ -15,16 +15,13 @@
 
 package org.kie.server.controller.api.service;
 
-import java.util.Collection;
-
-import org.kie.server.controller.api.model.runtime.Container;
+import org.kie.server.controller.api.model.runtime.ContainerList;
 import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
+import org.kie.server.controller.api.model.runtime.ServerInstanceKeyList;
 
 public interface RuntimeManagementService {
 
-    Collection<ServerInstanceKey> getServerInstances( final String serverTemplateId );
+    ServerInstanceKeyList getServerInstances(String serverTemplateId);
 
-    Collection<Container> getContainers( final ServerInstanceKey serverInstanceKey );
-
-
+    ContainerList getContainers(ServerInstanceKey serverInstanceKey);
 }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/service/SpecManagementService.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/service/SpecManagementService.java
@@ -15,47 +15,39 @@
 
 package org.kie.server.controller.api.service;
 
-import java.util.Collection;
-
-import org.kie.server.controller.api.model.spec.Capability;
-import org.kie.server.controller.api.model.spec.ContainerConfig;
-import org.kie.server.controller.api.model.spec.ContainerSpec;
-import org.kie.server.controller.api.model.spec.ContainerSpecKey;
-import org.kie.server.controller.api.model.spec.ServerConfig;
-import org.kie.server.controller.api.model.spec.ServerTemplate;
-import org.kie.server.controller.api.model.spec.ServerTemplateKey;
+import org.kie.server.controller.api.model.spec.*;
 
 public interface SpecManagementService {
 
-    void saveContainerSpec(final String serverTemplateId, final ContainerSpec containerSpec);
+    void saveContainerSpec(String serverTemplateId, ContainerSpec containerSpec);
 
-    void updateContainerSpec(final String serverTemplateId, final ContainerSpec containerSpec);
+    void updateContainerSpec(String serverTemplateId, ContainerSpec containerSpec);
 
-    void updateContainerSpec(final String serverTemplateId, final String containerId, final ContainerSpec containerSpec);
+    void updateContainerSpec(String serverTemplateId, String containerId, ContainerSpec containerSpec);
 
-    void saveServerTemplate(final ServerTemplate serverTemplate);
+    void saveServerTemplate(ServerTemplate serverTemplate);
 
-    ServerTemplate getServerTemplate(final String serverTemplateId);
+    ServerTemplate getServerTemplate(String serverTemplateId);
 
-    Collection<ServerTemplateKey> listServerTemplateKeys();
+    ServerTemplateKeyList listServerTemplateKeys();
 
-    Collection<ServerTemplate> listServerTemplates();
+    ServerTemplateList listServerTemplates();
 
-    Collection<ContainerSpec> listContainerSpec(final String serverTemplateId);
+    ContainerSpecList listContainerSpec(String serverTemplateId);
 
     ContainerSpec getContainerInfo(String serverTemplateId, String containerId);
 
-    void deleteContainerSpec(final String serverTemplateId, final String containerSpecId);
+    void deleteContainerSpec(String serverTemplateId, String containerSpecId);
 
-    void deleteServerTemplate(final String serverTemplateId);
+    void deleteServerTemplate(String serverTemplateId);
 
-    void copyServerTemplate(final String serverTemplateId,  final String newServerTemplateId, final String newServerTemplateName);
+    void copyServerTemplate(String serverTemplateId,  String newServerTemplateId, String newServerTemplateName);
 
-    void updateContainerConfig(final String serverTemplateId, final String containerSpecId, final Capability capability, final ContainerConfig containerConfig);
+    void updateContainerConfig(String serverTemplateId, String containerSpecId, Capability capability, ContainerConfig containerConfig);
 
-    void updateServerTemplateConfig(final String serverTemplateId, final Capability capability, final ServerConfig serverTemplateConfig);
+    void updateServerTemplateConfig(String serverTemplateId, Capability capability, ServerConfig serverTemplateConfig);
 
-    void startContainer(final ContainerSpecKey containerSpecKey);
+    void startContainer(ContainerSpecKey containerSpecKey);
 
-    void stopContainer(final ContainerSpecKey containerSpecKey);
+    void stopContainer(ContainerSpecKey containerSpecKey);
 }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/resources/META-INF/ErraiApp.properties
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/resources/META-INF/ErraiApp.properties
@@ -38,9 +38,11 @@ org.kie.server.controller.api.model.events.ServerInstanceDisconnected \
 org.kie.server.controller.api.model.events.ServerTemplateDeleted \
 org.kie.server.controller.api.model.events.ServerTemplateUpdated \
 org.kie.server.controller.api.model.runtime.Container \
+org.kie.server.controller.api.model.runtime.ContainerList \
 org.kie.server.controller.api.model.runtime.ContainerKey \
 org.kie.server.controller.api.model.runtime.ServerInstance \
 org.kie.server.controller.api.model.runtime.ServerInstanceKey \
+org.kie.server.controller.api.model.runtime.ServerInstanceKeyList \
 org.kie.server.controller.api.model.spec.Capability \
 org.kie.server.controller.api.model.spec.ContainerConfig \
 org.kie.server.controller.api.model.spec.ContainerSpec \
@@ -51,4 +53,5 @@ org.kie.server.controller.api.model.spec.RuleConfig \
 org.kie.server.controller.api.model.spec.ServerConfig \
 org.kie.server.controller.api.model.spec.ServerTemplate \
 org.kie.server.controller.api.model.spec.ServerTemplateKey \
+org.kie.server.controller.api.model.spec.ServerTemplateKeyList \
 org.kie.server.controller.api.model.spec.ServerTemplateList

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/RuleCapabilitiesServiceImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/RuleCapabilitiesServiceImpl.java
@@ -58,7 +58,7 @@ public class RuleCapabilitiesServiceImpl implements RuleCapabilitiesService {
 
     @Override
     public void startScanner(final ContainerSpecKey containerSpecKey,
-                             long interval) {
+                             final Long interval) {
 
         ServerTemplate serverTemplate = templateStorage.load(containerSpecKey.getServerTemplateKey().getId());
         if (serverTemplate == null) {

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/RuntimeManagementServiceImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/RuntimeManagementServiceImpl.java
@@ -18,7 +18,9 @@ package org.kie.server.controller.impl.service;
 import java.util.Collection;
 
 import org.kie.server.controller.api.model.runtime.Container;
+import org.kie.server.controller.api.model.runtime.ContainerList;
 import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
+import org.kie.server.controller.api.model.runtime.ServerInstanceKeyList;
 import org.kie.server.controller.api.model.spec.ServerTemplate;
 import org.kie.server.controller.api.service.RuntimeManagementService;
 import org.kie.server.controller.api.storage.KieServerTemplateStorage;
@@ -31,21 +33,19 @@ public class RuntimeManagementServiceImpl implements RuntimeManagementService {
     private KieServerInstanceManager kieServerInstanceManager = KieServerInstanceManager.getInstance();
 
     @Override
-    public Collection<ServerInstanceKey> getServerInstances(String serverTemplateId) {
+    public ServerInstanceKeyList getServerInstances(String serverTemplateId) {
         ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
         if (serverTemplate == null) {
             throw new RuntimeException("No server template found for id " + serverTemplateId);
         }
 
-        return serverTemplate.getServerInstanceKeys();
+        return new ServerInstanceKeyList(serverTemplate.getServerInstanceKeys());
     }
 
     @Override
-    public Collection<Container> getContainers(ServerInstanceKey serverInstanceKey) {
-
+    public ContainerList getContainers(ServerInstanceKey serverInstanceKey) {
         Collection<Container> containers = kieServerInstanceManager.getContainers(serverInstanceKey);
-
-        return containers;
+        return new ContainerList(containers);
     }
 
 

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/SpecManagementServiceImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/SpecManagementServiceImpl.java
@@ -29,15 +29,7 @@ import org.kie.server.controller.api.KieServerControllerNotFoundException;
 import org.kie.server.controller.api.model.events.ServerTemplateDeleted;
 import org.kie.server.controller.api.model.events.ServerTemplateUpdated;
 import org.kie.server.controller.api.model.runtime.Container;
-import org.kie.server.controller.api.model.spec.Capability;
-import org.kie.server.controller.api.model.spec.ContainerConfig;
-import org.kie.server.controller.api.model.spec.ContainerSpec;
-import org.kie.server.controller.api.model.spec.ContainerSpecKey;
-import org.kie.server.controller.api.model.spec.ProcessConfig;
-import org.kie.server.controller.api.model.spec.RuleConfig;
-import org.kie.server.controller.api.model.spec.ServerConfig;
-import org.kie.server.controller.api.model.spec.ServerTemplate;
-import org.kie.server.controller.api.model.spec.ServerTemplateKey;
+import org.kie.server.controller.api.model.spec.*;
 import org.kie.server.controller.api.service.NotificationService;
 import org.kie.server.controller.api.service.SpecManagementService;
 import org.kie.server.controller.api.storage.KieServerTemplateStorage;
@@ -150,23 +142,23 @@ public class SpecManagementServiceImpl implements SpecManagementService {
     }
 
     @Override
-    public Collection<ServerTemplateKey> listServerTemplateKeys() {
-        return templateStorage.loadKeys();
+    public ServerTemplateKeyList listServerTemplateKeys() {
+        return new ServerTemplateKeyList(templateStorage.loadKeys());
     }
 
     @Override
-    public Collection<ServerTemplate> listServerTemplates() {
-        return templateStorage.load();
+    public ServerTemplateList listServerTemplates() {
+        return new ServerTemplateList(templateStorage.load());
     }
 
     @Override
-    public Collection<ContainerSpec> listContainerSpec(String serverTemplateId) {
+    public ContainerSpecList listContainerSpec(String serverTemplateId) {
         ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
         if (serverTemplate == null) {
             throw new KieServerControllerNotFoundException("No server template found for id " + serverTemplateId);
         }
 
-        return serverTemplate.getContainersSpec();
+        return new ContainerSpecList(serverTemplate.getContainersSpec());
     }
 
     @Override

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/AbstractServiceImplTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/AbstractServiceImplTest.java
@@ -15,7 +15,6 @@
 
 package org.kie.server.controller.impl.service;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -23,18 +22,12 @@ import java.util.UUID;
 import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.KieScannerStatus;
 import org.kie.server.api.model.ReleaseId;
-import org.kie.server.controller.api.model.spec.Capability;
-import org.kie.server.controller.api.model.spec.ContainerConfig;
+import org.kie.server.controller.api.model.spec.*;
 import org.kie.server.controller.api.service.RuleCapabilitiesService;
 import org.kie.server.controller.api.service.RuntimeManagementService;
 import org.kie.server.controller.api.service.SpecManagementService;
 import org.kie.server.controller.impl.KieServerInstanceManager;
 import org.kie.server.controller.api.model.runtime.Container;
-import org.kie.server.controller.api.model.spec.ContainerSpec;
-import org.kie.server.controller.api.model.spec.ProcessConfig;
-import org.kie.server.controller.api.model.spec.RuleConfig;
-import org.kie.server.controller.api.model.spec.ServerTemplate;
-import org.kie.server.controller.api.model.spec.ServerTemplateKey;
 
 import static org.junit.Assert.*;
 
@@ -57,9 +50,9 @@ public abstract class AbstractServiceImplTest {
 
         specManagementService.saveServerTemplate(serverTemplate);
 
-        Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey> existing = specManagementService.listServerTemplateKeys();
+        ServerTemplateKeyList existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(1, existing.size());
+        assertEquals(1, existing.getServerTemplates().length);
 
         Map<Capability, ContainerConfig> configs = new HashMap<Capability, ContainerConfig>();
         RuleConfig ruleConfig = new RuleConfig();

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/RuntimeManagementServiceImplTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/RuntimeManagementServiceImplTest.java
@@ -16,14 +16,15 @@
 package org.kie.server.controller.impl.service;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.server.controller.api.model.runtime.Container;
+import org.kie.server.controller.api.model.runtime.ContainerList;
 import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
+import org.kie.server.controller.api.model.runtime.ServerInstanceKeyList;
 import org.kie.server.controller.impl.KieServerInstanceManager;
 import org.kie.server.controller.impl.storage.InMemoryKieServerTemplateStorage;
 import org.mockito.Mockito;
@@ -53,10 +54,10 @@ public class RuntimeManagementServiceImplTest extends AbstractServiceImplTest {
     @Test
     public void testGetServerInstances() {
 
-        Collection<org.kie.server.controller.api.model.runtime.ServerInstanceKey> found = runtimeManagementService.getServerInstances(serverTemplate.getId());
+        ServerInstanceKeyList found = runtimeManagementService.getServerInstances(serverTemplate.getId());
         assertNotNull(found);
 
-        assertEquals(0, found.size());
+        assertEquals(0, found.getServerInstanceKeys().length);
 
         serverTemplate.addServerInstance(new ServerInstanceKey(serverTemplate.getId(), "test server","instanceId" , "http://fake.url.org"));
         specManagementService.saveServerTemplate(serverTemplate);
@@ -64,9 +65,9 @@ public class RuntimeManagementServiceImplTest extends AbstractServiceImplTest {
         found = runtimeManagementService.getServerInstances(serverTemplate.getId());
         assertNotNull(found);
 
-        assertEquals(1, found.size());
+        assertEquals(1, found.getServerInstanceKeys().length);
 
-        org.kie.server.controller.api.model.runtime.ServerInstanceKey server = found.iterator().next();
+        org.kie.server.controller.api.model.runtime.ServerInstanceKey server = found.getServerInstanceKeys()[0];
         assertNotNull(server);
 
         assertEquals(serverTemplate.getId(), server.getServerTemplateId());
@@ -86,10 +87,10 @@ public class RuntimeManagementServiceImplTest extends AbstractServiceImplTest {
         serverTemplate.addServerInstance(instanceKey);
         specManagementService.saveServerTemplate(serverTemplate);
 
-        Collection<Container> containers = runtimeManagementService.getContainers(instanceKey);
+        ContainerList containers = runtimeManagementService.getContainers(instanceKey);
         assertNotNull(containers);
 
-        assertEquals(1, containers.size());
+        assertEquals(1, containers.getContainers().length);
         verify(kieServerInstanceManager, times(1)).getContainers(any(ServerInstanceKey.class));
     }
 

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/SpecManagementServiceImplTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/SpecManagementServiceImplTest.java
@@ -35,13 +35,7 @@ import org.kie.server.controller.api.KieServerControllerNotFoundException;
 import org.kie.server.controller.api.model.events.ServerTemplateUpdated;
 import org.kie.server.controller.api.model.runtime.Container;
 import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
-import org.kie.server.controller.api.model.spec.Capability;
-import org.kie.server.controller.api.model.spec.ContainerConfig;
-import org.kie.server.controller.api.model.spec.ContainerSpec;
-import org.kie.server.controller.api.model.spec.ProcessConfig;
-import org.kie.server.controller.api.model.spec.RuleConfig;
-import org.kie.server.controller.api.model.spec.ServerTemplate;
-import org.kie.server.controller.api.model.spec.ServerTemplateKey;
+import org.kie.server.controller.api.model.spec.*;
 import org.kie.server.controller.api.service.NotificationService;
 import org.kie.server.controller.api.storage.KieServerTemplateStorage;
 import org.kie.server.controller.impl.KieServerInstanceManager;
@@ -92,11 +86,11 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
         specManagementService.saveServerTemplate(serverTemplate);
 
-        Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey> existing = specManagementService.listServerTemplateKeys();
+        ServerTemplateKeyList existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(1, existing.size());
+        assertEquals(1, existing.getServerTemplates().length);
 
-        org.kie.server.controller.api.model.spec.ServerTemplateKey saved = existing.iterator().next();
+        org.kie.server.controller.api.model.spec.ServerTemplateKey saved = existing.getServerTemplates()[0];
 
         assertEquals(serverTemplate.getName(), saved.getName());
         assertEquals(serverTemplate.getId(), saved.getId());
@@ -112,9 +106,9 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
         specManagementService.saveServerTemplate(serverTemplate);
 
-        Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey> existing = specManagementService.listServerTemplateKeys();
+        ServerTemplateKeyList existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(1, existing.size());
+        assertEquals(1, existing.getServerTemplates().length);
 
         Map<Capability, ContainerConfig> configs = new HashMap<Capability, ContainerConfig>();
         RuleConfig ruleConfig = new RuleConfig();
@@ -156,11 +150,11 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
         assertNotNull(container.getConfigs());
         assertEquals(containerSpec.getConfigs().size(), container.getConfigs().size());
 
-        Collection<org.kie.server.controller.api.model.spec.ContainerSpec> specs = specManagementService.listContainerSpec(serverTemplate.getId());
+        ContainerSpecList specs = specManagementService.listContainerSpec(serverTemplate.getId());
         assertNotNull(specs);
-        assertEquals(1, specs.size());
+        assertEquals(1, specs.getContainerSpecs().length);
 
-        container = specs.iterator().next();
+        container = specs.getContainerSpecs()[0];
         assertNotNull(container);
 
         assertEquals(containerSpec.getId(), container.getId());
@@ -184,13 +178,13 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
             specManagementService.saveServerTemplate(serverTemplate);
         }
-        Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey> existing = specManagementService.listServerTemplateKeys();
+        ServerTemplateKeyList existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(limit, existing.size());
+        assertEquals(limit, existing.getServerTemplates().length);
 
-        Collection<org.kie.server.controller.api.model.spec.ServerTemplate> allTemplates = specManagementService.listServerTemplates();
+        ServerTemplateList allTemplates = specManagementService.listServerTemplates();
         assertNotNull(allTemplates);
-        assertEquals(limit, allTemplates.size());
+        assertEquals(limit, allTemplates.getServerTemplates().length);
     }
 
     @Test
@@ -203,11 +197,11 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
         specManagementService.saveServerTemplate(serverTemplate);
 
-        Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey> existing = specManagementService.listServerTemplateKeys();
+        ServerTemplateKeyList existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(1, existing.size());
+        assertEquals(1, existing.getServerTemplates().length);
 
-        org.kie.server.controller.api.model.spec.ServerTemplateKey saved = existing.iterator().next();
+        org.kie.server.controller.api.model.spec.ServerTemplateKey saved = existing.getServerTemplates()[0];
 
         assertEquals(serverTemplate.getName(), saved.getName());
         assertEquals(serverTemplate.getId(), saved.getId());
@@ -215,7 +209,7 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
         specManagementService.deleteServerTemplate(serverTemplate.getId());
         existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(0, existing.size());
+        assertEquals(0, existing.getServerTemplates().length);
     }
 
     @Test
@@ -228,9 +222,9 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
         specManagementService.saveServerTemplate(serverTemplate);
 
-        Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey> existing = specManagementService.listServerTemplateKeys();
+        ServerTemplateKeyList existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(1, existing.size());
+        assertEquals(1, existing.getServerTemplates().length);
 
         int limit = getRandomInt(3, 6);
         for (int x = 0; x < limit; x++) {
@@ -280,9 +274,9 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
         specManagementService.saveServerTemplate(serverTemplate);
 
-        Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey> existing = specManagementService.listServerTemplateKeys();
+        ServerTemplateKeyList existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(1, existing.size());
+        assertEquals(1, existing.getServerTemplates().length);
 
         Map<Capability, ContainerConfig> configs = new HashMap<Capability, ContainerConfig>();
         RuleConfig ruleConfig = new RuleConfig();
@@ -327,7 +321,7 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
         existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(2, existing.size());
+        assertEquals(2, existing.getServerTemplates().length);
 
         createdServerTemplate = specManagementService.getServerTemplate(newServerTemplateId);
         assertNotNull(createdServerTemplate);
@@ -359,9 +353,9 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
         specManagementService.saveServerTemplate(serverTemplate);
 
-        Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey> existing = specManagementService.listServerTemplateKeys();
+        ServerTemplateKeyList existing = specManagementService.listServerTemplateKeys();
         assertNotNull(existing);
-        assertEquals(1, existing.size());
+        assertEquals(1, existing.getServerTemplates().length);
 
         Map<Capability, ContainerConfig> configs = new HashMap<Capability, ContainerConfig>();
         RuleConfig ruleConfig = new RuleConfig();
@@ -415,11 +409,11 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
         specManagementService.updateContainerConfig(serverTemplate.getId(), containerSpec.getId(), Capability.RULE, containerConfig);
 
-        Collection<org.kie.server.controller.api.model.spec.ContainerSpec> specs = specManagementService.listContainerSpec(serverTemplate.getId());
+        ContainerSpecList specs = specManagementService.listContainerSpec(serverTemplate.getId());
         assertNotNull(specs);
-        assertEquals(1, specs.size());
+        assertEquals(1, specs.getContainerSpecs().length);
 
-        container = specs.iterator().next();
+        container = specs.getContainerSpecs()[0];
         assertNotNull(container);
 
         assertEquals(containerSpec.getId(), container.getId());

--- a/kie-server-parent/kie-server-controller/kie-server-controller-mgmt-client/src/main/java/org/kie/server/controller/management/client/rest/RestKieServerMgmtControllerClient.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-mgmt-client/src/main/java/org/kie/server/controller/management/client/rest/RestKieServerMgmtControllerClient.java
@@ -16,9 +16,6 @@
 
 package org.kie.server.controller.management.client.rest;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import javax.ws.rs.client.Client;
@@ -42,8 +39,10 @@ import org.kie.server.controller.api.model.KieServerSetup;
 import org.kie.server.controller.api.model.KieServerStatus;
 import org.kie.server.controller.api.model.runtime.Container;
 import org.kie.server.controller.api.model.runtime.ContainerKey;
+import org.kie.server.controller.api.model.runtime.ContainerList;
 import org.kie.server.controller.api.model.runtime.ServerInstance;
 import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
+import org.kie.server.controller.api.model.runtime.ServerInstanceKeyList;
 import org.kie.server.controller.api.model.spec.*;
 import org.kie.server.controller.management.client.KieServerMgmtControllerClient;
 import org.kie.server.controller.management.client.exception.UnexpectedResponseCodeException;
@@ -125,23 +124,13 @@ public class RestKieServerMgmtControllerClient implements KieServerMgmtControlle
     }
 
     @Override
-    public Collection<ServerTemplate> listServerTemplates() {
-        ServerTemplateList serverTemplateList = makeGetRequestAndCreateCustomResponse(controllerBaseUrl + MANAGEMENT_LAST_URI_PART, ServerTemplateList.class);
-        if (serverTemplateList != null && serverTemplateList.getServerTemplates() != null) {
-            return Arrays.asList(serverTemplateList.getServerTemplates());
-        }
-
-        return Collections.emptyList();
+    public ServerTemplateList listServerTemplates() {
+        return makeGetRequestAndCreateCustomResponse(controllerBaseUrl + MANAGEMENT_LAST_URI_PART, ServerTemplateList.class);
     }
 
     @Override
-    public Collection<ContainerSpec> listContainerSpec(String serverTemplateId) {
-        ContainerSpecList containerSpecList = makeGetRequestAndCreateCustomResponse(controllerBaseUrl + MANAGEMENT_URI_PART + serverTemplateId + CONTAINERS_LAST_URI_PART, ContainerSpecList.class);
-        if (containerSpecList != null && containerSpecList.getContainerSpecs() != null) {
-            return Arrays.asList(containerSpecList.getContainerSpecs());
-        }
-
-        return Collections.emptyList();
+    public ContainerSpecList listContainerSpec(String serverTemplateId) {
+        return makeGetRequestAndCreateCustomResponse(controllerBaseUrl + MANAGEMENT_URI_PART + serverTemplateId + CONTAINERS_LAST_URI_PART, ContainerSpecList.class);
     }
 
     @Override
@@ -159,14 +148,13 @@ public class RestKieServerMgmtControllerClient implements KieServerMgmtControlle
         makePostRequestAndCreateCustomResponse(controllerBaseUrl + MANAGEMENT_URI_PART + serverTemplateId + CONTAINERS_URI_PART + containerId + CONFIG_URI_PART + capability.toString(), config, Object.class);
     }
 
-    private static void throwUnsupportedException(){
+    private <T> T throwUnsupportedException(){
         throw new UnsupportedOperationException("Not supported for REST implementation");
     }
 
     @Override
-    public Collection<ServerTemplateKey> listServerTemplateKeys() {
-        throwUnsupportedException();
-        return null;
+    public ServerTemplateKeyList listServerTemplateKeys() {
+        return throwUnsupportedException();
     }
 
     @Override
@@ -190,14 +178,13 @@ public class RestKieServerMgmtControllerClient implements KieServerMgmtControlle
 
     @Override
     public void startScanner(ContainerSpecKey containerSpecKey,
-                             long interval) {
+                             Long interval) {
         throwUnsupportedException();
     }
 
     @Override
-    public Collection<ServerInstanceKey> getServerInstances(String serverTemplateId) {
-        throwUnsupportedException();
-        return null;
+    public ServerInstanceKeyList getServerInstances(String serverTemplateId) {
+        return throwUnsupportedException();
     }
 
     @Override
@@ -206,9 +193,8 @@ public class RestKieServerMgmtControllerClient implements KieServerMgmtControlle
     }
 
     @Override
-    public Collection<Container> getContainers(ServerInstanceKey serverInstanceKey) {
-        throwUnsupportedException();
-        return null;
+    public ContainerList getContainers(ServerInstanceKey serverInstanceKey) {
+        return throwUnsupportedException();
     }
 
     @Override

--- a/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/build/revapi-config.json
@@ -21,11 +21,47 @@
       }
     }
   },
-
   "ignores": {
     "revapi": {
       "_comment": "Changes between 7.0.0.Final and the current branch. These changes are desired and thus ignored.",
-      "ignore": []
+      "ignore": [
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method java.util.Collection<org.kie.server.controller.api.model.spec.ContainerSpec> org.kie.server.controller.impl.service.SpecManagementServiceImpl::listContainerSpec(java.lang.String) @ org.kie.server.controller.rest.RestSpecManagementServiceImpl",
+          "new": "method org.kie.server.controller.api.model.spec.ContainerSpecList org.kie.server.controller.impl.service.SpecManagementServiceImpl::listContainerSpec(java.lang.String) @ org.kie.server.controller.rest.RestSpecManagementServiceImpl",
+          "oldType": "java.util.Collection<org.kie.server.controller.api.model.spec.ContainerSpec>",
+          "newType": "org.kie.server.controller.api.model.spec.ContainerSpecList",
+          "package": "org.kie.server.controller.rest",
+          "classSimpleName": "RestSpecManagementServiceImpl",
+          "methodName": "listContainerSpec",
+          "elementKind": "method",
+          "justification": "Use list object type for serialization"
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method java.util.Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey> org.kie.server.controller.impl.service.SpecManagementServiceImpl::listServerTemplateKeys() @ org.kie.server.controller.rest.RestSpecManagementServiceImpl",
+          "new": "method org.kie.server.controller.api.model.spec.ServerTemplateKeyList org.kie.server.controller.impl.service.SpecManagementServiceImpl::listServerTemplateKeys() @ org.kie.server.controller.rest.RestSpecManagementServiceImpl",
+          "oldType": "java.util.Collection<org.kie.server.controller.api.model.spec.ServerTemplateKey>",
+          "newType": "org.kie.server.controller.api.model.spec.ServerTemplateKeyList",
+          "package": "org.kie.server.controller.rest",
+          "classSimpleName": "RestSpecManagementServiceImpl",
+          "methodName": "listServerTemplateKeys",
+          "elementKind": "method",
+          "justification": "Use list object type for serialization"
+        },
+        {
+          "code": "java.method.returnTypeChanged",
+          "old": "method java.util.Collection<org.kie.server.controller.api.model.spec.ServerTemplate> org.kie.server.controller.impl.service.SpecManagementServiceImpl::listServerTemplates() @ org.kie.server.controller.rest.RestSpecManagementServiceImpl",
+          "new": "method org.kie.server.controller.api.model.spec.ServerTemplateList org.kie.server.controller.impl.service.SpecManagementServiceImpl::listServerTemplates() @ org.kie.server.controller.rest.RestSpecManagementServiceImpl",
+          "oldType": "java.util.Collection<org.kie.server.controller.api.model.spec.ServerTemplate>",
+          "newType": "org.kie.server.controller.api.model.spec.ServerTemplateList",
+          "package": "org.kie.server.controller.rest",
+          "classSimpleName": "RestSpecManagementServiceImpl",
+          "methodName": "listServerTemplates",
+          "elementKind": "method",
+          "justification": "Use list object type for serialization"
+        }
+      ]
     }
   }
 }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/main/java/org/kie/server/controller/rest/ControllerUtils.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/main/java/org/kie/server/controller/rest/ControllerUtils.java
@@ -37,17 +37,11 @@ import org.kie.server.controller.api.model.KieServerSetup;
 import org.kie.server.controller.api.model.KieServerStatus;
 import org.kie.server.controller.api.model.runtime.Container;
 import org.kie.server.controller.api.model.runtime.ContainerKey;
+import org.kie.server.controller.api.model.runtime.ContainerList;
 import org.kie.server.controller.api.model.runtime.ServerInstance;
 import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
-import org.kie.server.controller.api.model.spec.ContainerSpec;
-import org.kie.server.controller.api.model.spec.ContainerSpecKey;
-import org.kie.server.controller.api.model.spec.ContainerSpecList;
-import org.kie.server.controller.api.model.spec.ProcessConfig;
-import org.kie.server.controller.api.model.spec.RuleConfig;
-import org.kie.server.controller.api.model.spec.ServerConfig;
-import org.kie.server.controller.api.model.spec.ServerTemplate;
-import org.kie.server.controller.api.model.spec.ServerTemplateKey;
-import org.kie.server.controller.api.model.spec.ServerTemplateList;
+import org.kie.server.controller.api.model.runtime.ServerInstanceKeyList;
+import org.kie.server.controller.api.model.spec.*;
 
 public class ControllerUtils {
 
@@ -65,14 +59,17 @@ public class ControllerUtils {
 
         modelClasses.add(ServerInstance.class);
         modelClasses.add(ServerInstanceKey.class);
+        modelClasses.add(ServerInstanceKeyList.class);
         modelClasses.add(ServerTemplate.class);
         modelClasses.add(ServerTemplateKey.class);
+        modelClasses.add(ServerTemplateKeyList.class);
         modelClasses.add(ServerConfig.class);
         modelClasses.add(RuleConfig.class);
         modelClasses.add(ProcessConfig.class);
         modelClasses.add(ContainerSpec.class);
         modelClasses.add(ContainerSpecKey.class);
         modelClasses.add(Container.class);
+        modelClasses.add(ContainerList.class);
         modelClasses.add(ContainerKey.class);
         modelClasses.add(ServerTemplateList.class);
         modelClasses.add(ContainerSpecList.class);

--- a/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/main/java/org/kie/server/controller/rest/RestSpecManagementServiceImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/main/java/org/kie/server/controller/rest/RestSpecManagementServiceImpl.java
@@ -15,7 +15,6 @@
 
 package org.kie.server.controller.rest;
 
-import java.util.Collection;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -34,10 +33,8 @@ import org.kie.server.controller.api.KieServerControllerNotFoundException;
 import org.kie.server.controller.api.model.spec.Capability;
 import org.kie.server.controller.api.model.spec.ContainerConfig;
 import org.kie.server.controller.api.model.spec.ContainerSpecKey;
-import org.kie.server.controller.api.model.spec.ContainerSpecList;
 import org.kie.server.controller.api.model.spec.RuleConfig;
 import org.kie.server.controller.api.model.spec.ServerTemplateKey;
-import org.kie.server.controller.api.model.spec.ServerTemplateList;
 import org.kie.server.controller.api.model.spec.ContainerSpec;
 import org.kie.server.controller.api.model.spec.ProcessConfig;
 import org.kie.server.controller.api.model.spec.ServerTemplate;
@@ -169,9 +166,8 @@ public class RestSpecManagementServiceImpl extends SpecManagementServiceImpl {
         String contentType = getContentType(headers);
         try {
             logger.debug("Received get server templates");
-            Collection<ServerTemplate> servers = super.listServerTemplates();
 
-            String response = marshal(contentType, new ServerTemplateList(servers));
+            String response = marshal(contentType, super.listServerTemplates());
             logger.debug("Returning response for get server templates: {}", response);
 
             return createCorrectVariant(response, headers, Response.Status.OK);
@@ -194,9 +190,7 @@ public class RestSpecManagementServiceImpl extends SpecManagementServiceImpl {
         try {
             logger.debug("Received get containers for server template with id {}", serverTemplateId);
 
-            Collection<ContainerSpec> containerSpecs =  super.listContainerSpec(serverTemplateId);
-
-            String response = marshal(contentType, new ContainerSpecList(containerSpecs));
+            String response = marshal(contentType, super.listContainerSpec(serverTemplateId));
             logger.debug("Returning response for get containers for server templates with id {}: {}", serverTemplateId, response);
 
             return createCorrectVariant(response, headers, Response.Status.OK);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/KieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/KieServerBaseIntegrationTest.java
@@ -18,7 +18,6 @@ package org.kie.server.integrationtests.shared.basetests;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +43,7 @@ import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.KieServicesConfiguration;
 import org.kie.server.client.KieServicesFactory;
 import org.kie.server.controller.api.model.spec.ServerTemplate;
+import org.kie.server.controller.api.model.spec.ServerTemplateList;
 import org.kie.server.controller.management.client.KieServerMgmtControllerClient;
 import org.kie.server.controller.management.client.KieServerMgmtControllerClientFactory;
 import org.kie.server.integrationtests.config.TestConfig;
@@ -174,9 +174,11 @@ public abstract class KieServerBaseIntegrationTest {
                                                                            MarshallingFormat.JAXB,
                                                                            configuration)
         ) {
-            Collection<ServerTemplate> serverTemplates = mgmtControllerClient.listServerTemplates();
-            for (ServerTemplate serverTemplate : serverTemplates) {
-                mgmtControllerClient.deleteServerTemplate(serverTemplate.getId());
+            ServerTemplateList serverTemplates = mgmtControllerClient.listServerTemplates();
+            if(serverTemplates.getServerTemplates() != null) {
+                for (ServerTemplate serverTemplate : serverTemplates.getServerTemplates()) {
+                    mgmtControllerClient.deleteServerTemplate(serverTemplate.getId());
+                }
             }
         } catch (Exception ex){
             logger.error("Error while deleting server templates: ", ex.getMessage(), ex);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerStartupIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerStartupIntegrationTest.java
@@ -17,7 +17,6 @@ package org.kie.server.integrationtests.controller;
 
 import static org.junit.Assert.*;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.concurrent.TimeoutException;
 
@@ -39,6 +38,7 @@ import org.kie.server.controller.api.model.spec.Capability;
 import org.kie.server.controller.api.model.spec.ContainerConfig;
 import org.kie.server.controller.api.model.spec.ContainerSpec;
 import org.kie.server.controller.api.model.spec.ServerTemplate;
+import org.kie.server.controller.api.model.spec.ServerTemplateList;
 import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
@@ -97,9 +97,9 @@ public class KieControllerStartupIntegrationTest extends KieControllerManagement
         server.stopKieServer();
 
         // Check that there are no kie servers deployed in controller.
-        Collection<ServerTemplate> instanceList = mgmtControllerClient.listServerTemplates();
+        ServerTemplateList instanceList = mgmtControllerClient.listServerTemplates();
         assertNotNull(instanceList);
-        KieServerAssert.assertNullOrEmpty("Active kie server instance found!", instanceList);
+        KieServerAssert.assertNullOrEmpty("Active kie server instance found!", instanceList.getServerTemplates());
 
         // Turn on new kie server.
         server.startKieServer();
@@ -107,7 +107,7 @@ public class KieControllerStartupIntegrationTest extends KieControllerManagement
         // Check that kie server is registered in controller.
         instanceList = mgmtControllerClient.listServerTemplates();
         assertNotNull(instanceList);
-        assertEquals(1, instanceList.size());
+        assertEquals(1, instanceList.getServerTemplates().length);
 
         // Getting info from currently started kie server.
         ServiceResponse<KieServerInfo> reply = client.getServerInfo();
@@ -115,7 +115,7 @@ public class KieControllerStartupIntegrationTest extends KieControllerManagement
         assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
         assertNotNull(reply.getResult());
 
-        ServerTemplate deployedServerInstance = instanceList.iterator().next();
+        ServerTemplate deployedServerInstance = instanceList.getServerTemplates()[0];
         assertNotNull(deployedServerInstance);
         assertEquals(reply.getResult().getServerId(), deployedServerInstance.getId());
     }
@@ -131,17 +131,17 @@ public class KieControllerStartupIntegrationTest extends KieControllerManagement
         mgmtControllerClient.saveServerTemplate(serverTemplate);
 
         // Check that kie server is registered.
-        Collection<ServerTemplate> instanceList = mgmtControllerClient.listServerTemplates();
-        assertEquals(1, instanceList.size());
-        assertEquals(kieServerInfo.getResult().getServerId(), instanceList.iterator().next().getId()); //maybe change to avoid next -> null
+        ServerTemplateList instanceList = mgmtControllerClient.listServerTemplates();
+        assertEquals(1, instanceList.getServerTemplates().length);
+        assertEquals(kieServerInfo.getResult().getServerId(), instanceList.getServerTemplates()[0].getId()); //maybe change to avoid next -> null
 
         // Turn off embedded kie server.
         server.stopKieServer();
 
         // Check that kie server is down in controller.
         instanceList = mgmtControllerClient.listServerTemplates();
-        assertEquals(1, instanceList.size());
-        assertEquals(kieServerInfo.getResult().getServerId(), instanceList.iterator().next().getId()); //maybe change to avoid next -> null
+        assertEquals(1, instanceList.getServerTemplates().length);
+        assertEquals(kieServerInfo.getResult().getServerId(), instanceList.getServerTemplates()[0].getId()); //maybe change to avoid next -> null
     }
 
     @Test
@@ -157,8 +157,8 @@ public class KieControllerStartupIntegrationTest extends KieControllerManagement
         KieServerAssert.assertNullOrEmpty("Active containers found!", containersList.getResult().getContainers());
 
         // Check that there are no kie servers deployed in controller.
-        Collection<ServerTemplate> instanceList = mgmtControllerClient.listServerTemplates();
-        KieServerAssert.assertNullOrEmpty("Active kie server instance found!", instanceList);
+        ServerTemplateList instanceList = mgmtControllerClient.listServerTemplates();
+        KieServerAssert.assertNullOrEmpty("Active kie server instance found!", instanceList.getServerTemplates());
 
         // Turn kie server off, add embedded kie server to controller, create container and start kie server again.
         server.stopKieServer();
@@ -216,8 +216,8 @@ public class KieControllerStartupIntegrationTest extends KieControllerManagement
         assertNotNull(containersList.getResult().getContainers());
         assertEquals(1, containersList.getResult().getContainers().size());
 
-        Collection<ServerTemplate> instanceList = mgmtControllerClient.listServerTemplates();
-        assertEquals(1, instanceList.size());
+        ServerTemplateList instanceList = mgmtControllerClient.listServerTemplates();
+        assertEquals(1, instanceList.getServerTemplates().length);
 
         // Turn kie server off, dispose container and start kie server again.
         server.stopKieServer();


### PR DESCRIPTION
@mswiderski changing the collection return types so objects can be properly serialized when using the new websocket client. So far this was the only way I could the entire graph to be serialized/deserialized without marshaling errors.