### PR TITLE
[do not merge yet] Skip unstable tests on Jenkins PR builder

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/category/UnstableOnJenkinsPrBuilder.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/category/UnstableOnJenkinsPrBuilder.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.server.integrationtests.category;
+
+/**
+ * Marks tests which are unstable when building using Jenkins PR builder (reason unknown) and may cause false positives.
+ */
+public interface UnstableOnJenkinsPrBuilder {
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/ProcessServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/ProcessServiceIntegrationTest.java
@@ -40,6 +40,7 @@ import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.api.model.instance.WorkItemInstance;
 import org.kie.server.api.exception.KieServicesException;
 import org.kie.server.integrationtests.category.Smoke;
+import org.kie.server.integrationtests.category.UnstableOnJenkinsPrBuilder;
 import org.kie.server.integrationtests.config.TestConfig;
 
 import static org.junit.Assert.*;
@@ -635,6 +636,7 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
     }
 
     @Test
+    @Category({UnstableOnJenkinsPrBuilder.class})
     public void testSignalContainer() throws Exception {
         Long processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_SIGNAL_PROCESS);
 

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -1048,6 +1048,27 @@
       </build>
     </profile>
     <profile>
+      <!-- Skip unstable tests on Jenkins PR builder. -->
+      <id>jenkins-pr-builder</id>
+      <activation>
+        <property>
+          <name>ghprbGhRepository</name>
+        </property>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-failsafe-plugin</artifactId>
+              <configuration>
+                <excludedGroups>org.kie.server.integrationtests.category.UnstableOnJenkinsPrBuilder</excludedGroups>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
       <!-- Integration tests are skipped by default. They are activated when specific container profile is used. -->
       <id>skipITs-by-default</id>
       <activation>


### PR DESCRIPTION
@mswiderski So far I wasn't able to figure out the cause of test failures, skipping it for PR builder.
From what I discovered the issue seems related to missing event listener when processing signal event [1]. It seems like the event listener isn't added in [2]. Also the issue seems to happen right after ProcessServiceIntegrationTest.testProcessInstanceWithTimer() [3]. Do you have any idea what can cause such behaviour?

In case we won't be able to find out the cause we can skip the test for PR builder (using this PR).




[1] https://github.com/kiegroup/jbpm/blob/f70a465dd2621f5598f043631b8eb991142e05ba/jbpm-flow/src/main/java/org/jbpm/process/instance/event/DefaultSignalManager.java#L85
[2] https://github.com/kiegroup/jbpm/blob/f70a465dd2621f5598f043631b8eb991142e05ba/jbpm-flow/src/main/java/org/jbpm/process/instance/event/DefaultSignalManager.java#L53
[3] https://github.com/kiegroup/droolsjbpm-integration/blob/6d4caaf430835e9f862e67cea4737a07ab049d2f/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/ProcessServiceIntegrationTest.java#L720