### PR TITLE
[7.7.x] RHPAM-1029: Smart Router Servers view error

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
@@ -20,7 +20,14 @@ import java.util.List;
 import java.util.ServiceLoader;
 
 import org.kie.server.api.KieServerConstants;
-import org.kie.server.api.model.*;
+import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieContainerResourceList;
+import org.kie.server.api.model.KieScannerResource;
+import org.kie.server.api.model.KieScannerStatus;
+import org.kie.server.api.model.KieServerConfigItem;
+import org.kie.server.api.model.Message;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.controller.api.KieServerControllerIllegalArgumentException;
 import org.kie.server.controller.api.model.runtime.Container;
@@ -432,16 +439,13 @@ public class KieServerInstanceManager {
             container.setStatus(containerSpec.getStatus());
 
             try {
-                KieServicesClient client = getClient(instanceUrl.getUrl());
-
-                operation.doOperation(client,
-                                      container);
+                final KieServicesClient client = getClient(instanceUrl.getUrl());
+                operation.doOperation(client, container);
+                containers.add(container);
             } catch (Exception e) {
                 logger.debug("Unable to connect to {}",
                              instanceUrl);
             }
-
-            containers.add(container);
         }
 
         return containers;

--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/test/java/org/kie/server/router/proxy/DefaultRestrictionPolicyTest.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/test/java/org/kie/server/router/proxy/DefaultRestrictionPolicyTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.router.proxy;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.ServerConnection;
+import io.undertow.util.HttpString;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultRestrictionPolicyTest {
+
+    @Mock
+    private ServerConnection serverConnection;
+
+    private DefaultRestrictionPolicy restrictionPolicy;
+
+    @Before
+    public void setup() {
+        restrictionPolicy = new DefaultRestrictionPolicy();
+    }
+
+    @Test
+    public void testRestrictedEndpointWhenEndpointIsNotRestricted() {
+
+        final HttpServerExchange exchange = makeHttpServerExchange("/containers/containerId", "GET");
+        final String containerId = "containerId";
+        final boolean isRestricted = restrictionPolicy.restrictedEndpoint(exchange, containerId);
+
+        assertFalse(isRestricted);
+    }
+
+    @Test
+    public void testRestrictedEndpointWhenRequestMethodIsNotGET() {
+
+        final HttpServerExchange exchange = makeHttpServerExchange("/containers/containerId", "POST");
+        final String containerId = "containerId";
+        final boolean isRestricted = restrictionPolicy.restrictedEndpoint(exchange, containerId);
+
+        assertTrue(isRestricted);
+    }
+
+    @Test
+    public void testRestrictedEndpointWhenRelativePathEndsWithContainerId() {
+
+        final HttpServerExchange exchange = makeHttpServerExchange("/scanner", "POST");
+        final String containerId = "containerId";
+        final boolean isRestricted = restrictionPolicy.restrictedEndpoint(exchange, containerId);
+
+        assertTrue(isRestricted);
+    }
+
+    @Test
+    public void testRestrictedEndpointWhenRelativePathEndsWithReleaseId() {
+
+        final HttpServerExchange exchange = makeHttpServerExchange("/release-id", "POST");
+        final String containerId = "containerId";
+        final boolean isRestricted = restrictionPolicy.restrictedEndpoint(exchange, containerId);
+
+        assertTrue(isRestricted);
+    }
+
+    private HttpServerExchange makeHttpServerExchange(final String relativePath,
+                                                      final String requestMethod) {
+
+        final HttpServerExchange exchange = new HttpServerExchange(serverConnection);
+        exchange.setRelativePath(relativePath);
+        exchange.setRequestMethod(HttpString.tryFromString(requestMethod));
+        return exchange;
+    }
+}


### PR DESCRIPTION
See: https://issues.jboss.org/browse/RHPAM-1029

---

Cherry picked from https://github.com/kiegroup/droolsjbpm-integration/pull/1486