### PR TITLE
JBPM-6935 Adding test coverate for Case mtmg operations

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
@@ -400,6 +400,10 @@ public class JaxbMarshaller implements Marshaller {
 
     @Override
     public String marshall(Object input) {
+        if (input == null) {
+            return null;
+        }
+
         StringWriter writer = new StringWriter();
         try {
             getMarshaller().marshal(ModelWrapper.wrap(input), writer);

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-case-mgmt/src/main/java/org/kie/server/remote/rest/casemgmt/CaseResource.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-case-mgmt/src/main/java/org/kie/server/remote/rest/casemgmt/CaseResource.java
@@ -84,6 +84,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Variant;
 
 import org.jbpm.casemgmt.api.CaseCommentNotFoundException;
+import org.jbpm.casemgmt.api.CaseDefinitionNotFoundException;
 import org.jbpm.casemgmt.api.model.CaseStatus;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.server.api.model.cases.CaseAdHocFragmentList;
@@ -145,10 +146,15 @@ public class CaseResource extends AbstractCaseResource {
                 containerId,
                 null,
                 (Variant v, String type, Header... customHeaders) -> {
-                    String response = caseManagementServiceBase.startCase(containerId, caseDefId, payload, type);
-                    logger.debug("Returning CREATED response for start case with content '{}'", response);
+                    try {
+                        String response = caseManagementServiceBase.startCase(containerId, caseDefId, payload, type);
+                        logger.debug("Returning CREATED response for start case with content '{}'", response);
 
-                    return createResponse(response, v, Response.Status.CREATED, customHeaders);
+                        return createResponse(response, v, Response.Status.CREATED, customHeaders);
+                    } catch (CaseDefinitionNotFoundException e) {
+                        return notFound(
+                                MessageFormat.format(CASE_DEFINITION_NOT_FOUND, caseDefId, containerId), v, customHeaders);
+                    }
                 });
     }
 

--- a/kie-server-parent/kie-server-services/kie-server-services-case-mgmt/src/main/java/org/kie/server/services/casemgmt/CaseManagementServiceBase.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-case-mgmt/src/main/java/org/kie/server/services/casemgmt/CaseManagementServiceBase.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.jbpm.casemgmt.api.CaseDefinitionNotFoundException;
 import org.jbpm.casemgmt.api.CaseNotFoundException;
 import org.jbpm.casemgmt.api.CaseRuntimeDataService;
 import org.jbpm.casemgmt.api.CaseService;
@@ -100,7 +101,7 @@ public class CaseManagementServiceBase {
 
         CaseDefinition caseDef = caseRuntimeDataService.getCase(containerId, caseDefinitionId);
         if( caseDef == null ) {
-            throw new IllegalStateException("Unable to find case '" + caseDefinitionId + "' in container " + containerId);
+            throw new CaseDefinitionNotFoundException("Unable to find case '" + caseDefinitionId + "' in container " + containerId);
         }
 
         logger.debug("About to unmarshal case file from payload: '{}'", payload);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseRuntimeDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseRuntimeDataServiceIntegrationTest.java
@@ -1701,7 +1701,8 @@ public class CaseRuntimeDataServiceIntegrationTest extends JbpmKieServerBaseInte
         assertClientException(
                 () -> caseClient.triggerAdHocFragmentInStage(CONTAINER_ID, caseClaimId, stage.getIdentifier(), SUBMIT_POLICE_REPORT_TASK, Collections.EMPTY_MAP),
                 404,
-                "Could not trigger Fragment for Completed stage " + stage.getName());
+                "No stage found with id " + stage.getIdentifier()
+        );
 
         caseClient.destroyCaseInstance(CONTAINER_ID, caseClaimId);
     }
@@ -1823,11 +1824,12 @@ public class CaseRuntimeDataServiceIntegrationTest extends JbpmKieServerBaseInte
         assertNotNull(milestones);
         assertEquals(0, milestones.size());
 
+        final String nonExistingAdHocFragment = "not existing";
         assertClientException(
-                () -> caseClient.triggerAdHocFragment(CONTAINER_ID, caseId, "not existing", Collections.EMPTY_MAP),
+                () -> caseClient.triggerAdHocFragment(CONTAINER_ID, caseId, nonExistingAdHocFragment, Collections.EMPTY_MAP),
                 404,
-                "Could not find case instance \"" + caseId + "\"",
-                "Case with id " + caseId + " was not found");
+                "AdHoc fragment '" + nonExistingAdHocFragment + "' not found in case " + caseId
+        );
     }
 
     @Test

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseRuntimeDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseRuntimeDataServiceIntegrationTest.java
@@ -1660,7 +1660,6 @@ public class CaseRuntimeDataServiceIntegrationTest extends JbpmKieServerBaseInte
         caseClient.destroyCaseInstance(CONTAINER_ID, caseId);
     }
 
