### PR TITLE
[7.7.x] Stabilize SLA tests for production DBs

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/kjars-sources/case-sla/src/main/resources/org/kie/server/testing/UserTaskCaseWithSLA.bpmn2
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/kjars-sources/case-sla/src/main/resources/org/kie/server/testing/UserTaskCaseWithSLA.bpmn2
@@ -14,7 +14,7 @@
         <tns:metaValue>HR</tns:metaValue>
       </tns:metaData>    
       <tns:metaData name="customSLADueDate">
-        <tns:metaValue>2s</tns:metaValue>
+        <tns:metaValue>4s</tns:metaValue>
       </tns:metaData>
     </bpmn2:extensionElements>
     <bpmn2:property id="s" itemSubjectRef="_sItem" name="s"/>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseSLAComplianceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseSLAComplianceIntegrationTest.java
@@ -22,7 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -31,7 +30,6 @@ import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.cases.CaseFile;
 import org.kie.server.api.model.cases.CaseInstance;
-import org.kie.server.api.model.instance.NodeInstance;
 import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.integrationtests.jbpm.JbpmKieServerBaseIntegrationTest;
@@ -100,7 +98,7 @@ public class CaseSLAComplianceIntegrationTest extends JbpmKieServerBaseIntegrati
         Long caseProcessInstanceId = johnTask.getProcessInstanceId();
 
         // Wait for SLA to expire
-        KieServerSynchronization.waitForProcessInstanceSLAViolated(queryClient, caseProcessInstanceId, 3_000L);
+        KieServerSynchronization.waitForProcessInstanceSLAViolated(queryClient, caseProcessInstanceId, 6_000L);
 
         caseInstance = caseClient.getCaseInstance(CONTAINER_ID, caseId);
         assertThat(caseInstance.getCaseId()).isEqualTo(caseId);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/definition-project/src/main/resources/UserTaskWithSLA.bpmn2
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/definition-project/src/main/resources/UserTaskWithSLA.bpmn2
@@ -15,7 +15,7 @@
   <process processType="Private" isExecutable="true" id="definition-project.UserTaskWithSLA" name="User Task" >
     <extensionElements>
       <tns:metaData name="customSLADueDate">
-        <tns:metaValue>2s</tns:metaValue>
+        <tns:metaValue>4s</tns:metaValue>
       </tns:metaData>
     </extensionElements>
     <property id="s" itemSubjectRef="_sItem"/>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/definition-project/src/main/resources/UserTaskWithSLAOnTask.bpmn2
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/definition-project/src/main/resources/UserTaskWithSLAOnTask.bpmn2
@@ -19,7 +19,7 @@
     <userTask id="_2" name="Hello" >
       <extensionElements>
         <tns:metaData name="customSLADueDate">
-          <tns:metaValue>2s</tns:metaValue>
+          <tns:metaValue>4s</tns:metaValue>
         </tns:metaData>
       </extensionElements>
       <ioSpecification>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/SLAComplianceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/SLAComplianceIntegrationTest.java
@@ -70,7 +70,7 @@ public class SLAComplianceIntegrationTest extends JbpmKieServerBaseIntegrationTe
         assertNodeInstance(taskNode, "Hello", SLA_NA);
 
         // Let's wait for SLA violation
-        KieServerSynchronization.waitForProcessInstanceSLAViolated(queryClient, pid, 3_000L);
+        KieServerSynchronization.waitForProcessInstanceSLAViolated(queryClient, pid, 6_000L);
         assertProcessInstance(pid, STATE_ACTIVE, SLA_VIOLATED);
 
         taskClient.completeAutoProgress(CONTAINER_ID, task.getId(), USER_YODA, null);
@@ -136,7 +136,7 @@ public class SLAComplianceIntegrationTest extends JbpmKieServerBaseIntegrationTe
         assertNodeInstance(taskNode, "Hello", SLA_PENDING);
 
         // Let's wait for SLA violation
-        KieServerSynchronization.waitForNodeInstanceSLAViolated(queryClient, pid, taskNode.getId(), 3_000L);
+        KieServerSynchronization.waitForNodeInstanceSLAViolated(queryClient, pid, taskNode.getId(), 6_000L);
 
         assertProcessInstance(pid, STATE_ACTIVE, SLA_NA);
 


### PR DESCRIPTION
Same as #1463 but for 7.7.x.