### PR TITLE
Fix code replacement so that it doesn't result in dirty working tree

### DIFF
--- a/kie-spring/pom.xml
+++ b/kie-spring/pom.xml
@@ -330,34 +330,46 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>com.google.code.maven-replacer-plugin</groupId>
-        <artifactId>replacer</artifactId>
+        <artifactId>maven-resources-plugin</artifactId>
         <executions>
           <execution>
-            <phase>generate-sources</phase>
+            <id>copy-resources</id>
+            <phase>generate-test-sources</phase>
             <goals>
-              <goal>replace</goal>
+              <goal>copy-resources</goal>
             </goals>
+            <configuration>
+              <outputDirectory>${basedir}/target/generated-test-sources</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/test/filtered-resources</directory>
+                  <includes>
+                    <include>org/kie/spring/CodeVersion.java</include>
+                  </includes>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
           </execution>
         </executions>
-        <configuration>
-          <basedir>${basedir}/src/test</basedir>
-          <includes>
-            <include>java/org/kie/spring/CodeVersion.java</include>
-            <include>resources/org/kie/spring/kie-import-releaseid.xml</include>
-          </includes>
-          <regex>true</regex>
-          <replacements>
-            <replacement>
-              <token>public final static String VERSION = ".*</token>
-              <value>public final static String VERSION = "${project.version}";</value>
-            </replacement>
-            <replacement>
-              <token>artifactId="named-kiesession" version=".*</token>
-              <value>artifactId="named-kiesession" version="${project.version}"/></value>
-            </replacement>
-          </replacements>
-        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-test-source</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${basedir}/target/generated-test-sources</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/kie-spring/src/test/filtered-resources/org/kie/spring/CodeVersion.java
+++ b/kie-spring/src/test/filtered-resources/org/kie/spring/CodeVersion.java
@@ -3,7 +3,8 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ * You may obtain a copy of the License at
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -11,13 +12,15 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.kie.spring;
 
 public class CodeVersion {
 
-    // Do not modify this: this is automatically incremented by the maven replacer plugin
-    public final static String VERSION = "7.6.0-SNAPSHOT";
+    // Do not modify this: this is automatically replaced by Resources Plugin and copied
+    // to target/generated-test-sources. The generated-test-sources directory is then added to the project with
+    // Build Helper plugin, which results in compiling the source file to test-classes.
+    public final static String VERSION = "${project.version}";
 
 }


### PR DESCRIPTION
Previously, the version update in `CodeVersion.java` was done directly in the tracked file. This resulted in a dirty working tree after `mvn clean install`, which made it difficult to automate local "full downstream" builds.