### PR TITLE
[AF-1224] Execution UI should point to swagger, instead of endpoint

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/spec/Capability.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/spec/Capability.java
@@ -17,5 +17,5 @@ package org.kie.server.controller.api.model.spec;
 
 
 public enum Capability {
-    PROCESS, RULE, PLANNING
+    PROCESS, RULE, PLANNING, SWAGGER
 }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerControllerImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerControllerImpl.java
@@ -179,6 +179,9 @@ public abstract class KieServerControllerImpl implements KieServerController {
             if (serverInfo.getCapabilities().contains(KieServerConstants.CAPABILITY_BRP)) {
                 capabilities.add(Capability.PLANNING.toString());
             }
+            if (serverInfo.getCapabilities().contains(KieServerConstants.CAPABILITY_SWAGGER)) {
+                capabilities.add(Capability.SWAGGER.toString());
+            }
             serverTemplate.setCapabilities(capabilities);
 
             // add newly connected server instance


### PR DESCRIPTION
added capabilities information to server instance key so it can
be retrieved by the use and act acordingly