### PR TITLE
fix for JBPM-4531 - Upgrade Quartz to Version 2.x

### DIFF
--- a/droolsjbpm-bpms-distribution/pom.xml
+++ b/droolsjbpm-bpms-distribution/pom.xml
@@ -264,14 +264,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.quartz-scheduler</groupId>
-      <artifactId>quartz-oracle</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.quartz-scheduler</groupId>
-      <artifactId>quartz-weblogic</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.spec.javax.security.jacc</groupId>
       <artifactId>jboss-jacc-api_1.5_spec</artifactId>
     </dependency>


### PR DESCRIPTION
quartz-oracle and quartz-weblogic are included now in quartz artifact per https://jira.terracotta.org/jira/browse/QTZ-396