-    @Ignore // test is ignore due JBPM-6001 and JBPM-6008
     @Test
     public void testTriggerTaskIntoStage() throws Exception {
         String caseClaimId = startCarInsuranceClaimCase(USER_YODA, USER_JOHN, USER_YODA);
@@ -1701,7 +1700,7 @@ public class CaseRuntimeDataServiceIntegrationTest extends JbpmKieServerBaseInte
 
         assertClientException(
                 () -> caseClient.triggerAdHocFragmentInStage(CONTAINER_ID, caseClaimId, stage.getIdentifier(), SUBMIT_POLICE_REPORT_TASK, Collections.EMPTY_MAP),
-                400,
+                404,
                 "Could not trigger Fragment for Completed stage " + stage.getName());
 
         caseClient.destroyCaseInstance(CONTAINER_ID, caseClaimId);
@@ -1823,12 +1822,12 @@ public class CaseRuntimeDataServiceIntegrationTest extends JbpmKieServerBaseInte
         List<CaseMilestone> milestones = caseClient.getMilestones(CONTAINER_ID, caseId, true, 0, 10);
         assertNotNull(milestones);
         assertEquals(0, milestones.size());
-        try {
-            caseClient.triggerAdHocFragment(CONTAINER_ID, caseId, "not existing", null);
-            fail("Should have failed because of not existing comment Id.");
-        } catch (KieServicesException e) {
-            // expected
-        }
+
+        assertClientException(
+                () -> caseClient.triggerAdHocFragment(CONTAINER_ID, caseId, "not existing", Collections.EMPTY_MAP),
+                404,
+                "Could not find case instance \"" + caseId + "\"",
+                "Case with id " + caseId + " was not found");
     }
 
     @Test

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
@@ -646,11 +646,20 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
         Assertions.assertThat(nonExistingData).isNull();
 
         assertClientException(
-                () -> caseClient.getCaseInstanceData(CONTAINER_ID, "NonExistingCaseId"),
+                () -> caseClient.getCaseInstanceData(CONTAINER_ID, NON_EXISTENT_CASE_ID),
                 404,
-                "Could not find case instance \"NonExistingCaseId\"");
+                "Could not find case instance \"" + NON_EXISTENT_CASE_ID + "\"");
     }
-    
+
+    @Test
+    public void testRetrievalOfRoleAssignmentsOfNonExistingCase() {
+        assertClientException(
+                () -> caseClient.getRoleAssignments(CONTAINER_ID, NON_EXISTENT_CASE_ID),
+                404,
+                "Could not find case instance \"" + NON_EXISTENT_CASE_ID + "\"");
+
+    }
+
     private void assertCarInsuranceCaseInstance(CaseInstance caseInstance, String caseId, String owner) {
         Assertions.assertThat(caseInstance).isNotNull();
         Assertions.assertThat(caseInstance.getCaseId()).isEqualTo(caseId);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
@@ -98,8 +98,12 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
 
     @Test
     public void testStartNonExistingCaseDefinition() {
-        assertClientException(() -> caseClient.startCase(CONTAINER_ID, "NonExistingCaseDefinition"), 404,
-                              "Could not find case definition \"NonExistingCaseDefinition\" in container \"insurance\"");
+        final String nonExistingCaseDefinition = "NonExistingCaseDefinition";
+        assertClientException(() -> caseClient.startCase(CONTAINER_ID, nonExistingCaseDefinition),
+                              404,
+                              "Could not find case definition \"" + nonExistingCaseDefinition + "\" in container \"insurance\"",
+                              "Unable to find case '" + nonExistingCaseDefinition + "' in container insurance"
+        );
     }
 
     @Test
@@ -654,7 +658,8 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
         assertClientException(
                 () -> caseClient.getRoleAssignments(CONTAINER_ID, NON_EXISTENT_CASE_ID),
                 404,
-                "Could not find case instance \"" + NON_EXISTENT_CASE_ID + "\"");
+                "Could not find case instance \"" + NON_EXISTENT_CASE_ID + "\"",
+                "Case with id " + NON_EXISTENT_CASE_ID + " not found");
 
     }
 
