### PR TITLE
Skip several tests on Jenkins as they tend to be unstable there

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/SLAComplianceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/SLAComplianceIntegrationTest.java
@@ -30,11 +30,13 @@ import java.util.stream.Collectors;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.kie.api.KieServices;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.NodeInstance;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.api.model.instance.TaskSummary;
+import org.kie.server.integrationtests.category.UnstableOnJenkinsPrBuilder;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.KieServerSynchronization;
 
@@ -54,6 +56,7 @@ public class SLAComplianceIntegrationTest extends JbpmKieServerBaseIntegrationTe
     }
 
     @Test
+    @Category({UnstableOnJenkinsPrBuilder.class})
     public void testSLAonProcessViolated() throws Exception {
         Long pid = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK_WITH_SLA, new HashMap<>());
         assertProcessInstance(pid, STATE_ACTIVE, SLA_PENDING);
@@ -119,6 +122,7 @@ public class SLAComplianceIntegrationTest extends JbpmKieServerBaseIntegrationTe
     }
 
     @Test
+    @Category({UnstableOnJenkinsPrBuilder.class})
     public void testSLAonUserTaskViolated() throws Exception {
         Long pid = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK_WITH_SLA_ON_TASK, new HashMap<>());
         assertProcessInstance(pid, STATE_ACTIVE, SLA_NA);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/admin/ProcessInstanceAdminServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/admin/ProcessInstanceAdminServiceIntegrationTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.kie.api.KieServices;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.admin.ExecutionErrorInstance;
@@ -29,6 +30,7 @@ import org.kie.server.api.model.admin.TimerInstance;
 import org.kie.server.api.model.instance.NodeInstance;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.api.exception.KieServicesException;
+import org.kie.server.integrationtests.category.UnstableOnJenkinsPrBuilder;
 import org.kie.server.integrationtests.jbpm.JbpmKieServerBaseIntegrationTest;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.KieServerSynchronization;
@@ -251,6 +253,7 @@ public class ProcessInstanceAdminServiceIntegrationTest extends JbpmKieServerBas
     }
 
     @Test
+    @Category({UnstableOnJenkinsPrBuilder.class})
     public void testErrorHandlingFailedToSignal() throws Exception {
 
         Map<String, Object> parameters = new HashMap<String, Object>();


### PR DESCRIPTION
Based on test failure analysis.
For some unknown reason these tests cause random database transaction issues when executed in community Jenkins.
@mswiderski Could it be possible to add "jenkins-pr-builder" profile to Jenkins downstream tests so these tests are skipped for downstream builds too?