### PR TITLE
RHBA-409 - JAXB unmarshalls Date object as XMLGregorianCalendarImpl

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/type/JaxbDate.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/type/JaxbDate.java
@@ -26,7 +26,7 @@ import org.kie.server.api.model.Wrapped;
 
 @XmlRootElement(name = "date-type")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class JaxbDate implements Wrapped<Date> {
+public class JaxbDate implements Wrapped<Date>, Comparable<Date> {
 
     @XmlElement
     @XmlSchemaType(name = "dateTime")
@@ -50,5 +50,10 @@ public class JaxbDate implements Wrapped<Date> {
     @Override
     public Date unwrap() {
         return value;
+    }
+
+    @Override
+    public int compareTo(Date o) {
+        return value.compareTo(o);
     }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
@@ -25,7 +25,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.rules.ExternalResource;
+import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.instance.ProcessInstance;
+import org.kie.server.api.model.type.JaxbDate;
 import org.kie.server.client.DocumentServicesClient;
 import org.kie.server.client.JobServicesClient;
 import org.kie.server.client.KieServicesClient;
@@ -112,9 +114,15 @@ public abstract class JbpmKieServerBaseIntegrationTest extends RestJmsSharedBase
         userTaskAdminClient = client.getServicesClient(UserTaskAdminServicesClient.class);
     }
     
-    protected Date subtractOneMinuteFromDate(Date date) {
+    protected Comparable<?> subtractOneMinuteFromDate(Date date) {
         Instant instant = Instant.from(date.toInstant());
         instant = instant.minus(Duration.ofMinutes(1));
-        return Date.from(instant);
+        Date calculated = Date.from(instant);
+        
+        if (marshallingFormat.equals(MarshallingFormat.JAXB)) {
+            return new JaxbDate(calculated);
+        }
+        
+        return calculated;
     }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/TaskSearchServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/TaskSearchServiceIntegrationTest.java
@@ -117,7 +117,7 @@ public class TaskSearchServiceIntegrationTest extends JbpmKieServerBaseIntegrati
         Assertions.assertThat( tasks ).isNotEmpty();
         TaskSummary task = tasks.get( 0 );
         testFindTaskInstanceWithSearchService( createQueryFilterGreaterThanOrEqualsTo( TaskField.CREATEDON,
-                                                                                       subtractOneMinuteFromDate( task.getCreatedOn() ) ),
+                                                                                       subtractOneMinuteFromDate( task.getCreatedOn() ) ) ,
                                                task.getId() );
     }
 


### PR DESCRIPTION
@sutaakar could you please have a look?

in general I made it possible to use jaxbdate object when using custom queries and lists. 