@@ -663,13 +668,15 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
         assertClientException(
                 () -> caseClient.putCaseInstanceData(CONTAINER_ID, NON_EXISTENT_CASE_ID, "someKey", "data"),
                 404,
-                "Could not find case instance \"" + NON_EXISTENT_CASE_ID + "\""
+                "Could not find case instance \"" + NON_EXISTENT_CASE_ID + "\"",
+                "Case with id " + NON_EXISTENT_CASE_ID + " not found"
         );
 
         assertClientException(
                 () -> caseClient.putCaseInstanceData(CONTAINER_ID, NON_EXISTENT_CASE_ID, Collections.EMPTY_MAP),
                 404,
-                "Could not find case instance \"" + NON_EXISTENT_CASE_ID + "\""
+                "Could not find case instance \"" + NON_EXISTENT_CASE_ID + "\"",
+                "Case with id " + NON_EXISTENT_CASE_ID + " not found"
         );
     }
 
@@ -678,7 +685,8 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
         assertClientException(
                 () -> caseClient.removeCaseInstanceData(CONTAINER_ID, NON_EXISTENT_CASE_ID, "someKey"),
                 404,
-                "Could not find case instance \"" + NON_EXISTENT_CASE_ID + "\""
+                "Could not find case instance \"" + NON_EXISTENT_CASE_ID + "\"",
+                "Case with id " + NON_EXISTENT_CASE_ID + " not found"
         );
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
@@ -485,6 +485,22 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
         Assertions.assertThat(caseData).isNotNull();
         Assertions.assertThat(caseData).hasSize(0);
     }
+
+    @Test
+    public void testRetrievalOfNonExistingCaseData() {
+        String caseId = startCarInsuranceClaimCaseWithEmptyData(USER_YODA, USER_JOHN, USER_YODA);
+        assertNotNull(caseId);
+
+        Map<String, Object> data = caseClient.getCaseInstanceData(CONTAINER_ID, caseId);
+        Assertions.assertThat(data).isEmpty();
+        Object nonExistingData = caseClient.getCaseInstanceData(CONTAINER_ID, caseId, "NonExistingData");
+        Assertions.assertThat(nonExistingData).isNull();
+
+        assertClientException(
+                () -> caseClient.getCaseInstanceData(CONTAINER_ID, "NonExistingCaseId"),
+                404,
+                "Could not find case instance \"NonExistingCaseId\"");
+    }
     
     private void assertCarInsuranceCaseInstance(CaseInstance caseInstance, String caseId, String owner) {
         Assertions.assertThat(caseInstance).isNotNull();
@@ -502,6 +518,10 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
     private String startCarInsuranceClaimCase(String insured, String insuranceRep, String assessor) {
         Map<String, Object> data = new HashMap<>();
         data.put("s", "first case started");
+        return startCarInsuranceClaimCase(insured, insuranceRep, assessor, data);
+    }
+
+    private String startCarInsuranceClaimCase(String insured, String insuranceRep, String assessor, Map<String, Object> data) {
         CaseFile caseFile = CaseFile.builder()
                 .addUserAssignments(CASE_INSURED_ROLE, insured)
                 .addUserAssignments(CASE_INS_REP_ROLE, insuranceRep)
@@ -512,5 +532,9 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
         String caseId = caseClient.startCase(CONTAINER_ID, CLAIM_CASE_DEF_ID, caseFile);
         assertNotNull(caseId);
         return caseId;
+    }
+
+    private String startCarInsuranceClaimCaseWithEmptyData(String insured, String insuranceRep, String assessor) {
+        return startCarInsuranceClaimCase(insured, insuranceRep, assessor, new HashMap<>());
     }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
@@ -663,6 +663,30 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
 
     }
 
