### PR TITLE
JBPM-7245 Stunner - Diagram SVG is not highlighted on the WB (jbpm-process-svg)

### DIFF
--- a/jbpm-process-svg/src/main/java/org/jbpm/process/svg/SVGImageProcessor.java
+++ b/jbpm-process-svg/src/main/java/org/jbpm/process/svg/SVGImageProcessor.java
@@ -17,60 +17,53 @@ package org.jbpm.process.svg;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StringWriter;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-
 import org.apache.batik.anim.dom.SAXSVGDocumentFactory;
-import org.apache.batik.anim.dom.SVGOMTSpanElement;
 import org.apache.batik.util.XMLResourceDescriptor;
-import org.jbpm.process.svg.model.NodeSummary;
-import org.jbpm.process.svg.model.SVGSummary;
-import org.jbpm.process.svg.model.SetBackgroundColorTransformation;
-import org.jbpm.process.svg.model.SetBorderColorTransformation;
-import org.jbpm.process.svg.model.SetSubProcessLinkTransformation;
 import org.jbpm.process.svg.model.Transformation;
+import org.jbpm.process.svg.processor.SVGProcessor;
+import org.jbpm.process.svg.processor.SVGProcessorFactory;
 import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NamedNodeMap;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 
 public class SVGImageProcessor {
 
-    private Document svgDocument;
-    private SVGSummary summary = new SVGSummary();
-    private boolean mapById = true;
+    private SVGProcessor svgProcessor;
 
     public SVGImageProcessor(InputStream svg) {
         this(svg, true);
     }
     
     public SVGImageProcessor(InputStream svg, boolean mapById) {
-        this.mapById = mapById;
+
         try {
             String parser = XMLResourceDescriptor.getXMLParserClassName();
             SAXSVGDocumentFactory factory = new SAXSVGDocumentFactory(parser);
             factory.setValidating(false);
-            svgDocument = factory.createDocument("http://jbpm.org", svg);
-            processNodes(svgDocument.getChildNodes());
+            Document svgDocument = factory.createDocument("http://jbpm.org", svg);
+
+            svgProcessor = new SVGProcessorFactory().create(svgDocument, mapById);
+            svgProcessor.processNodes(svgDocument.getChildNodes());
+
         } catch (IOException e) {
             throw new RuntimeException("Could not parse svg", e);
         }
     }
+
+    public SVGProcessor getProcessor() {
+        return svgProcessor;
+    }
+
+    //Static methods to keep backward compatibility
 
     public static String transform(InputStream svg, List<String> completed, List<String> active) {
         return transform(svg, completed, active, null);
     }
 
     public static String transform(InputStream svg, List<String> completed, List<String> active, Map<String, String> subProcessLinks) {
-        SVGImageProcessor processor = new SVGImageProcessor(svg);
+        SVGProcessor processor = new SVGImageProcessor(svg).getProcessor();
+
         for (String nodeId : completed) {
             if (!active.contains(nodeId)) {
                 processor.defaultCompletedTransformation(nodeId);
@@ -90,7 +83,7 @@ public class SVGImageProcessor {
     }
 
     public static String transformByName(InputStream svg, List<String> completed, List<String> active) {
-        SVGImageProcessor processor = new SVGImageProcessor(svg, false);
+        SVGProcessor processor = new SVGImageProcessor(svg, false).getProcessor();
         for (String nodeId : completed) {
             if (!active.contains(nodeId)) {
                 processor.defaultCompletedTransformation(nodeId);
@@ -103,87 +96,25 @@ public class SVGImageProcessor {
         return processor.getSVG();
     }
 
+    //Delegate just to keep backward compatibility
+
     public void transform(Transformation t) {
-        t.transform(summary);
+        getProcessor().transform(t);
     }
 
     public void defaultCompletedTransformation(String nodeId) {
-        transform(new SetBackgroundColorTransformation(nodeId, "#C0C0C0"));
+        getProcessor().defaultCompletedTransformation(nodeId);
     }
 
     public void defaultActiveTransformation(String nodeId) {
-        transform(new SetBorderColorTransformation(nodeId, "#FF0000"));
+        getProcessor().defaultActiveTransformation(nodeId);
     }
 
     public void defaultSubProcessLinkTransformation(String nodeId, String link) {
-        transform(new SetSubProcessLinkTransformation(nodeId, link));
+        getProcessor().defaultSubProcessLinkTransformation(nodeId, link);
     }
 
     public String getSVG() {
-        try {
-            DOMSource domSource = new DOMSource(svgDocument.getFirstChild());
-            StringWriter writer = new StringWriter();
-            StreamResult result = new StreamResult(writer);
-            TransformerFactory tf = TransformerFactory.newInstance();
-            Transformer transformer = tf.newTransformer();
-            transformer.transform(domSource, result);
-            return writer.toString();
-        } catch (TransformerException e) {
-            throw new RuntimeException("Could not transform svg", e);
-        }
+        return getProcessor().getSVG();
     }
-
-    private void processNodes(NodeList nodes) {
-        for (int i = 0; i < nodes.getLength(); i++) {
-            Node node = nodes.item(i);
-            NamedNodeMap attributes = node.getAttributes();
-            if (attributes != null) {
-                Node svgIdNode = attributes.getNamedItem("id");
-                if (svgIdNode != null) {
-                    String svgId = svgIdNode.getNodeValue();
-                    if (mapById) {
-                        Node nodeIdNode = attributes.getNamedItem("bpmn2nodeid");
-                        if (nodeIdNode != null) {
-                            String nodeId = nodeIdNode.getNodeValue();
-                            Element border = null;
-                            Element background = null;
-                            Element subProcessLink = null;
-                            if (nodeId != null) {
-                                background = svgDocument.getElementById(svgId + "fill_el");
-                                border = svgDocument.getElementById(svgId + "bg_frame");
-                                Element borderSubProcess = svgDocument.getElementById(svgId + "frame");
-
-                                subProcessLink = svgDocument.getElementById(svgId + "pimg");
-                                summary.addNode(new NodeSummary(nodeId, border, background, borderSubProcess, subProcessLink));
-                            }
-                        }
-                    } else {
-                        // map by name
-                        if (svgId.endsWith("text_name")) {
-                            svgId = svgId.substring(0, svgId.length() - 9);
-                            StringBuilder taskLabel = new StringBuilder();
-                            for (int j = 0; j < node.getChildNodes().getLength(); j++) {
-                                if (node.getChildNodes().item(j) instanceof SVGOMTSpanElement) {
-                                    SVGOMTSpanElement spanElement = (SVGOMTSpanElement)node.getChildNodes().item(j);
-                                    taskLabel.append(spanElement.getFirstChild().getNodeValue());
-                                }
-                            }
-                            String name = taskLabel.toString();
-                            // filtering out nodes with no name
-                            if (!name.trim().isEmpty()) {
-                                Element background = svgDocument.getElementById(svgId + "fill_el");
-                                Element border = svgDocument.getElementById(svgId + "bg_frame");
-                                Element borderSubProcess = svgDocument.getElementById(svgId + "frame");
-
-                                Element subProcessLink = svgDocument.getElementById(svgId + "pimg");
-                                summary.addNode(new NodeSummary(name, border, background, borderSubProcess, subProcessLink));
-                            }
-                        }
-                    }
-                }
-            }
-            processNodes(node.getChildNodes());
-        }
-    }
-    
 }

--- a/jbpm-process-svg/src/main/java/org/jbpm/process/svg/model/NodeSummary.java
+++ b/jbpm-process-svg/src/main/java/org/jbpm/process/svg/model/NodeSummary.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -11,26 +11,38 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.jbpm.process.svg.model;
+
+import java.util.Optional;
 
 import org.w3c.dom.Element;
 
 public class NodeSummary {
 
-    private String nodeId;
-    private Element border;
-    private Element borderSubProcess;
-    private Element background;
-    private Element subProcessLink;
+    private final String nodeId;
+    private final Element border;
+    private final Element borderSubProcess;
+    private final Element background;
+    private final Element subProcessLink;
+    private final Optional<RenderType> renderType;
 
     public NodeSummary(String nodeId, Element border, Element background, Element borderSubProcess, Element subProcessLink) {
+        this(nodeId, border, background, borderSubProcess, subProcessLink, null);
+    }
+
+    public NodeSummary(String nodeId) {
+        this(nodeId, null, null, null, null, null);
+    }
+
+    public NodeSummary(String nodeId, Element border, Element background, Element borderSubProcess, Element subProcessLink, RenderType renderType) {
         this.nodeId = nodeId;
         this.border = border;
         this.background = background;
         this.borderSubProcess = borderSubProcess;
         this.subProcessLink = subProcessLink;
+        this.renderType = Optional.ofNullable(renderType);
     }
 
     public String getNodeId() {
@@ -51,5 +63,9 @@ public class NodeSummary {
 
     public Element getSubProcessLink() {
         return subProcessLink;
+    }
+
+    public Optional<RenderType> getRenderType() {
+        return renderType;
     }
 }

--- a/jbpm-process-svg/src/main/java/org/jbpm/process/svg/model/RenderType.java
+++ b/jbpm-process-svg/src/main/java/org/jbpm/process/svg/model/RenderType.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.process.svg.model;
+
+public enum RenderType {
+
+    FILL,
+    STROKE;
+}

--- a/jbpm-process-svg/src/main/java/org/jbpm/process/svg/processor/AbstractSVGProcessor.java
+++ b/jbpm-process-svg/src/main/java/org/jbpm/process/svg/processor/AbstractSVGProcessor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.process.svg.processor;
+
+import java.io.StringWriter;
+
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.jbpm.process.svg.model.SVGSummary;
+import org.jbpm.process.svg.model.Transformation;
+import org.w3c.dom.Document;
+
+public abstract class AbstractSVGProcessor implements SVGProcessor{
+
+    protected Document svgDocument;
+    protected SVGSummary summary = new SVGSummary();
+    protected boolean mapById = true;
+
+    public AbstractSVGProcessor(Document svgDocument, boolean mapById) {
+        this.svgDocument = svgDocument;
+        this.mapById = mapById;
+    }
+
+    @Override
+    public void transform(Transformation t) {
+        t.transform(summary);
+    }
+
+    @Override
+    public String getSVG() {
+        try {
+            DOMSource domSource = new DOMSource(svgDocument.getFirstChild());
+            StringWriter writer = new StringWriter();
+            StreamResult result = new StreamResult(writer);
+            TransformerFactory tf = TransformerFactory.newInstance();
+            Transformer transformer = tf.newTransformer();
+            transformer.transform(domSource, result);
+            return writer.toString();
+        } catch (TransformerException e) {
+            throw new RuntimeException("Could not transform svg", e);
+        }
+    }
+
+}

--- a/jbpm-process-svg/src/main/java/org/jbpm/process/svg/processor/JBPMDesignerSVGProcessor.java
+++ b/jbpm-process-svg/src/main/java/org/jbpm/process/svg/processor/JBPMDesignerSVGProcessor.java
@@ -1,0 +1,88 @@
+package org.jbpm.process.svg.processor;
+
+import org.apache.batik.anim.dom.SVGOMTSpanElement;
+import org.jbpm.process.svg.model.NodeSummary;
+import org.jbpm.process.svg.model.SetBackgroundColorTransformation;
+import org.jbpm.process.svg.model.SetBorderColorTransformation;
+import org.jbpm.process.svg.model.SetSubProcessLinkTransformation;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class JBPMDesignerSVGProcessor extends AbstractSVGProcessor {
+
+    public JBPMDesignerSVGProcessor(Document svgDocument, boolean mapById) {
+        super(svgDocument, mapById);
+    }
+
+    @Override
+    public void defaultCompletedTransformation(String nodeId) {
+        transform(new SetBackgroundColorTransformation(nodeId, COMPLETED_COLOR));
+    }
+
+    @Override
+    public void defaultActiveTransformation(String nodeId) {
+        transform(new SetBorderColorTransformation(nodeId, ACTIVE_COLOR));
+    }
+
+    @Override
+    public void defaultSubProcessLinkTransformation(String nodeId, String link) {
+        transform(new SetSubProcessLinkTransformation(nodeId, link));
+    }
+
+    @Override
+    public void processNodes(NodeList nodes) {
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.item(i);
+            NamedNodeMap attributes = node.getAttributes();
+            if (attributes != null) {
+                Node svgIdNode = attributes.getNamedItem("id");
+                if (svgIdNode != null) {
+                    String svgId = svgIdNode.getNodeValue();
+                    if (mapById) {
+                        Node nodeIdNode = attributes.getNamedItem("bpmn2nodeid");
+                        if (nodeIdNode != null) {
+                            String nodeId = nodeIdNode.getNodeValue();
+                            Element border = null;
+                            Element background = null;
+                            Element subProcessLink = null;
+                            if (nodeId != null) {
+                                background = svgDocument.getElementById(svgId + "fill_el");
+                                border = svgDocument.getElementById(svgId + "bg_frame");
+                                Element borderSubProcess = svgDocument.getElementById(svgId + "frame");
+
+                                subProcessLink = svgDocument.getElementById(svgId + "pimg");
+                                summary.addNode(new NodeSummary(nodeId, border, background, borderSubProcess, subProcessLink));
+                            }
+                        }
+                    } else {
+                        // map by name
+                        if (svgId.endsWith("text_name")) {
+                            svgId = svgId.substring(0, svgId.length() - 9);
+                            StringBuilder taskLabel = new StringBuilder();
+                            for (int j = 0; j < node.getChildNodes().getLength(); j++) {
+                                if (node.getChildNodes().item(j) instanceof SVGOMTSpanElement) {
+                                    SVGOMTSpanElement spanElement = (SVGOMTSpanElement) node.getChildNodes().item(j);
+                                    taskLabel.append(spanElement.getFirstChild().getNodeValue());
+                                }
+                            }
+                            String name = taskLabel.toString();
+                            // filtering out nodes with no name
+                            if (!name.trim().isEmpty()) {
+                                Element background = svgDocument.getElementById(svgId + "fill_el");
+                                Element border = svgDocument.getElementById(svgId + "bg_frame");
+                                Element borderSubProcess = svgDocument.getElementById(svgId + "frame");
+
+                                Element subProcessLink = svgDocument.getElementById(svgId + "pimg");
+                                summary.addNode(new NodeSummary(name, border, background, borderSubProcess, subProcessLink));
+                            }
+                        }
+                    }
+                }
+            }
+            processNodes(node.getChildNodes());
+        }
+    }
+}

--- a/jbpm-process-svg/src/main/java/org/jbpm/process/svg/processor/SVGProcessor.java
+++ b/jbpm-process-svg/src/main/java/org/jbpm/process/svg/processor/SVGProcessor.java
@@ -1,0 +1,23 @@
+package org.jbpm.process.svg.processor;
+
+import org.jbpm.process.svg.model.Transformation;
+import org.w3c.dom.NodeList;
+
+public interface SVGProcessor {
+
+    String COMPLETED_COLOR = "#C0C0C0";
+    String COMPLETED_BORDER_COLOR = "#030303";
+    String ACTIVE_COLOR = "#FF0000";
+
+    void transform(Transformation t);
+
+    void defaultCompletedTransformation(String nodeId);
+
+    void defaultActiveTransformation(String nodeId);
+
+    void defaultSubProcessLinkTransformation(String nodeId, String link);
+
+    String getSVG();
+
+    void processNodes(NodeList nodes);
+}

--- a/jbpm-process-svg/src/main/java/org/jbpm/process/svg/processor/SVGProcessorFactory.java
+++ b/jbpm-process-svg/src/main/java/org/jbpm/process/svg/processor/SVGProcessorFactory.java
@@ -1,0 +1,18 @@
+package org.jbpm.process.svg.processor;
+
+import java.util.Objects;
+
+import org.w3c.dom.Document;
+
+public class SVGProcessorFactory {
+
+    public SVGProcessor create(Document svg, boolean mapById){
+
+        String attribute = svg.getDocumentElement().getAttributeNS("http://www.w3.org/2000/xmlns/", "oryx");
+        if(Objects.equals("http://oryx-editor.org", attribute)){
+            return new JBPMDesignerSVGProcessor(svg, mapById);
+        }
+
+        return new StunnerSVGProcessor(svg);
+    }
+}

--- a/jbpm-process-svg/src/main/java/org/jbpm/process/svg/processor/StunnerSVGProcessor.java
+++ b/jbpm-process-svg/src/main/java/org/jbpm/process/svg/processor/StunnerSVGProcessor.java
@@ -1,0 +1,121 @@
+package org.jbpm.process.svg.processor;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.StringTokenizer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jbpm.process.svg.model.NodeSummary;
+import org.jbpm.process.svg.model.RenderType;
+import org.jbpm.process.svg.model.SetSubProcessLinkTransformation;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class StunnerSVGProcessor extends AbstractSVGProcessor {
+
+    public StunnerSVGProcessor(Document svgDocument) {
+        super(svgDocument, true);
+    }
+
+    @Override
+    public void defaultCompletedTransformation(String nodeId) {
+        transform((summary) -> {
+            Optional.ofNullable(summary.getNode(nodeId)).ifPresent(node -> {
+                Optional.ofNullable(node.getBackground()).ifPresent(background -> {
+                    background.setAttribute("fill", COMPLETED_COLOR);
+                    setNodeBorderColor(node.getRenderType(), node.getBorder(), COMPLETED_BORDER_COLOR);
+                });
+            });
+        });
+    }
+
+    @Override
+    public void defaultActiveTransformation(String nodeId) {
+        transform((summary) -> {
+            Optional.ofNullable(summary.getNode(nodeId)).ifPresent(node -> {
+                Optional.ofNullable(node.getBorder()).ifPresent(border -> {
+                    setNodeBorderColor(node.getRenderType(), border, ACTIVE_COLOR);
+                });
+            });
+        });
+    }
+
+    private void setNodeBorderColor(Optional<RenderType> renderType, Element border, String color) {
+        final RenderType render = renderType.orElse(RenderType.STROKE);
+        switch (render) {
+            case STROKE:
+                border.setAttribute("stroke-width", "2");
+                border.setAttribute("stroke", color);
+                break;
+            case FILL:
+                border.setAttribute("fill", color);
+                break;
+        }
+    }
+
+    @Override
+    public void defaultSubProcessLinkTransformation(String nodeId, String link) {
+        transform(new SetSubProcessLinkTransformation(nodeId, link));
+    }
+
+    private void processNode(final Node parent, final String nodeId) {
+        final NodeList nodes = parent.getChildNodes();
+        for (int i = 0; i < nodes.getLength(); i++) {
+            final Node node = nodes.item(i);
+            final NamedNodeMap attributes = node.getAttributes();
+            if (attributes != null) {
+                final Node svgIdNode = attributes.getNamedItem("id");
+                if (svgIdNode != null) {
+                    final String value = svgIdNode.getNodeValue();
+                    if (Objects.nonNull(value)) {
+                        Map<String, String> parameters =
+                                Stream.of(value.substring(value.indexOf("?") + 1))
+                                        .filter(Objects::nonNull)
+                                        .map(str -> Collections.list(new StringTokenizer(str, "&")))
+                                        .flatMap(list -> list.stream())
+                                        .map(String::valueOf)
+                                        .filter(str -> str.split("=").length == 2)
+                                        .collect(Collectors.toMap(v -> v.split("=")[0], v -> v.split("=")[1]));
+
+                        NodeSummary nodeSummary = summary.getNodesMap().getOrDefault(nodeId, new NodeSummary(nodeId, null, null, null, null, null));
+                        Element border = Objects.equals(parameters.get("shapeType"), "BORDER") ? (Element) node : nodeSummary.getBorder();
+                        Element background = Objects.equals(parameters.get("shapeType"), "BACKGROUND") ? (Element) node : nodeSummary.getBackground();
+                        RenderType renderType = RenderType.valueOf(Optional.ofNullable(parameters.get("renderType")).orElse(nodeSummary.getRenderType().orElse(RenderType.STROKE).name()));
+
+                        summary.addNode(new NodeSummary(nodeId, border, background, null, null, renderType));
+                    }
+                    break;
+                }
+            }
+            processNode(node, nodeId);
+        }
+    }
+
+    @Override
+    public void processNodes(NodeList nodes) {
+        for (int i = 0; i < nodes.getLength(); i++) {
+            Node node = nodes.item(i);
+            NamedNodeMap attributes = node.getAttributes();
+            if (attributes != null) {
+                Node svgIdNode = attributes.getNamedItem("id");
+                if (svgIdNode != null) {
+                    Node nodeIdNode = attributes.getNamedItem("bpmn2nodeid");
+                    if (nodeIdNode != null) {
+                        String nodeId = nodeIdNode.getNodeValue();
+                        if (nodeId != null) {
+                            //process bpmn2 node to parse the attributes
+                            processNode(node, nodeId);
+                        }
+                    }
+                }
+            }
+            processNodes(node.getChildNodes());
+        }
+    }
+}


### PR DESCRIPTION
Changes on **jbpm-process-svg** module to support Diagram SVG is not highlighted on the WB .

A refactor was made to choose the implementation between JBPM Designer or Stunner.
The `SVGImageProcessor` kept the method signature to keep a backward compatibility since this is a library that could be used in may places.

PS: unit tests will be updated later, the PR is to be tested ASAP since this is a blocker.

@romartin 
@LuboTerifaj 