### PR TITLE
JBPM-7344: Use Tomcat 9 for Kie server integration tests

### DIFF
--- a/kie-server-parent/kie-server-tests/README.md
+++ b/kie-server-parent/kie-server-tests/README.md
@@ -22,7 +22,7 @@ The following table lists all currently supported combinations of parameters:
 | -----------------   | --------------------- | ----------------------------------------- |
 |     WildFly10       | wildfly10             | *none*                                    |
 |     EAP 7           | eap7                  | eap7.download.url                         |
-|     Tomcat 8        | tomcat8               | *none*                                    |
+|     Tomcat 9        | tomcat9               | *none*                                    |
 | Oracle WebLogic 12  | oracle-wls-12         | weblogic.home                             |
 | IBM WebSphere 9*    | websphere9            | websphere.home                            |
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
@@ -340,7 +340,7 @@
       </dependencies>
     </profile>
     <profile>
-      <id>tomcat8</id>
+      <id>tomcat9</id>
     </profile>
     <profile>
       <id>wildfly10</id>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-case-id-generator/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-case-id-generator/pom.xml
@@ -165,7 +165,7 @@
 
   <profiles>
     <profile>
-      <id>tomcat8</id>
+      <id>tomcat9</id>
       <build>
         <pluginManagement>
           <plugins>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
@@ -270,7 +270,7 @@
       </dependencies>
     </profile>
     <profile>
-      <id>tomcat8</id>
+      <id>tomcat9</id>
       <dependencies>
         <dependency>
           <groupId>io.undertow</groupId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/pom.xml
@@ -155,7 +155,7 @@
 
   <profiles>
     <profile>
-      <id>tomcat8</id>
+      <id>tomcat9</id>
       <build>
         <pluginManagement>
           <plugins>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/pom.xml
@@ -275,7 +275,7 @@
       </dependencies>
     </profile>
     <profile>
-      <id>tomcat8</id>
+      <id>tomcat9</id>
     </profile>
     <profile>
       <id>wildfly10</id>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
@@ -276,7 +276,7 @@
       </dependencies>
     </profile>
     <profile>
-      <id>tomcat8</id>
+      <id>tomcat9</id>
     </profile>
     <profile>
       <id>wildfly10</id>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
@@ -335,7 +335,7 @@
       </dependencies>
     </profile>
     <profile>
-      <id>tomcat8</id>
+      <id>tomcat9</id>
     </profile>
     <profile>
       <id>wildfly10</id>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
@@ -262,7 +262,7 @@
       </dependencies>
     </profile>
     <profile>
-      <id>tomcat8</id>
+      <id>tomcat9</id>
     </profile>
     <profile>
       <id>wildfly10</id>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/pom.xml
@@ -302,7 +302,7 @@
       </dependencies>
     </profile>
     <profile>
-      <id>tomcat8</id>
+      <id>tomcat9</id>
     </profile>
     <profile>
       <id>wildfly10</id>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/pom.xml
@@ -335,7 +335,7 @@
       </dependencies>
     </profile>
     <profile>
-      <id>tomcat8</id>
+      <id>tomcat9</id>
     </profile>
     <profile>
       <id>wildfly10</id>

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -57,7 +57,7 @@
     <org.kie.server.datasource.password>sa</org.kie.server.datasource.password>
     <org.kie.server.datasource.driver.class>org.h2.jdbcx.JdbcDataSource</org.kie.server.datasource.driver.class>
 
-    <version.tomcat8>8.5.12</version.tomcat8>
+    <version.tomcat9>9.0.8</version.tomcat9>
     <version.wildfly11>11.0.0.Final</version.wildfly11>
     <version.org.jboss.marshalling>2.0.2.Final</version.org.jboss.marshalling>
     <version.org.postgresql>42.1.1</version.org.postgresql>
@@ -494,12 +494,12 @@
       </build>
     </profile>
     <profile>
-      <id>tomcat8</id>
+      <id>tomcat9</id>
       <properties>
         <org.kie.server.persistence.ds>java:comp/env/jdbc/jbpm</org.kie.server.persistence.ds>
         <kie.server.classifier>webc</kie.server.classifier>
         <kie.server.war.path>${org.kie.server:kie-server:war:webc}</kie.server.war.path>
-        <cargo.container.id>tomcat8x</cargo.container.id>
+        <cargo.container.id>tomcat9x</cargo.container.id>
         <failsafe.excluded.groups>org.kie.server.integrationtests.category.JMSOnly,org.kie.server.integrationtests.category.Email,org.kie.server.integrationtests.category.RemotelyControlled</failsafe.excluded.groups>
       </properties>
       <build>
@@ -514,10 +514,10 @@
                   <artifactInstaller>
                     <groupId>org.apache.tomcat</groupId>
                     <artifactId>tomcat</artifactId>
-                    <version>${version.tomcat8}</version>
+                    <version>${version.tomcat9}</version>
                   </artifactInstaller>
                   <systemProperties>
-                    <tomcat.home>${project.build.directory}/cargo/configurations/tomcat8x</tomcat.home>
+                    <tomcat.home>${project.build.directory}/cargo/configurations/tomcat9x</tomcat.home>
                     <conf.directory>${project.build.testOutputDirectory}</conf.directory>
                     <tmp.directory>${project.build.directory}</tmp.directory>
                     <jbpm.tsr.jndi.lookup>java:comp/env/TransactionSynchronizationRegistry</jbpm.tsr.jndi.lookup>
@@ -578,7 +578,7 @@
         </pluginManagement>
       </build>
       <dependencies>
-        <!-- Deps needed by Tomcat 8 -->
+        <!-- Deps needed by Tomcat 9 -->
         <dependency>
           <groupId>com.h2database</groupId>
           <artifactId>h2</artifactId>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/webc-resources/README.md
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/webc-resources/README.md
@@ -1,6 +1,6 @@
-Installing KIE Server on Tomcat 8
+Installing KIE Server on Tomcat 9
 
-This instruction describes all steps to install KIE Server on Tomcat 8 standalone distribution - this means it's Tomcat downloaded as zip/tar.
+This instruction describes all steps to install KIE Server on Tomcat 9 standalone distribution - this means it's Tomcat downloaded as zip/tar.
 
  1. Extract Tomcat archive into desired location - TOMCAT_HOME
  2. Copy following libraries into TOMCAT_HOME/lib


### PR DESCRIPTION
Tested on subset of the test suite: common, drools and jbpm. All passed.