### PR TITLE
Fix kie-camel to allow executing commands

### DIFF
--- a/kie-camel/src/main/java/org/kie/camel/KieComponent.java
+++ b/kie-camel/src/main/java/org/kie/camel/KieComponent.java
@@ -50,6 +50,11 @@ public class KieComponent extends DefaultComponent {
 
         kieServicesConf.setUserName( kieConfiguration.getUsername() );
         kieServicesConf.setPassword( kieConfiguration.getPassword() );
+
+        if (kieConfiguration.getKieServicesConfigurationCustomizer() != null) {
+            kieServicesConf = kieConfiguration.getKieServicesConfigurationCustomizer().apply(kieServicesConf);
+        }
+
         return new KieEndpoint(uri, this, kieServicesConf, configuration);
     }
 

--- a/kie-camel/src/main/java/org/kie/camel/KieConfiguration.java
+++ b/kie-camel/src/main/java/org/kie/camel/KieConfiguration.java
@@ -32,6 +32,8 @@ public class KieConfiguration implements Cloneable {
     @UriParam(label = "security", secret = true)
     private String password;
 
+    private KieServicesConfigurationCustomizer kieServicesConfigurationCustomizer;
+
     private Map<String, String> bodyParams = new HashMap<>();
 
     public KieConfiguration() {
@@ -86,6 +88,14 @@ public class KieConfiguration implements Cloneable {
 
     public void setPassword( String password ) {
         this.password = password;
+    }
+
+    public KieServicesConfigurationCustomizer getKieServicesConfigurationCustomizer() {
+        return kieServicesConfigurationCustomizer;
+    }
+
+    public void setKieServicesConfigurationCustomizer(KieServicesConfigurationCustomizer kieServicesConfigurationCustomizer) {
+        this.kieServicesConfigurationCustomizer = kieServicesConfigurationCustomizer;
     }
 
     public KieConfiguration setBodyParam(String serviceName, String methodName, String paramName) {

--- a/kie-camel/src/main/java/org/kie/camel/KieServicesConfigurationCustomizer.java
+++ b/kie-camel/src/main/java/org/kie/camel/KieServicesConfigurationCustomizer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.camel;
+
+import org.kie.server.client.KieServicesConfiguration;
+
+import java.util.function.Function;
+
+/**
+ * Allows to customize the kie services configuration created by the component.
+ */
+public interface KieServicesConfigurationCustomizer extends Function<KieServicesConfiguration, KieServicesConfiguration> {
+
+}


### PR DESCRIPTION
I was trying to reimplement a fabric8 quickstart using the new kie-camel component but I hit 2 issues (and fixed them).
The quickstart is here: https://github.com/nicolaferraro/spring-boot-camel-drools/tree/new-component-draft

First one was that method `executeCommandsWithResults` of the rule service has 2 versions with same number of arguments and they were collapsed by the comparator (it returned 0), so I got a random overloaded instance each time I ran the application.

Second one was that I could not hook into the services configuration to inject some jaxb classes I need to use.
Now I can do: https://github.com/nicolaferraro/spring-boot-camel-drools/blob/new-component-draft/src/main/java/io/fabric8/quickstarts/camel/drools/Application.java#L42-L51

This fixes both.