### PR TITLE
JBPM-6142: Removed unused constant.

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
@@ -113,7 +113,6 @@ public class KieServerConstants {
     public static final String CAPABILITY_BRP = "BRP"; // Business Resource Planning
     public static final String CAPABILITY_CASE = "CaseMgmt"; // Case Management
     public static final String CAPABILITY_DMN = "DMN"; // DMN
-    public static final String CAPABILITY_BPM_QUERIES = "BPMQueries"; // BPM Queries
     public static final String CAPABILITY_SWAGGER = "Swagger"; // Swagger
 
     public static final String FAILURE_REASON_PROP = "failure-reason";


### PR DESCRIPTION
The jBPM-Query/Search KIE-Server extension/capability has been removed, so we can remove this extension.