### PR TITLE
Add wildfly10 integration test profile

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerExecutor.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerExecutor.java
@@ -42,12 +42,16 @@ public class KieServerExecutor {
     private static SimpleDateFormat serverIdSuffixDateFormat = new SimpleDateFormat("yyyy-MM-DD-HHmmss_SSS");
 
     public void startKieServer() {
+        startKieServer(false);
+    }
+
+    public void startKieServer(boolean syncWithController) {
         if (server != null) {
             throw new RuntimeException("Kie execution server is already created!");
         }
 
         registerKieServerId();
-        setKieServerProperties();
+        setKieServerProperties(syncWithController);
         
 
         server = new TJWSEmbeddedJaxrsServer();
@@ -56,7 +60,7 @@ public class KieServerExecutor {
 
         addServerSingletonResources();
     }
-    protected void setKieServerProperties() {
+    protected void setKieServerProperties(boolean syncWithController) {
         System.setProperty(KieServerConstants.CFG_BYPASS_AUTH_USER, "true");
         System.setProperty(KieServerConstants.CFG_HT_CALLBACK, "custom");
         System.setProperty(KieServerConstants.CFG_HT_CALLBACK_CLASS, "org.kie.server.integrationtests.jbpm.util.FixedUserGroupCallbackImpl");
@@ -67,6 +71,7 @@ public class KieServerExecutor {
         System.setProperty(KieServerConstants.CFG_KIE_CONTROLLER_PASSWORD, TestConfig.getPassword());
         System.setProperty(KieServerConstants.KIE_SERVER_LOCATION, TestConfig.getEmbeddedKieServerHttpUrl());
         System.setProperty(KieServerConstants.KIE_SERVER_STATE_REPO, "./target");
+        System.setProperty(KieServerConstants.CFG_SYNC_DEPLOYMENT, Boolean.toString(syncWithController));
 
         // kie server policy settings
         System.setProperty(KieServerConstants.KIE_SERVER_ACTIVATE_POLICIES, "KeepLatestOnly");

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/WebSocketKieControllerStartupIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/WebSocketKieControllerStartupIntegrationTest.java
@@ -81,8 +81,8 @@ public class WebSocketKieControllerStartupIntegrationTest extends KieControllerM
             server = new KieServerExecutor() {
                 
                 @Override
-                protected void setKieServerProperties() {
-                    super.setKieServerProperties();
+                protected void setKieServerProperties(boolean syncWithController) {
+                    super.setKieServerProperties(syncWithController);
                     URL controllerUrl;
                     try {
                         origControllerUrl = System.getProperty(KieServerConstants.KIE_SERVER_CONTROLLER);
@@ -206,7 +206,7 @@ public class WebSocketKieControllerStartupIntegrationTest extends KieControllerM
 
         mgmtControllerClient.startContainer(containerSpec);
 
-        server.startKieServer();
+        server.startKieServer(true);
 
         // Check that container is deployed on kie server.
         ServiceResponse<KieContainerResource> containerInfo = client.getContainerInfo(CONTAINER_ID);
@@ -258,7 +258,7 @@ public class WebSocketKieControllerStartupIntegrationTest extends KieControllerM
         ContainerSpecList containerList = mgmtControllerClient.listContainerSpec(serverTemplate.getId());
         KieServerAssert.assertNullOrEmpty("Active containers spec found!", containerList.getContainerSpecs());
 
-        server.startKieServer();
+        server.startKieServer(true);
 
         // Check that no container is deployed on kie server.
         containersList = client.listContainers();

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
@@ -57,7 +57,7 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
 
     private static final String CONTAINER_ID = "query-definition-project";
 
-    private static final long EXTENDED_TIMEOUT = 300000;
+    private static final long EXTENDED_TIMEOUT = 600000;
 
     @BeforeClass
     public static void buildAndDeployArtifacts() {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/JbpmRestIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/JbpmRestIntegrationTest.java
@@ -293,11 +293,11 @@ public class JbpmRestIntegrationTest extends RestJbpmBaseIntegrationTest {
             clientRequest = newRequest(build(TestConfig.getKieServerHttpUrl(), DOCUMENT_URI +"/"+ DOCUMENT_INSTANCE_GET_URI, valuesMap));
             logger.info( "[GET] " + clientRequest.getUri());
             response = clientRequest.request(getMediaType()).get();
-            Assert.assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
-            Assert.assertEquals(MediaType.TEXT_PLAIN, response.getHeaders().getFirst("Content-Type"));
+            Assertions.assertThat(response.getStatus()).isEqualTo(Response.Status.NOT_FOUND.getStatusCode());
+            Assertions.assertThat((String)response.getHeaders().getFirst("Content-Type")).startsWith(MediaType.TEXT_PLAIN);
             
             String responseBody = response.readEntity(String.class);
-            Assert.assertEquals( "\"Document with id not-existing-doc not found\"", responseBody);
+            Assertions.assertThat(responseBody).isEqualTo("\"Document with id not-existing-doc not found\"");
            
 
         } finally {

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -492,6 +492,8 @@
         <kie.server.context.factory>org.jboss.naming.remote.client.InitialContextFactory</kie.server.context.factory>
         <org.kie.server.persistence.ds>java:jboss/datasources/ExampleDS</org.kie.server.persistence.ds>
         <cargo.container.id>wildfly10x</cargo.container.id>
+        <!-- Excluded due to Cargo bug. -->
+        <failsafe.excluded.groups>org.kie.server.integrationtests.category.RemotelyControlled</failsafe.excluded.groups>
       </properties>
       <build>
         <pluginManagement>

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -486,6 +486,86 @@
       </dependencies>
     </profile>    
     <profile>
+      <id>wildfly10</id>
+      <properties>
+        <kie.server.remoting.url>http-remoting://${container.hostname}:${container.port}</kie.server.remoting.url>
+        <kie.server.context.factory>org.jboss.naming.remote.client.InitialContextFactory</kie.server.context.factory>
+        <org.kie.server.persistence.ds>java:jboss/datasources/ExampleDS</org.kie.server.persistence.ds>
+        <cargo.container.id>wildfly10x</cargo.container.id>
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.codehaus.cargo</groupId>
+              <artifactId>cargo-maven2-plugin</artifactId>
+              <configuration>
+                <container>
+                  <type>installed</type>
+                  <artifactInstaller>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-dist</artifactId>
+                    <version>${version.wildfly11}</version>
+                  </artifactInstaller>
+                  <systemProperties>
+                    <!-- disable JMS support for executor to use same tests for all containers for jbpm executor -->
+                    <org.kie.executor.jms>false</org.kie.executor.jms>
+                    <org.kie.server.sync.deploy>true</org.kie.server.sync.deploy>
+                    <org.kie.mail.session>java:/mail/Session</org.kie.mail.session>
+                  </systemProperties>
+                </container>
+                <configuration>
+                  <properties>
+                    <cargo.jboss.configuration>standalone-full</cargo.jboss.configuration>
+                    <cargo.jvmargs>-Xmx1024m</cargo.jvmargs>
+                    <cargo.resource.resource.mail>
+                       cargo.resource.name=mail/Session|
+                       cargo.resource.type=javax.mail.Session|
+                       cargo.resource.id=mail|
+                       cargo.resource.parameters=mail.smtp.host=localhost;mail.smtp.port=2525;mail.smtp.from=kie-server-test@domain.com
+                    </cargo.resource.resource.mail>
+                  </properties>
+                </configuration>
+              </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-failsafe-plugin</artifactId>
+              <configuration>
+                <systemPropertyVariables>
+                  <!-- Reuse yoda user for deploying and undeploying Kie server from within the test -->
+                  <cargo.remote.username>yoda</cargo.remote.username>
+                  <cargo.remote.password>usetheforce123@</cargo.remote.password>
+                </systemPropertyVariables>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+      <dependencyManagement>
+        <dependencies>
+          <!-- This is far from ideal, as it is not designed as BOM. However, 
+            there is nothing like wildfly-bom, so this is the closest thing I could find. 
+            Important: this overrides lots of the versions coming from kie-p-w-d -->
+          <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-parent</artifactId>
+            <version>${version.wildfly11}</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.wildfly</groupId>
+          <artifactId>wildfly-jms-client-bom</artifactId>
+          <type>pom</type>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>wildfly11</id>
       <properties>        
         <kie.server.remoting.url>http-remoting://${container.hostname}:${container.port}</kie.server.remoting.url>


### PR DESCRIPTION
Contains same config as wildfly11. Used for reactivation of PR builder tests.