### PR TITLE
RHBRMS-3044: Store template map when template file doesn't exist

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/storage/FileBasedKieServerTemplateStorage.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/storage/FileBasedKieServerTemplateStorage.java
@@ -130,6 +130,16 @@ public class FileBasedKieServerTemplateStorage implements KieServerTemplateStora
 
         try (FileReader reader = new FileReader(templatesLocation)) {
             templates = (ArrayList<ServerTemplate>)this.xstream.fromXML(reader);
+
+            if (templates != null && !templates.isEmpty()) {
+                templates.forEach(template -> {
+                    newTemplateKeyMap.put(template.getId(),new ServerTemplateKey(template.getId(),template.getName()));
+                    newTemplateMap.put(template.getId(),template);
+                });
+            }
+            templateKeyMap = newTemplateKeyMap;
+            templateMap = newTemplateMap;
+
         } catch (FileNotFoundException e) {
             logger.warn("Unable to read server template maps from file {}. File does not exist.", templatesLocation);
             writeTemplateMap();
@@ -138,14 +148,6 @@ public class FileBasedKieServerTemplateStorage implements KieServerTemplateStora
         } catch (Throwable e) {
             logger.error("Unable to read server template maps from file",e);
         }
-        if (templates != null && !templates.isEmpty()) {
-            templates.forEach(template -> {
-                newTemplateKeyMap.put(template.getId(),new ServerTemplateKey(template.getId(),template.getName()));
-                newTemplateMap.put(template.getId(),template);
-            });
-        }
-        templateKeyMap = newTemplateKeyMap;
-        templateMap = newTemplateMap;
     }
 
 

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/storage/FileBasedKieServerTemplateStorageTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/storage/FileBasedKieServerTemplateStorageTest.java
@@ -275,6 +275,21 @@ public class FileBasedKieServerTemplateStorageTest {
     }
 
     @Test
+    public void testLoadNotExistingTemplate() {
+        List<ServerTemplate> templates = storage.load();
+        assertEquals(3, templates.size());
+
+        // Delete template file
+        tmpTemplateStore.delete();
+
+        storage.loadTemplateMapsFromFile();
+
+        // Storage should still contain previously loaded templates
+        templates = storage.load();
+        assertEquals(3, templates.size());
+    }
+
+    @Test
     public void testGetStorageLocation() {
         String location = storage.getTemplatesLocation();
         assertEquals(tmpTemplateStore.getAbsolutePath(), location);


### PR DESCRIPTION
Even Files.write() generates 2 file events when modifying content. I suppose the first event is caused by deleting old content, second contains new content.
Adjusted loadTemplateMapsFromFile() to store actual content just in case of missing file, in case of malformed file it will just show warning.