+    @Test
+    public void testPutDataToNonExistingCase() {
+        assertClientException(
+                () -> caseClient.putCaseInstanceData(CONTAINER_ID, NON_EXISTENT_CASE_ID, "someKey", "data"),
+                404,
+                "Could not find case instance \"" + NON_EXISTENT_CASE_ID + "\""
+        );
+
+        assertClientException(
+                () -> caseClient.putCaseInstanceData(CONTAINER_ID, NON_EXISTENT_CASE_ID, Collections.EMPTY_MAP),
+                404,
+                "Could not find case instance \"" + NON_EXISTENT_CASE_ID + "\""
+        );
+    }
+
+    @Test
+    public void testRemoveDataFromNonExistingCase() {
+        assertClientException(
+                () -> caseClient.removeCaseInstanceData(CONTAINER_ID, NON_EXISTENT_CASE_ID, "someKey"),
+                404,
+                "Could not find case instance \"" + NON_EXISTENT_CASE_ID + "\""
+        );
+    }
+
     private void assertCarInsuranceCaseInstance(CaseInstance caseInstance, String caseId, String owner) {
         Assertions.assertThat(caseInstance).isNotNull();
         Assertions.assertThat(caseInstance.getCaseId()).isEqualTo(caseId);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
 import org.junit.BeforeClass;
@@ -435,18 +436,20 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
                 activeStageId,
                 taskName,
                 "Contact car producer",
-                USER_JOHN,
-                "mygroup",
+                USER_YODA,
+                "NO GROUP",
                 Collections.emptyMap());
 
-        TaskSummary currentTask;
-        do {
-            List<TaskSummary> activeTasks = taskClient.findTasksAssignedAsPotentialOwner(USER_JOHN,0, 50);
+
+            List<TaskSummary> activeTasks = taskClient.findTasksAssignedAsPotentialOwner(USER_YODA,0, 50);
             Assertions.assertThat(activeTasks).isNotEmpty();
-            currentTask = activeTasks.get(0);
-            taskClient.completeAutoProgress(CONTAINER_ID, currentTask.getId(), USER_JOHN, Collections.emptyMap());
-            System.out.println(currentTask);
-        } while (currentTask.getName() != taskName);
+            Optional<TaskSummary> addedTask = activeTasks
+                    .stream()
+                    .filter(task -> taskName.equals(task.getName()))
+                    .findFirst();
+            Assertions.assertThat(addedTask).isNotEmpty();
+
+            taskClient.completeAutoProgress(CONTAINER_ID, addedTask.get().getId(), USER_YODA, Collections.emptyMap());
     }
 
     @Test

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
@@ -532,7 +532,7 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
                         inactiveStageId,
                         DATA_VERIFICATION_DEF_ID,
                         Collections.emptyMap()),
-                404, "No stage found with id " + NON_EXISTENT_STAGE_ID
+                404, "No stage found with id " + inactiveStageId
         );
     }
 
@@ -647,11 +647,6 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
         Assertions.assertThat(data).isEmpty();
         Object nonExistingData = caseClient.getCaseInstanceData(CONTAINER_ID, caseId, "NonExistingData");
         Assertions.assertThat(nonExistingData).isNull();
-
-        assertClientException(
-                () -> caseClient.getCaseInstanceData(CONTAINER_ID, NON_EXISTENT_CASE_ID),
-                404,
-                "Could not find case instance \"" + NON_EXISTENT_CASE_ID + "\"");
     }
 
     @Test

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseServiceIntegrationTest.java
@@ -87,6 +87,12 @@ public class CaseServiceIntegrationTest extends JbpmKieServerBaseIntegrationTest
     }
 
     @Test
+    public void testStartNonExistingCaseDefinition() {
+        assertClientException(() -> caseClient.startCase(CONTAINER_ID, "NonExistingCaseDefinition"), 404,
+                              "Could not find case definition \"NonExistingCaseDefinition\" in container \"insurance\"");
+    }
+
+    @Test
     public void testCreateCaseWithEmptyCaseFile() {
         String caseId = startCarInsuranceClaimCase(USER_YODA, USER_JOHN, USER_YODA);
 


### PR DESCRIPTION
- adds negative scenarios to Case mgmt testing in KIE Server
- fixes one smaller issue (return code 404 vs 500)
- reveals difference between error messages provided by JMS and REST:
 <"Case with id I don't exist case not found"> vs. <"Could not find case instance "I don't exist case"">
- reveals that Jaxb cannot marshall null when retrieving non-existing case file data

Once we agree on what to do with last two points, I can open a PR to 7.7.x branch.
