### PR TITLE
JBPM-6740 - Expose readiness and liveness checks in KIE Server

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/resource/KieServerRestImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/resource/KieServerRestImpl.java
@@ -18,9 +18,13 @@ package org.kie.server.remote.rest.common.resource;
 import static org.kie.server.remote.rest.common.util.RestUtils.buildConversationIdHeader;
 import static org.kie.server.remote.rest.common.util.RestUtils.createCorrectVariant;
 import static org.kie.server.remote.rest.common.util.RestUtils.getContentType;
+import static org.kie.server.remote.rest.common.util.RestUtils.serviceUnavailable;
+
+import java.util.List;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
@@ -38,9 +42,11 @@ import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieContainerResourceFilter;
 import org.kie.server.api.model.KieContainerStatusFilter;
 import org.kie.server.api.model.KieScannerResource;
+import org.kie.server.api.model.Message;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ReleaseIdFilter;
 import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.api.model.Severity;
 import org.kie.server.remote.rest.common.Header;
 import org.kie.server.services.impl.KieServerImpl;
 import org.kie.server.services.impl.KieServerLocator;
@@ -224,6 +230,45 @@ public class KieServerRestImpl {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     public Response getServerState(@Context HttpHeaders headers) {
         return createCorrectVariant(server.getServerState(), headers);
+    }
+    
+    
+    
+    @ApiOperation(value="Readiness check for KIE Server that indicates that server is fully booted and ready to accept requests",
+            response=Void.class, code=200)
+    @ApiResponses(value = { @ApiResponse(code = 503, message = "Service not yet available") })
+    @GET
+    @Path("readycheck")
+    @Produces({MediaType.TEXT_PLAIN})
+    public Response readycheck(@Context HttpHeaders headers) { 
+        if (server.isKieServerReady()) {
+            return Response.status(Response.Status.OK).build();
+        }
+        return serviceUnavailable();
+    }
+    
+    @ApiOperation(value="Liveness check for KIE Server that validates both kie server and all extensions, optionally produces report",
+            response=Message.class, code=200, responseContainer="List")
+    @ApiResponses(value = { @ApiResponse(code = 503, message = "If any of the checks failed") })
+    @GET
+    @Path("healthcheck")
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public Response healthcheck(@Context HttpHeaders headers,
+                             @ApiParam(value = "optional report flag to return detailed report of the check, defaults to false", required = false) @QueryParam("report")  @DefaultValue("false") boolean report) { 
+        List<Message> healthMessages = server.healthCheck(report);
+        
+        boolean anyfailures = healthMessages.stream().anyMatch(msg -> msg.getSeverity().equals(Severity.ERROR));
+        if (anyfailures) {
+            if (report) {
+                return createCorrectVariant(healthMessages, headers, Response.Status.SERVICE_UNAVAILABLE);
+            }
+            
+            return serviceUnavailable();
+        }
+        if (report) {
+            return createCorrectVariant(healthMessages, headers, Response.Status.OK);
+        }
+        return Response.status(Response.Status.OK).build();
     }
 
 }

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/util/RestUtils.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/util/RestUtils.java
@@ -176,6 +176,10 @@ public class RestUtils {
     public static Response noContent(Variant v, Header... customHeaders) {
         return createResponse("", v, Response.Status.NO_CONTENT, customHeaders);
     }
+    
+    public static Response serviceUnavailable(Header... customHeaders) {
+        return createResponse("", ERROR_VARIANT, Response.Status.SERVICE_UNAVAILABLE, customHeaders);
+    }
 
     protected static void applyCustomHeaders(Response.ResponseBuilder builder, Header... customHeaders) {
         if (customHeaders != null && customHeaders.length > 0) {

--- a/kie-server-parent/kie-server-services/kie-server-services-case-mgmt/src/main/java/org/kie/server/services/casemgmt/CaseKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-case-mgmt/src/main/java/org/kie/server/services/casemgmt/CaseKieServerExtension.java
@@ -20,24 +20,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 
-import org.jbpm.casemgmt.api.CaseRuntimeDataService;
 import org.jbpm.casemgmt.api.generator.CaseIdGenerator;
 import org.jbpm.casemgmt.impl.AuthorizationManagerImpl;
 import org.jbpm.casemgmt.impl.CaseRuntimeDataServiceImpl;
 import org.jbpm.casemgmt.impl.CaseServiceImpl;
 import org.jbpm.casemgmt.impl.event.CaseConfigurationDeploymentListener;
-import org.jbpm.casemgmt.impl.generator.InMemoryCaseIdGenerator;
 import org.jbpm.casemgmt.impl.generator.TableCaseIdGenerator;
-import org.jbpm.kie.services.impl.FormManagerService;
 import org.jbpm.kie.services.impl.KModuleDeploymentService;
 import org.jbpm.runtime.manager.impl.jpa.EntityManagerFactoryManager;
-import org.jbpm.services.api.DefinitionService;
 import org.jbpm.services.api.DeploymentService;
 import org.jbpm.services.api.ProcessService;
 import org.jbpm.services.api.RuntimeDataService;
-import org.jbpm.services.api.UserTaskService;
 import org.jbpm.shared.services.impl.TransactionalCommandService;
 import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.model.Message;
+import org.kie.server.api.model.Severity;
 import org.kie.server.services.api.KieContainerCommandService;
 import org.kie.server.services.api.KieContainerInstance;
 import org.kie.server.services.api.KieServerApplicationComponentsService;
@@ -256,5 +253,16 @@ public class CaseKieServerExtension implements KieServerExtension {
     @Override
     public String toString() {
         return EXTENSION_NAME + " KIE Server extension";
+    }
+    
+
+    @Override
+    public List<Message> healthCheck(boolean report) {
+        List<Message> messages = KieServerExtension.super.healthCheck(report);
+        
+        if (report) {
+            messages.add(new Message(Severity.INFO, getExtensionName() + " is alive"));
+        }        
+        return messages;
     }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
@@ -145,6 +145,11 @@
       <artifactId>xstream</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
     <!-- log -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieServerExtension.java
@@ -15,9 +15,12 @@
 
 package org.kie.server.services.api;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.kie.server.api.model.Message;
+import org.kie.server.api.model.Severity;
 import org.kie.server.services.impl.KieServerImpl;
 
 public interface KieServerExtension {
@@ -49,4 +52,13 @@ public interface KieServerExtension {
     String getExtensionName();
 
     Integer getStartOrder();
+    
+    default List<Message> healthCheck(boolean report) {
+        List<Message> messages = new ArrayList<>();
+        if (!isInitialized()) {
+            messages.add(new Message(Severity.ERROR, getExtensionName() + " failed to start"));
+        }
+        
+        return messages;
+    }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/ContainerManager.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/ContainerManager.java
@@ -36,6 +36,7 @@ public class ContainerManager {
     public void installContainersSync(KieServerImpl kieServer, Set<KieContainerResource> containers, KieServerState currentState, KieServerSetup kieServerSetup) {
         logger.info("About to install containers '{}' on kie server '{}'", containers, kieServer);
         if (containers == null) {
+            kieServer.markAsReady();
             return;
         }
         for (KieContainerResource containerResource : containers) {
@@ -48,5 +49,6 @@ public class ContainerManager {
             currentState.setConfiguration(kieServerSetup.getServerConfig());
         }
         kieServer.getServerRegistry().getStateRepository().store(KieServerEnvironment.getServerId(), currentState);
+        kieServer.markAsReady();
     }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-dmn/src/main/java/org/kie/server/services/dmn/DMNKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-dmn/src/main/java/org/kie/server/services/dmn/DMNKieServerExtension.java
@@ -16,6 +16,8 @@
 package org.kie.server.services.dmn;
 
 import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.model.Message;
+import org.kie.server.api.model.Severity;
 import org.kie.server.services.api.*;
 import org.kie.server.services.impl.KieServerImpl;
 import org.slf4j.Logger;
@@ -144,4 +146,13 @@ public class DMNKieServerExtension
         return EXTENSION_NAME + " KIE Server extension";
     }
 
+    @Override
+    public List<Message> healthCheck(boolean report) {
+        List<Message> messages = KieServerExtension.super.healthCheck(report);
+        
+        if (report) {
+            messages.add(new Message(Severity.INFO, getExtensionName() + " is alive"));
+        }        
+        return messages;
+    }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-drools/src/main/java/org/kie/server/services/drools/DroolsKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-drools/src/main/java/org/kie/server/services/drools/DroolsKieServerExtension.java
@@ -23,12 +23,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
+
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 import org.kie.api.remote.Remotable;
 import org.kie.scanner.KieModuleMetaData;
 import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.model.Message;
+import org.kie.server.api.model.Severity;
 import org.kie.server.services.api.KieContainerCommandService;
 import org.kie.server.services.api.KieContainerInstance;
 import org.kie.server.services.api.KieServerApplicationComponentsService;
@@ -229,5 +232,16 @@ public class DroolsKieServerExtension implements KieServerExtension {
         } else {
             extraClasses.add(classToAdd);
         }
+    }
+    
+
+    @Override
+    public List<Message> healthCheck(boolean report) {
+        List<Message> messages = KieServerExtension.super.healthCheck(report);
+        
+        if (report) {
+            messages.add(new Message(Severity.INFO, getExtensionName() + " is alive"));
+        }        
+        return messages;
     }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/JBPMUIKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/JBPMUIKieServerExtension.java
@@ -241,4 +241,13 @@ public class JBPMUIKieServerExtension implements KieServerExtension {
         return EXTENSION_NAME + " KIE Server extension";
     }
 
+    @Override
+    public List<Message> healthCheck(boolean report) {
+        List<Message> messages = KieServerExtension.super.healthCheck(report);
+        
+        if (report) {
+            messages.add(new Message(Severity.INFO, getExtensionName() + " is alive"));
+        }        
+        return messages;
+    }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
@@ -766,4 +766,22 @@ public class JbpmKieServerExtension implements KieServerExtension {
         this.context = context;
     }
 
+    @Override
+    public List<Message> healthCheck(boolean report) {
+        List<Message> messages = KieServerExtension.super.healthCheck(report);
+        
+        try {
+            // run base query to make sure data access layer is available
+            runtimeDataService.getProcessInstanceById(-99999);
+            if (report) {
+                messages.add(new Message(Severity.INFO, getExtensionName() + " is alive"));
+            }
+        } catch (Exception e) {
+            messages.add(new Message(Severity.ERROR, getExtensionName() + " failed due to " + e.getMessage()));
+        }
+        
+        return messages;
+    }
+
+    
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-optaplanner/src/main/java/org/kie/server/services/optaplanner/OptaplannerKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-optaplanner/src/main/java/org/kie/server/services/optaplanner/OptaplannerKieServerExtension.java
@@ -25,6 +25,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.model.Message;
+import org.kie.server.api.model.Severity;
 import org.kie.server.services.api.KieContainerInstance;
 import org.kie.server.services.api.KieServerApplicationComponentsService;
 import org.kie.server.services.api.KieServerExtension;
@@ -174,4 +176,19 @@ public class OptaplannerKieServerExtension
         return EXTENSION_NAME + " KIE Server extension";
     }
 
+
+    @Override
+    public List<Message> healthCheck(boolean report) {
+        List<Message> messages = KieServerExtension.super.healthCheck(report);
+        
+        if (this.threadPool.isTerminated() && this.initialized) {
+            messages.add(new Message(Severity.ERROR, getExtensionName() + " failed due to thread pool is terminated while the extension is still alive"));
+        } else {
+            
+            if (report) {
+                messages.add(new Message(Severity.INFO, getExtensionName() + " is alive"));
+            }       
+        }
+        return messages;
+    }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-swagger/src/main/java/org/kie/server/services/swagger/SwaggerKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-swagger/src/main/java/org/kie/server/services/swagger/SwaggerKieServerExtension.java
@@ -22,6 +22,8 @@ import java.util.ServiceLoader;
 
 import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.KieServerEnvironment;
+import org.kie.server.api.model.Message;
+import org.kie.server.api.model.Severity;
 import org.kie.server.services.api.KieContainerInstance;
 import org.kie.server.services.api.KieServerApplicationComponentsService;
 import org.kie.server.services.api.KieServerExtension;
@@ -157,4 +159,13 @@ public class SwaggerKieServerExtension implements KieServerExtension {
         return EXTENSION_NAME + " KIE Server extension";
     }
    
+    @Override
+    public List<Message> healthCheck(boolean report) {
+        List<Message> messages = KieServerExtension.super.healthCheck(report);
+        
+        if (report) {
+            messages.add(new Message(Severity.INFO, getExtensionName() + " is alive"));
+        }        
+        return messages;
+    }
 }


### PR DESCRIPTION
@etirelli @ge0ffrey @tarilabs @sutaakar 

here is the implementation that aims at providing basic readiness and liveness checks for KIE Server and all extensions activated. 
In general: 
- readiness will either respond with 200 (OK) when it's actually ready or with 503 (Service Unavailable) when it's still booting/deploying containers/waiting for controller.
- liveness (aka health check) will perform following:
    - will check readiness
    - will check for failed kie containers
    - will ask each active extension to health check itself
response codes for health check are same as for readiness. Meaning that any error found will result in response 503, regardless if that is failed container, failed extension or not ready yet

Health check can be invoked in two modes: 
- basic - that will return status only 200 or 503
- report - will respond with both status and report in response body that will provide info like below (body can be XML or JSON)

Now I did implement some checks in extensions but not sure if the make sense or more stuff should be added or not. So please take a moment and let me know what you would like to health check in extension you deal with.

```
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<list-type>
    <items>
        <items xsi:type="kie-message" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
            <content>KIE Server 'managed-server' is ready to serve requests true</content>
            <content>Server is up for 0 days, 0 hours, 2 minutes, 31 seconds</content>
            <severity>INFO</severity>
            <timestamp>2018-01-12T10:40:34.375+01:00</timestamp>
        </items>
        <items xsi:type="kie-message" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
            <content>Drools is alive</content>
            <severity>INFO</severity>
            <timestamp>2018-01-12T10:40:34.375+01:00</timestamp>
        </items>
        <items xsi:type="kie-message" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
            <content>jBPM is alive</content>
            <severity>INFO</severity>
            <timestamp>2018-01-12T10:40:34.378+01:00</timestamp>
        </items>
        <items xsi:type="kie-message" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
            <content>Case-Mgmt is alive</content>
            <severity>INFO</severity>
            <timestamp>2018-01-12T10:40:34.378+01:00</timestamp>
        </items>
        <items xsi:type="kie-message" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
            <content>jBPM-UI is alive</content>
            <severity>INFO</severity>
            <timestamp>2018-01-12T10:40:34.378+01:00</timestamp>
        </items>
        <items xsi:type="kie-message" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
            <content>OptaPlanner is alive</content>
            <severity>INFO</severity>
            <timestamp>2018-01-12T10:40:34.378+01:00</timestamp>
        </items>
        <items xsi:type="kie-message" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
            <content>DMN is alive</content>
            <severity>INFO</severity>
            <timestamp>2018-01-12T10:40:34.378+01:00</timestamp>
        </items>
        <items xsi:type="kie-message" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
            <content>Swagger is alive</content>
            <severity>INFO</severity>
            <timestamp>2018-01-12T10:40:34.378+01:00</timestamp>
        </items>
        <items xsi:type="kie-message" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
            <content>Health check done in 3 ms</content>
            <severity>INFO</severity>
            <timestamp>2018-01-12T10:40:34.378+01:00</timestamp>
        </items>
    </items>
</list-type>
```

