### PR TITLE
JBPM-6243 Simplify WebSocket marshalling utils

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-client/src/main/java/org/kie/server/controller/client/websocket/WebSocketKieServerControllerClient.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-client/src/main/java/org/kie/server/controller/client/websocket/WebSocketKieServerControllerClient.java
@@ -18,7 +18,6 @@ package org.kie.server.controller.client.websocket;
 
 import java.io.IOException;
 
-import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.KieServiceResponse.ResponseType;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.controller.api.commands.KieServerControllerDescriptorCommand;
@@ -87,8 +86,7 @@ public class WebSocketKieServerControllerClient implements KieServerControllerCl
         LOGGER.debug("About to send descriptor command to kie server controller: {}",
                      command);
 
-        final String content = WebSocketUtils.marshal(MarshallingFormat.JSON.getType(),
-                                                      command);
+        final String content = WebSocketUtils.marshal(command);
         LOGGER.debug("Content to be sent over Web Socket '{}'",
                      content);
         try {
@@ -114,7 +112,6 @@ public class WebSocketKieServerControllerClient implements KieServerControllerCl
     protected WebSocketServiceResponse getMessageHandler() {
         return new WebSocketServiceResponse(true,
                                             (message) -> WebSocketUtils.unmarshal(message,
-                                                                                  MarshallingFormat.JSON.getType(),
                                                                                   KieServerControllerServiceResponse.class));
     }
 

--- a/kie-server-parent/kie-server-controller/kie-server-controller-client/src/test/java/org/kie/server/controller/client/websocket/WebSocketKieServerControllerClientTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-client/src/test/java/org/kie/server/controller/client/websocket/WebSocketKieServerControllerClientTest.java
@@ -23,7 +23,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.server.api.commands.DescriptorCommand;
-import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.controller.api.service.RuleCapabilitiesService;
 import org.kie.server.controller.api.service.RuntimeManagementService;
 import org.kie.server.controller.api.service.SpecManagementService;
@@ -83,7 +82,6 @@ public class WebSocketKieServerControllerClientTest {
                                                any(InternalMessageHandler.class));
 
             final DescriptorCommand command = WebSocketUtils.unmarshal(contentCaptor.getValue(),
-                                                                 MarshallingFormat.JSON.getType(),
                                                                  DescriptorCommand.class);
             assertNotNull(command);
             assertEquals(name,

--- a/kie-server-parent/kie-server-controller/kie-server-controller-websocket-common/src/main/java/org/kie/server/controller/websocket/common/WebSocketUtils.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-websocket-common/src/main/java/org/kie/server/controller/websocket/common/WebSocketUtils.java
@@ -16,79 +16,22 @@
 
 package org.kie.server.controller.websocket.common;
 
-import java.util.HashSet;
-import java.util.Set;
-
 import org.kie.server.api.marshalling.Marshaller;
 import org.kie.server.api.marshalling.MarshallerFactory;
 import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.Wrapped;
-import org.kie.server.controller.api.commands.KieServerControllerDescriptorCommand;
-import org.kie.server.controller.api.model.*;
-import org.kie.server.controller.api.model.runtime.Container;
-import org.kie.server.controller.api.model.runtime.ContainerKey;
-import org.kie.server.controller.api.model.runtime.ServerInstance;
-import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
-import org.kie.server.controller.api.model.spec.*;
 
 public class WebSocketUtils {
 
     private static Marshaller jsonMarshaller = MarshallerFactory.getMarshaller(null, MarshallingFormat.JSON, WebSocketUtils.class.getClassLoader());
-    private static Marshaller jaxbMarshaller = MarshallerFactory.getMarshaller(getModelClasses(), MarshallingFormat.JAXB, WebSocketUtils.class.getClassLoader());
-
-    public static Set<Class<?>> getModelClasses() {
-        Set<Class<?>> modelClasses = new HashSet<Class<?>>();
-
-        modelClasses.add(KieServerInstance.class);
-        modelClasses.add(KieServerInstanceList.class);
-        modelClasses.add(KieServerInstanceInfo.class);
-        modelClasses.add(KieServerSetup.class);
-        modelClasses.add(KieServerStatus.class);
-
-        modelClasses.add(ServerInstance.class);
-        modelClasses.add(ServerInstanceKey.class);
-        modelClasses.add(ServerTemplate.class);
-        modelClasses.add(ServerTemplateKey.class);
-        modelClasses.add(ServerConfig.class);
-        modelClasses.add(RuleConfig.class);
-        modelClasses.add(ProcessConfig.class);
-        modelClasses.add(ContainerSpec.class);
-        modelClasses.add(ContainerSpecKey.class);
-        modelClasses.add(Container.class);
-        modelClasses.add(ContainerKey.class);
-        modelClasses.add(ServerTemplateList.class);
-        modelClasses.add(ContainerSpecList.class);
-
-        modelClasses.add(KieServerControllerServiceResponse.class);
-        modelClasses.add(KieServerControllerDescriptorCommand.class);
-
-        return modelClasses;
-    }
 
     @SuppressWarnings("unchecked")
-    public static <T> T unmarshal(String data, String marshallingFormat, Class<T> unmarshalType) {
+    public static <T> T unmarshal(String data, Class<T> unmarshalType) {
         if (data == null || data.isEmpty()) {
             return null;
         }
-        MarshallingFormat format = getFormat(marshallingFormat);
 
-        Marshaller marshaller = null;
-        switch (format) {
-            case JAXB: {
-                marshaller = jaxbMarshaller;
-                break;
-            }
-            case JSON: {
-                marshaller = jsonMarshaller;
-                break;
-            }
-            default: {
-                marshaller = jsonMarshaller;
-                break;
-            }
-        }
-
-        Object instance = marshaller.unmarshall(data, unmarshalType);
+        Object instance = jsonMarshaller.unmarshall(data, unmarshalType);
 
         if (instance instanceof Wrapped) {
             return (T) ((Wrapped<?>) instance).unwrap();
@@ -97,40 +40,8 @@ public class WebSocketUtils {
         return (T) instance;
     }
 
-    public static String marshal(String marshallingFormat, Object entity) {
-        MarshallingFormat format = getFormat(marshallingFormat);
-
-
-        if (format == null) {
-            throw new IllegalArgumentException("Unknown marshalling format " + marshallingFormat);
-        }
-
-        Marshaller marshaller = null;
-        switch (format) {
-            case JAXB: {
-                marshaller = jaxbMarshaller;
-                break;
-            }
-            case JSON: {
-                marshaller = jsonMarshaller;
-                break;
-            }
-            default: {
-                marshaller = jsonMarshaller;
-                break;
-            }
-        }
-
-        return marshaller.marshall(entity);
-
+    public static String marshal(Object entity) {
+        return jsonMarshaller.marshall(entity);
     }
     
-    public static MarshallingFormat getFormat(String descriptor) {
-        MarshallingFormat format = MarshallingFormat.fromType(descriptor);
-        if (format == null) {
-            format = MarshallingFormat.valueOf(descriptor);
-        }
-
-        return format;
-    }
 }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-websocket-common/src/main/java/org/kie/server/controller/websocket/common/decoder/KieServerControllerDescriptorCommandDecoder.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-websocket-common/src/main/java/org/kie/server/controller/websocket/common/decoder/KieServerControllerDescriptorCommandDecoder.java
@@ -20,7 +20,6 @@ import javax.websocket.DecodeException;
 import javax.websocket.Decoder;
 import javax.websocket.EndpointConfig;
 
-import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.controller.api.commands.KieServerControllerDescriptorCommand;
 import org.kie.server.controller.websocket.common.WebSocketUtils;
 
@@ -29,7 +28,6 @@ public class KieServerControllerDescriptorCommandDecoder implements Decoder.Text
     @Override
     public KieServerControllerDescriptorCommand decode(final String content) throws DecodeException {
         return WebSocketUtils.unmarshal(content,
-                                        MarshallingFormat.JSON.getType(),
                                         KieServerControllerDescriptorCommand.class);
     }
 

--- a/kie-server-parent/kie-server-controller/kie-server-controller-websocket-common/src/main/java/org/kie/server/controller/websocket/common/decoder/KieServerControllerServiceResponseDecoder.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-websocket-common/src/main/java/org/kie/server/controller/websocket/common/decoder/KieServerControllerServiceResponseDecoder.java
@@ -20,7 +20,6 @@ import javax.websocket.DecodeException;
 import javax.websocket.Decoder;
 import javax.websocket.EndpointConfig;
 
-import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.controller.api.model.KieServerControllerServiceResponse;
 import org.kie.server.controller.websocket.common.WebSocketUtils;
 
@@ -29,7 +28,6 @@ public class KieServerControllerServiceResponseDecoder implements Decoder.Text<K
     @Override
     public KieServerControllerServiceResponse decode(final String content) throws DecodeException {
         return WebSocketUtils.unmarshal(content,
-                                        MarshallingFormat.JSON.getType(),
                                         KieServerControllerServiceResponse.class);
     }
 

--- a/kie-server-parent/kie-server-controller/kie-server-controller-websocket-common/src/main/java/org/kie/server/controller/websocket/common/encoder/KieServerControllerDescriptorCommandEncoder.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-websocket-common/src/main/java/org/kie/server/controller/websocket/common/encoder/KieServerControllerDescriptorCommandEncoder.java
@@ -20,7 +20,6 @@ import javax.websocket.EncodeException;
 import javax.websocket.Encoder;
 import javax.websocket.EndpointConfig;
 
-import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.controller.api.commands.KieServerControllerDescriptorCommand;
 import org.kie.server.controller.websocket.common.WebSocketUtils;
 
@@ -28,8 +27,7 @@ public class KieServerControllerDescriptorCommandEncoder implements Encoder.Text
 
     @Override
     public String encode(final KieServerControllerDescriptorCommand command) throws EncodeException {
-        return WebSocketUtils.marshal(MarshallingFormat.JSON.getType(),
-                                      command);
+        return WebSocketUtils.marshal(command);
     }
 
     @Override

--- a/kie-server-parent/kie-server-controller/kie-server-controller-websocket-common/src/main/java/org/kie/server/controller/websocket/common/encoder/KieServerControllerServiceResponseEncoder.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-websocket-common/src/main/java/org/kie/server/controller/websocket/common/encoder/KieServerControllerServiceResponseEncoder.java
@@ -20,7 +20,6 @@ import javax.websocket.EncodeException;
 import javax.websocket.Encoder;
 import javax.websocket.EndpointConfig;
 
-import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.controller.api.model.KieServerControllerServiceResponse;
 import org.kie.server.controller.websocket.common.WebSocketUtils;
 
@@ -28,8 +27,7 @@ public class KieServerControllerServiceResponseEncoder implements Encoder.Text<K
 
     @Override
     public String encode(final KieServerControllerServiceResponse object) throws EncodeException {
-        return WebSocketUtils.marshal(MarshallingFormat.JSON.getType(),
-                                      object);
+        return WebSocketUtils.marshal(object);
     }
 
     @Override

--- a/kie-server-parent/kie-server-controller/kie-server-controller-websocket-common/src/test/java/org/kie/server/controller/websocket/common/WebSocketUtilsTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-websocket-common/src/test/java/org/kie/server/controller/websocket/common/WebSocketUtilsTest.java
@@ -16,13 +16,7 @@
 
 package org.kie.server.controller.websocket.common;
 
-import java.util.Arrays;
-import java.util.Collection;
-
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.KieScannerStatus;
 import org.kie.server.api.model.ReleaseId;
@@ -38,18 +32,9 @@ import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.*;
 
-@RunWith(Parameterized.class)
 public class WebSocketUtilsTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WebSocketUtilsTest.class);
-
-    @Parameterized.Parameter
-    public MarshallingFormat marshallingFormat;
-
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{{MarshallingFormat.JAXB}, {MarshallingFormat.JSON}});
-    }
 
     @Test
     public void testContainerSpecSerialization() {
@@ -70,11 +55,9 @@ public class WebSocketUtilsTest {
                                                      KieScannerStatus.SCANNING);
         spec.addConfig(Capability.RULE,
                        ruleConfig);
-        final String specContent = WebSocketUtils.marshal(marshallingFormat.getType(),
-                                                          spec);
-        LOGGER.info("{} content\n{}", marshallingFormat.getType(), specContent);
+        final String specContent = WebSocketUtils.marshal(spec);
+        LOGGER.info("JSON content\n{}", specContent);
         final ContainerSpec specResult = WebSocketUtils.unmarshal(specContent,
-                                                                  marshallingFormat.getType(),
                                                                   ContainerSpec.class);
 
         assertNotNull(specResult);
@@ -119,11 +102,9 @@ public class WebSocketUtilsTest {
                                                                                                 capability,
                                                                                                 processConfig,
                                                                                                 ruleConfig);
-        final String content = WebSocketUtils.marshal(marshallingFormat.getType(),
-                                                      command);
-        LOGGER.info("{} content\n{}", marshallingFormat.getType(), content);
+        final String content = WebSocketUtils.marshal(command);
+        LOGGER.info("JSON content\n{}", content);
         final KieServerControllerDescriptorCommand commandResult = WebSocketUtils.unmarshal(content,
-                                                                                            marshallingFormat.getType(),
                                                                                             KieServerControllerDescriptorCommand.class);
         assertNotNull(commandResult);
         assertEquals(command.getService(),

--- a/kie-server-parent/kie-server-controller/kie-server-controller-websocket/src/main/java/org/kie/server/controller/websocket/ConnectedKieServerHandler.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-websocket/src/main/java/org/kie/server/controller/websocket/ConnectedKieServerHandler.java
@@ -17,7 +17,6 @@ package org.kie.server.controller.websocket;
 
 import javax.websocket.Session;
 
-import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.KieServerInfo;
 import org.kie.server.controller.api.model.KieServerSetup;
 import org.kie.server.controller.api.model.events.ServerInstanceConnected;
@@ -53,16 +52,14 @@ public class ConnectedKieServerHandler implements InternalMessageHandler {
 
     @Override
     public String onMessage(String message) {
-        String contentType = MarshallingFormat.JSON.getType();
-        
-        serverInfo = WebSocketUtils.unmarshal(message, contentType, KieServerInfo.class);
+        serverInfo = WebSocketUtils.unmarshal(message, KieServerInfo.class);
         manager.addSession(serverInfo, session);
         
         logger.debug("Server info {}", serverInfo);
         KieServerSetup serverSetup = controller.connect(serverInfo);
 
         logger.info("Server with id '{}' connected", serverId);
-        String response = WebSocketUtils.marshal(contentType, serverSetup);
+        String response = WebSocketUtils.marshal(serverSetup);
         
         return response;
     }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-websocket/src/main/java/org/kie/server/controller/websocket/client/WebSocketKieServerClient.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-websocket/src/main/java/org/kie/server/controller/websocket/client/WebSocketKieServerClient.java
@@ -109,9 +109,9 @@ public class WebSocketKieServerClient implements KieServicesClient {
                 @Override
                 public void replaceQuery(QueryDefinition queryDefinition) {
                     CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryDataService", "replaceQuery",
-                                                                                                                                WebSocketUtils.marshal(MarshallingFormat.JSON.toString(), queryDefinition), MarshallingFormat.JSON.toString(), new Object[]{queryDefinition.getName()})));
+                                                                                                                                WebSocketUtils.marshal(queryDefinition), MarshallingFormat.JSON.toString(), new Object[]{queryDefinition.getName()})));
                     sendCommandToAllSessions(script, new WebSocketServiceResponse(true, (message) -> {
-                        WebSocketUtils.unmarshal(message, MarshallingFormat.JSON.getType(), ServiceResponsesList.class);
+                        WebSocketUtils.unmarshal(message, ServiceResponsesList.class);
                         return null;
                     })).getResponses();    
                 }
@@ -348,7 +348,7 @@ public class WebSocketKieServerClient implements KieServicesClient {
         Session session = sessions.get(0);
         
         logger.debug("Web Socket session ({}) is open {}", session.getId(), session.isOpen());
-        String content = WebSocketUtils.marshal(MarshallingFormat.JSON.getType(), script);
+        String content = WebSocketUtils.marshal(script);
         logger.debug("Content to be sent over Web Socket '{}'", content);
         try {
             manager.getHandler(session.getId()).addHandler(response);
@@ -371,7 +371,7 @@ public class WebSocketKieServerClient implements KieServicesClient {
         for (Session session : sessions) {
         
             logger.debug("Web Socket session ({}) is open {}", session.getId(), session.isOpen());
-            String content = WebSocketUtils.marshal(MarshallingFormat.JSON.getType(), script);
+            String content = WebSocketUtils.marshal(script);
             logger.debug("Content to be sent over Web Socket '{}'", content);
             try {
                 manager.getHandler(session.getId()).addHandler(response);
@@ -392,7 +392,7 @@ public class WebSocketKieServerClient implements KieServicesClient {
     public ServiceResponse<KieServerInfo> getServerInfo() {
         CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new GetServerInfoCommand()));
         ServiceResponse<KieServerInfo> response = (ServiceResponse<KieServerInfo>) sendCommand(script, new WebSocketServiceResponse(true, (message) -> {
-            ServiceResponsesList list = WebSocketUtils.unmarshal(message, MarshallingFormat.JSON.getType(), ServiceResponsesList.class);
+            ServiceResponsesList list = WebSocketUtils.unmarshal(message, ServiceResponsesList.class);
             return list.getResponses().get(0);
         })).getResponses().get(0);
         
@@ -409,7 +409,7 @@ public class WebSocketKieServerClient implements KieServicesClient {
     public ServiceResponse<KieContainerResourceList> listContainers(KieContainerResourceFilter containerFilter) {
         CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new ListContainersCommand(containerFilter)));
         ServiceResponse<KieContainerResourceList> response = (ServiceResponse<KieContainerResourceList>) sendCommand(script, new WebSocketServiceResponse(true, (message) -> {
-            ServiceResponsesList list = WebSocketUtils.unmarshal(message, MarshallingFormat.JSON.getType(), ServiceResponsesList.class);
+            ServiceResponsesList list = WebSocketUtils.unmarshal(message, ServiceResponsesList.class);
             return list.getResponses().get(0);
         })).getResponses().get(0);
         
@@ -420,7 +420,7 @@ public class WebSocketKieServerClient implements KieServicesClient {
     public ServiceResponse<KieContainerResource> createContainer(String id, KieContainerResource resource) {
         CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new CreateContainerCommand(resource)));
         ServiceResponse<KieContainerResource> response = (ServiceResponse<KieContainerResource>) sendCommandToAllSessions(script, new WebSocketServiceResponse(true, (message) -> {
-            ServiceResponsesList list = WebSocketUtils.unmarshal(message, MarshallingFormat.JSON.getType(), ServiceResponsesList.class);
+            ServiceResponsesList list = WebSocketUtils.unmarshal(message, ServiceResponsesList.class);
             return list.getResponses().get(0);
         })).getResponses().get(0);
         
@@ -431,7 +431,7 @@ public class WebSocketKieServerClient implements KieServicesClient {
     public ServiceResponse<KieContainerResource> getContainerInfo(String id) {
         CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new GetContainerInfoCommand(id)));
         ServiceResponse<KieContainerResource> response = (ServiceResponse<KieContainerResource>) sendCommand(script, new WebSocketServiceResponse(true, (message) -> {
-            ServiceResponsesList list = WebSocketUtils.unmarshal(message, MarshallingFormat.JSON.getType(), ServiceResponsesList.class);
+            ServiceResponsesList list = WebSocketUtils.unmarshal(message, ServiceResponsesList.class);
             return list.getResponses().get(0);
         })).getResponses().get(0);
         
@@ -442,7 +442,7 @@ public class WebSocketKieServerClient implements KieServicesClient {
     public ServiceResponse<Void> disposeContainer(String id) {
         CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DisposeContainerCommand(id)));
         ServiceResponse<Void> response = (ServiceResponse<Void>) sendCommandToAllSessions(script, new WebSocketServiceResponse(true, (message) -> {
-            ServiceResponsesList list = WebSocketUtils.unmarshal(message, MarshallingFormat.JSON.getType(), ServiceResponsesList.class);
+            ServiceResponsesList list = WebSocketUtils.unmarshal(message, ServiceResponsesList.class);
             return list.getResponses().get(0);
         })).getResponses().get(0);
         
@@ -458,7 +458,7 @@ public class WebSocketKieServerClient implements KieServicesClient {
     public ServiceResponse<KieScannerResource> getScannerInfo(String id) {
         CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new GetScannerInfoCommand(id)));
         ServiceResponse<KieScannerResource> response = (ServiceResponse<KieScannerResource>) sendCommand(script, new WebSocketServiceResponse(true, (message) -> {
-            ServiceResponsesList list = WebSocketUtils.unmarshal(message, MarshallingFormat.JSON.getType(), ServiceResponsesList.class);
+            ServiceResponsesList list = WebSocketUtils.unmarshal(message, ServiceResponsesList.class);
             return list.getResponses().get(0);
         })).getResponses().get(0);
         
@@ -469,7 +469,7 @@ public class WebSocketKieServerClient implements KieServicesClient {
     public ServiceResponse<KieScannerResource> updateScanner(String id, KieScannerResource resource) {
         CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new UpdateScannerCommand(id, resource)));
         ServiceResponse<KieScannerResource> response = (ServiceResponse<KieScannerResource>) sendCommandToAllSessions(script, new WebSocketServiceResponse(true, (message) -> {
-            ServiceResponsesList list = WebSocketUtils.unmarshal(message, MarshallingFormat.JSON.getType(), ServiceResponsesList.class);
+            ServiceResponsesList list = WebSocketUtils.unmarshal(message, ServiceResponsesList.class);
             return list.getResponses().get(0);
         })).getResponses().get(0);
         
@@ -480,7 +480,7 @@ public class WebSocketKieServerClient implements KieServicesClient {
     public ServiceResponse<ReleaseId> getReleaseId(String containerId) {
         CommandScript script = new CommandScript(Collections.singletonList(new GetReleaseIdCommand(containerId)));
         ServiceResponse<ReleaseId> response = (ServiceResponse<ReleaseId>) sendCommand(script, new WebSocketServiceResponse(true, (message) -> {
-            ServiceResponsesList list = WebSocketUtils.unmarshal(message, MarshallingFormat.JSON.getType(), ServiceResponsesList.class);
+            ServiceResponsesList list = WebSocketUtils.unmarshal(message, ServiceResponsesList.class);
             return list.getResponses().get(0);
         })).getResponses().get(0);
         
@@ -491,7 +491,7 @@ public class WebSocketKieServerClient implements KieServicesClient {
     public ServiceResponse<ReleaseId> updateReleaseId(String id, ReleaseId releaseId) {
         CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new UpdateReleaseIdCommand(id, releaseId)));
         ServiceResponse<ReleaseId> response = (ServiceResponse<ReleaseId>) sendCommandToAllSessions(script, new WebSocketServiceResponse(true, (message) -> {
-            ServiceResponsesList list = WebSocketUtils.unmarshal(message, MarshallingFormat.JSON.getType(), ServiceResponsesList.class);
+            ServiceResponsesList list = WebSocketUtils.unmarshal(message, ServiceResponsesList.class);
             return list.getResponses().get(0);
         })).getResponses().get(0);
         
@@ -502,7 +502,7 @@ public class WebSocketKieServerClient implements KieServicesClient {
     public ServiceResponse<KieServerStateInfo> getServerState() {
         CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new GetServerStateCommand()));
         ServiceResponse<KieServerStateInfo> response = (ServiceResponse<KieServerStateInfo>) sendCommand(script, new WebSocketServiceResponse(true, (message) -> {
-            ServiceResponsesList list = WebSocketUtils.unmarshal(message, MarshallingFormat.JSON.getType(), ServiceResponsesList.class);
+            ServiceResponsesList list = WebSocketUtils.unmarshal(message, ServiceResponsesList.class);
             return list.getResponses().get(0);
         })).getResponses().get(0);
         

--- a/kie-server-parent/kie-server-controller/kie-server-controller-websocket/src/test/java/org/kie/server/controller/websocket/management/KieServerMgmtCommandServiceImplTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-websocket/src/test/java/org/kie/server/controller/websocket/management/KieServerMgmtCommandServiceImplTest.java
@@ -16,13 +16,7 @@
 
 package org.kie.server.controller.websocket.management;
 
-import java.util.Arrays;
-import java.util.Collection;
-
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.controller.api.commands.KieServerControllerDescriptorCommand;
 import org.kie.server.controller.api.model.KieServerControllerServiceResponse;
@@ -37,7 +31,6 @@ import static org.junit.Assert.*;
 import static org.kie.server.api.model.KieServiceResponse.ResponseType.FAILURE;
 import static org.kie.server.api.model.KieServiceResponse.ResponseType.SUCCESS;
 
-@RunWith(Parameterized.class)
 public class KieServerMgmtCommandServiceImplTest {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(KieServerMgmtCommandServiceImplTest.class);
@@ -47,14 +40,6 @@ public class KieServerMgmtCommandServiceImplTest {
     private static final String CONTAINER_SPEC_NAME = "specName";
 
     private KieServerMgmtCommandService service = KieServerMgmtCommandServiceImpl.getInstance();
-
-    @Parameterized.Parameter
-    public MarshallingFormat marshallingFormat;
-
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][]{{MarshallingFormat.JAXB}, {MarshallingFormat.JSON}});
-    }
 
     @Test
     public void testNullCommandScript() {
@@ -105,12 +90,10 @@ public class KieServerMgmtCommandServiceImplTest {
                                                                                                 "saveServerTemplate",
                                                                                                 serverTemplate);
 
-        final String content = WebSocketUtils.marshal(marshallingFormat.getType(),
-                                                      command);
+        final String content = WebSocketUtils.marshal(command);
 
-        LOGGER.info("{} content\n{}", marshallingFormat.getType(), content);
+        LOGGER.info("JSON content\n{}", content);
         KieServerControllerServiceResponse response = service.executeCommand(WebSocketUtils.unmarshal(content,
-                                                                                                      marshallingFormat.getType(),
                                                                                                       KieServerControllerDescriptorCommand.class));
 
         assertNotNull(response);
@@ -132,10 +115,8 @@ public class KieServerMgmtCommandServiceImplTest {
         assertEquals(serverTemplate,
                      response.getResult());
 
-        String responseContent = WebSocketUtils.marshal(marshallingFormat.getType(),
-                                                        response);
+        String responseContent = WebSocketUtils.marshal(response);
         response = WebSocketUtils.unmarshal(responseContent,
-                                            marshallingFormat.getType(),
                                             KieServerControllerServiceResponse.class);
         assertNotNull(response);
         assertEquals(SUCCESS,
@@ -156,11 +137,9 @@ public class KieServerMgmtCommandServiceImplTest {
                                                                                                 null,
                                                                                                 "templateId",
                                                                                                 containerSpec);
-        final String content = WebSocketUtils.marshal(marshallingFormat.getType(),
-                                                      command);
-        LOGGER.info("{} content\n{}", marshallingFormat.getType(), content);
+        final String content = WebSocketUtils.marshal(command);
+        LOGGER.info("JSON content\n{}", content);
         KieServerControllerServiceResponse response = service.executeCommand(WebSocketUtils.unmarshal(content,
-                                                                                                      marshallingFormat.getType(),
                                                                                                       KieServerControllerDescriptorCommand.class));
 
         assertNotNull(response);
@@ -183,11 +162,9 @@ public class KieServerMgmtCommandServiceImplTest {
                                                                                                 "upgradeContainer",
                                                                                                 serverTemplate,
                                                                                                 releaseId);
-        final String content = WebSocketUtils.marshal(marshallingFormat.getType(),
-                                                      command);
-        LOGGER.info("{} content\n{}", marshallingFormat.getType(), content);
+        final String content = WebSocketUtils.marshal(command);
+        LOGGER.info("JSON content\n{}", content);
         KieServerControllerServiceResponse response = service.executeCommand(WebSocketUtils.unmarshal(content,
-                                                                                                      marshallingFormat.getType(),
                                                                                                       KieServerControllerDescriptorCommand.class));
 
         assertNotNull(response);
@@ -207,11 +184,9 @@ public class KieServerMgmtCommandServiceImplTest {
                                                                                                 "containerSpecId",
                                                                                                 Capability.PROCESS,
                                                                                                 new ProcessConfig());
-        final String content = WebSocketUtils.marshal(marshallingFormat.getType(),
-                                                      command);
-        LOGGER.info("{} content\n{}", marshallingFormat.getType(), content);
+        final String content = WebSocketUtils.marshal(command);
+        LOGGER.info("JSON content\n{}", content);
         KieServerControllerServiceResponse response = service.executeCommand(WebSocketUtils.unmarshal(content,
-                                                                                                      marshallingFormat.getType(),
                                                                                                       KieServerControllerDescriptorCommand.class));
 
         assertNotNull(response);


### PR DESCRIPTION
Removing JAXB support as JSON is always used.