### PR TITLE
[7.5.x] RHDM-232 - ClassNotFoundException when invoking image related operation, RHDM-226 - Print request payload into the log 

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-drools/src/main/java/org/kie/server/remote/rest/drools/CommandResource.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-drools/src/main/java/org/kie/server/remote/rest/drools/CommandResource.java
@@ -82,7 +82,7 @@ public class CommandResource {
         if (format == null) {
             format = MarshallingFormat.valueOf(contentType);
         }
-
+        logger.debug("Received request with content '{}'", cmdPayload);
         Object result = delegate.callContainer(id, cmdPayload, format, classType);
         Header conversationIdHeader = buildConversationIdHeader(id, registry, headers);
         try {

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee7-container.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee7-container.xml
@@ -81,6 +81,8 @@
         <include>org.quartz-scheduler:quartz</include>
 
         <include>com.google.inject.extensions:guice-servlet</include>
+        
+        <include>xerces:xercesImpl</include>
       </includes>
       <excludes>
         <exclude>org.jboss.resteasy:*</exclude>


### PR DESCRIPTION
@sutaakar here is back port of #1327 

@etirelli it includes another jira that just adds logging of payload for rules execution that was requested by CEE. I believe it's worth adding to RHDM 7