### PR TITLE
RHBPMS-5026 and RHBRMS-3033 - Version difference of jackson artifacts…

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
@@ -211,7 +211,7 @@ public class JSONMarshaller implements Marshaller {
                         TypeIdResolver idRes = idResolver(config, baseType, subtypes, false, true);
                         switch (_includeAs) {
                             case WRAPPER_OBJECT:
-                                return new CustomAsWrapperTypeDeserializer(baseType, idRes, _typeProperty, true, _defaultImpl);
+                                return new CustomAsWrapperTypeDeserializer(baseType, idRes, _typeProperty, true, baseType);
 
                         }
                     }
@@ -224,6 +224,7 @@ public class JSONMarshaller implements Marshaller {
             typer2 = typer2.init(JsonTypeInfo.Id.CLASS, null);
             typer2 = typer2.inclusion(JsonTypeInfo.As.WRAPPER_OBJECT);
             deserializeObjectMapper.setDefaultTyping(typer2);
+            
 
             SimpleModule modDeser = new SimpleModule("custom-object-unmapper", Version.unknownVersion());
             modDeser.addDeserializer(Object.class, new CustomObjectDeserializer(classes));
@@ -755,7 +756,7 @@ public class JSONMarshaller implements Marshaller {
 
     class CustomAsWrapperTypeDeserializer extends AsWrapperTypeDeserializer {
 
-        public CustomAsWrapperTypeDeserializer(JavaType bt, TypeIdResolver idRes, String typePropertyName, boolean typeIdVisible, Class<?> defaultImpl) {
+        public CustomAsWrapperTypeDeserializer(JavaType bt, TypeIdResolver idRes, String typePropertyName, boolean typeIdVisible, JavaType defaultImpl) {
             super(bt, idRes, typePropertyName, typeIdVisible, defaultImpl);
         }
 

--- a/kie-server-parent/kie-server-remote/kie-server-client/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-client/pom.xml
@@ -69,16 +69,6 @@
       <artifactId>kie-server-common</artifactId>
     </dependency>
 
-    <!-- JSON (un)marshalling -->
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-xc</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/JbpmRestIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/JbpmRestIntegrationTest.java
@@ -28,6 +28,7 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -101,7 +102,7 @@ public class JbpmRestIntegrationTest extends RestJbpmBaseIntegrationTest {
             logger.info( "[POST] " + clientRequest.getUri());
             response = clientRequest.request().post(createEntity(""));
             Assert.assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
-            Assert.assertEquals(getMediaType().toString(), response.getHeaders().getFirst("Content-Type"));
+            Assertions.assertThat((String)response.getHeaders().getFirst("Content-Type")).startsWith(getMediaType().toString());
 
             JaxbLong pId = response.readEntity(JaxbLong.class);
             valuesMap.put(PROCESS_INST_ID, pId.unwrap());
@@ -147,7 +148,7 @@ public class JbpmRestIntegrationTest extends RestJbpmBaseIntegrationTest {
             logger.info( "[POST] " + clientRequest.getUri());
             response = clientRequest.request(getMediaType()).post(createEntity(""));
             Assert.assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
-            Assert.assertEquals(getMediaType().toString(), response.getHeaders().getFirst("Content-Type"));
+            Assertions.assertThat((String)response.getHeaders().getFirst("Content-Type")).startsWith(getMediaType().toString());
 
             JaxbLong pId = response.readEntity(JaxbLong.class);
             valuesMap.put(PROCESS_INST_ID, pId.unwrap());
@@ -182,7 +183,7 @@ public class JbpmRestIntegrationTest extends RestJbpmBaseIntegrationTest {
             logger.info( "[POST] " + clientRequest.getUri());
             response = clientRequest.request(acceptHeadersByFormat.get(marshallingFormat)).post(createEntity(""));
             Assert.assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatus());
-            Assert.assertEquals(getMediaType().toString(), response.getHeaders().getFirst("Content-Type"));
+            Assertions.assertThat((String)response.getHeaders().getFirst("Content-Type")).startsWith(getMediaType().toString());
 
             JaxbLong pId = response.readEntity(JaxbLong.class);
             valuesMap.put(PROCESS_INST_ID, pId.unwrap());

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -50,10 +50,8 @@
     <jms.skip>false</jms.skip>
 
     <version.tomcat8>8.5.12</version.tomcat8>
-    <version.wildfly10>10.1.0.Final</version.wildfly10>
-    <version.wildfly11>11.0.0.Final</version.wildfly11>
-    <!-- Need to override jboss-remoting version to be compatible with jboss-remote-naming -->
-    <version.org.jboss.remoting>4.0.18.Final</version.org.jboss.remoting>
+    <version.wildfly11>11.0.0.Final</version.wildfly11>      
+    <version.org.jboss.marshalling>2.0.2.Final</version.org.jboss.marshalling>
     <!-- The EAP 7 binary can't be anonymously downloaded because of the license. It can be downloaded manually
          and for free (e.g. from http://jbossas.jboss.org/downloads.html) and the zip location needs to be specified
          here or via system property when running the build (don't forget to use the `file://` prefix when
@@ -486,173 +484,14 @@
           <artifactId>kie-tomcat-integration</artifactId>
         </dependency>
       </dependencies>
-    </profile>
-    <profile>
-      <id>wildfly10</id>
-      <properties>
-        <kie.server.remoting.url>http-remoting://${container.hostname}:${container.port}</kie.server.remoting.url>
-        <org.kie.server.persistence.ds>java:jboss/datasources/ExampleDS</org.kie.server.persistence.ds>
-        <cargo.container.id>wildfly10x</cargo.container.id>
-      </properties>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.codehaus.cargo</groupId>
-              <artifactId>cargo-maven2-plugin</artifactId>
-              <configuration>
-                <container>
-                  <type>installed</type>
-                  <artifactInstaller>
-                    <groupId>org.wildfly</groupId>
-                    <artifactId>wildfly-dist</artifactId>
-                    <version>${version.wildfly10}</version>
-                  </artifactInstaller>
-                  <systemProperties>
-                    <!-- disable JMS support for executor to use same tests for all containers for jbpm executor -->
-                    <org.kie.executor.jms>false</org.kie.executor.jms>
-                    <org.kie.server.sync.deploy>true</org.kie.server.sync.deploy>
-                    <org.kie.mail.session>java:/mail/Session</org.kie.mail.session>
-                  </systemProperties>
-                </container>
-                <configuration>
-                  <properties>
-                    <cargo.jboss.configuration>standalone-full</cargo.jboss.configuration>
-                    <cargo.jvmargs>-Xmx1024m</cargo.jvmargs>
-                    <cargo.resource.resource.mail>
-                       cargo.resource.name=mail/Session|
-                       cargo.resource.type=javax.mail.Session|
-                       cargo.resource.id=mail|
-                       cargo.resource.parameters=mail.smtp.host=localhost;mail.smtp.port=2525;mail.smtp.from=kie-server-test@domain.com
-                    </cargo.resource.resource.mail>
-                  </properties>
-                </configuration>
-              </configuration>
-            </plugin>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-failsafe-plugin</artifactId>
-              <configuration>
-                <systemPropertyVariables>
-                  <!-- Reuse yoda user for deploying and undeploying Kie server from within the test -->
-                  <cargo.remote.username>yoda</cargo.remote.username>
-                  <cargo.remote.password>usetheforce123@</cargo.remote.password>
-                </systemPropertyVariables>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-      <dependencyManagement>
-        <dependencies>
-          <!-- This is far from ideal, as it is not designed as BOM. However, there is nothing like wildfly-bom,
-               so this is the closest thing I could find.
-               Important: this overrides lots of the versions coming from kie-p-w-d -->
-          <dependency>
-            <groupId>org.wildfly</groupId>
-            <artifactId>wildfly-parent</artifactId>
-            <version>${version.wildfly10}</version>
-            <type>pom</type>
-            <scope>import</scope>
-          </dependency>
-          <dependency>
-            <groupId>org.jboss.remoting</groupId>
-            <artifactId>jboss-remoting</artifactId>
-            <version>${version.org.jboss.remoting}</version>
-          </dependency>
-          <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${version.com.google.guava}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
-            <version>${version.org.jboss.resteasy}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>${version.org.jboss.resteasy}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson-provider</artifactId>
-            <version>${version.org.jboss.resteasy}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${version.org.apache.httpcomponents.httpclient}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>${version.org.apache.httpcomponents.httpcore}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-aether-provider</artifactId>
-            <version>${version.org.apache.maven}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-api</artifactId>
-            <version>${version.org.eclipse.aether}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-util</artifactId>
-            <version>${version.org.eclipse.aether}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-impl</artifactId>
-            <version>${version.org.eclipse.aether}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-connector-basic</artifactId>
-            <version>${version.org.eclipse.aether}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-spi</artifactId>
-            <version>${version.org.eclipse.aether}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-transport-file</artifactId>
-            <version>${version.org.eclipse.aether}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-transport-http</artifactId>
-            <version>${version.org.eclipse.aether}</version>
-          </dependency>
-          <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>${version.com.sun.xml.bind}</version>
-          </dependency>
-        </dependencies>
-      </dependencyManagement>
-      <dependencies>
-        <dependency>
-          <groupId>org.wildfly</groupId>
-          <artifactId>wildfly-jms-client-bom</artifactId>
-          <type>pom</type>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
+    </profile>    
     <profile>
       <id>wildfly11</id>
-      <properties>
-<!--         <kie.server.remoting.url>http-remoting://${container.hostname}:${container.port}</kie.server.remoting.url> -->
+      <properties>        
+        <kie.server.remoting.url>http-remoting://${container.hostname}:${container.port}</kie.server.remoting.url>
+        <kie.server.context.factory>org.jboss.naming.remote.client.InitialContextFactory</kie.server.context.factory>
         <org.kie.server.persistence.ds>java:jboss/datasources/ExampleDS</org.kie.server.persistence.ds>
         <cargo.container.id>wildfly10x</cargo.container.id>
-        <failsafe.excluded.groups>org.kie.server.integrationtests.category.JMSOnly</failsafe.excluded.groups>
       </properties>
       <build>
         <pluginManagement>
@@ -703,6 +542,28 @@
           </plugins>
         </pluginManagement>
       </build>
+      <dependencyManagement>
+        <dependencies>
+          <!-- This is far from ideal, as it is not designed as BOM. However, 
+            there is nothing like wildfly-bom, so this is the closest thing I could find. 
+            Important: this overrides lots of the versions coming from kie-p-w-d -->
+          <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-parent</artifactId>
+            <version>${version.wildfly11}</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.wildfly</groupId>
+          <artifactId>wildfly-jms-client-bom</artifactId>
+          <type>pom</type>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
     </profile>
     <profile>
       <id>eap7</id>
@@ -760,96 +621,16 @@
         </pluginManagement>
       </build>
       <dependencyManagement>
-        <dependencies>
-          <!-- This is far from ideal, as it is not designed as BOM. However, there is nothing like wildfly-bom,
-               so this is the closest thing I could find.
-               Important: this overrides lots of the versions coming from kie-p-w-d -->
+       <dependencies>
+          <!-- This is far from ideal, as it is not designed as BOM. However, 
+            there is nothing like wildfly-bom, so this is the closest thing I could find. 
+            Important: this overrides lots of the versions coming from kie-p-w-d -->
           <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-parent</artifactId>
-            <version>${version.wildfly10}</version>
+            <version>${version.wildfly11}</version>
             <type>pom</type>
             <scope>import</scope>
-          </dependency>
-          <dependency>
-            <groupId>org.jboss.remoting</groupId>
-            <artifactId>jboss-remoting</artifactId>
-            <version>${version.org.jboss.remoting}</version>
-          </dependency>
-          <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${version.com.google.guava}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxrs</artifactId>
-            <version>${version.org.jboss.resteasy}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jaxb-provider</artifactId>
-            <version>${version.org.jboss.resteasy}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson-provider</artifactId>
-            <version>${version.org.jboss.resteasy}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${version.org.apache.httpcomponents.httpclient}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>${version.org.apache.httpcomponents.httpcore}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-aether-provider</artifactId>
-            <version>${version.org.apache.maven}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-api</artifactId>
-            <version>${version.org.eclipse.aether}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-util</artifactId>
-            <version>${version.org.eclipse.aether}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-impl</artifactId>
-            <version>${version.org.eclipse.aether}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-connector-basic</artifactId>
-            <version>${version.org.eclipse.aether}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-spi</artifactId>
-            <version>${version.org.eclipse.aether}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-transport-file</artifactId>
-            <version>${version.org.eclipse.aether}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.eclipse.aether</groupId>
-            <artifactId>aether-transport-http</artifactId>
-            <version>${version.org.eclipse.aether}</version>
-          </dependency>
-          <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>${version.com.sun.xml.bind}</version>
           </dependency>
         </dependencies>
       </dependencyManagement>


### PR DESCRIPTION
… - support for WildFly 11 and EAP 7.1

this provides support for WildFly 11 and EAp 7.1 which requires upgrade of jackson library (which is not backward compatible in terms what is used in KIE Server's JSON Marshaller).

At the same time it removes wildfly10 profile and moves EAP 7 to use WildFly 11 instead of 10.

@sutaakar could you please review?

It needs to be merged with https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/583