### PR TITLE
[7.7.x] JBPM-7280: Skip removing of container info if not existing

### DIFF
--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/Configuration.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/Configuration.java
@@ -25,9 +25,12 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArraySet;
 
+import org.jboss.logging.Logger;
 import org.kie.server.router.utils.FailedHostInfo;
 
 public class Configuration {
+
+    private static final Logger log = Logger.getLogger(Configuration.class);
 
     private Map<String, List<String>> hostsPerServer = new ConcurrentHashMap<>();
     private Map<String, List<String>> hostsPerContainer = new ConcurrentHashMap<>();
@@ -105,6 +108,12 @@ public class Configuration {
 
     public void removeContainerInfo(ContainerInfo containerInfo) {
         List<ContainerInfo> containersById = containerInfosPerContainer.get(containerInfo.getContainerId());
+
+        if (containersById == null) {
+            log.warn("Container info with id '" + containerInfo.getContainerId() + "' is not found, nothing is removed.");
+            return;
+        }
+
         containersById.remove(containerInfo);
         
         List<String> hosts = hostsPerContainer.getOrDefault(containerInfo.getContainerId(), Collections.emptyList());

--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/test/java/org/kie/server/router/ConfigurationTest.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/test/java/org/kie/server/router/ConfigurationTest.java
@@ -269,4 +269,20 @@ public class ConfigurationTest {
         assertEquals("http://localhost:8081/server", config.getHostsPerContainer().get("container1").get(1));        
         assertEquals("http://localhost:8081/server", config.getHostsPerServer().get("server1").get(1));
     }
+
+    @Test
+    public void testRemoveNotExistingContainerInfo() {
+
+        Configuration config = new Configuration();
+
+        ContainerInfo containerInfo = new ContainerInfo("test1.0", "test", "org.kie:test:1.0");
+        config.addContainerInfo(containerInfo);
+
+        assertEquals(2, config.getContainerInfosPerContainer().size());
+
+        ContainerInfo notExistingContainerInfo = new ContainerInfo("not-existing-test1.0", "not-existing-test", "org.kie:test:1.0");
+        config.removeContainerInfo(notExistingContainerInfo);
+
+        assertEquals(2, config.getContainerInfosPerContainer().size());
+    }
 }


### PR DESCRIPTION
Cherrypick of https://github.com/kiegroup/droolsjbpm-integration/pull/1470