### PR TITLE
[7.7.x] Try to stabilize testErrorHandlingFailedTo* tests

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/RestJmsSharedBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/RestJmsSharedBaseIntegrationTest.java
@@ -18,6 +18,8 @@ package org.kie.server.integrationtests.shared.basetests;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.jms.ConnectionFactory;
 import javax.jms.Queue;
@@ -32,6 +34,7 @@ import org.kie.api.runtime.KieContainer;
 import org.kie.server.api.exception.KieServicesException;
 import org.kie.server.api.exception.KieServicesHttpException;
 import org.kie.server.api.marshalling.MarshallingFormat;
+import org.kie.server.api.model.admin.ExecutionErrorInstance;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.KieServicesConfiguration;
 import org.kie.server.client.KieServicesFactory;
@@ -159,5 +162,13 @@ public abstract class RestJmsSharedBaseIntegrationTest extends KieServerBaseInte
                     .isInstanceOf(KieServicesException.class)
                     .hasMessageContaining(jmsMessage);
         }
+    }
+
+    protected List<ExecutionErrorInstance> filterErrorsByProcessId(Collection<ExecutionErrorInstance> errors, String processId) {
+        return errors.stream().filter(error -> error.getProcessId().equals(processId)).collect(Collectors.toList());
+    }
+
+    protected List<ExecutionErrorInstance> filterErrorsByProcessInstanceId(Collection<ExecutionErrorInstance> errors, Long processInstanceId) {
+        return errors.stream().filter(error -> error.getProcessInstanceId().equals(processInstanceId)).collect(Collectors.toList());
     }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/query-definition-project/src/main/resources/usertask.bpmn2
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/query-definition-project/src/main/resources/usertask.bpmn2
@@ -9,6 +9,11 @@
   <bpmn2:itemDefinition id="__87C563E0-EB8C-4184-BDB0-219E05780A0E_string2_InputXItem" structureRef="String"/>
   <bpmn2:itemDefinition id="__87C563E0-EB8C-4184-BDB0-219E05780A0E_person2_InputXItem" structureRef="org.jbpm.data.Person"/>
   <bpmn2:process id="definition-project.usertask" drools:packageName="org.jbpm" drools:version="1.0" name="usertask" isExecutable="true">
+    <bpmn2:extensionElements>
+      <drools:metaData name="customDescription">
+        <drools:metaValue>Very nice process description</drools:metaValue>
+      </drools:metaData>
+    </bpmn2:extensionElements>
     <bpmn2:property id="stringData" itemSubjectRef="_stringDataItem"/>
     <bpmn2:property id="personData" itemSubjectRef="_personDataItem"/>
     <bpmn2:startEvent id="processStartEvent" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="start">

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
@@ -26,7 +26,6 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.api.KieServices;
-import org.kie.api.task.model.TaskSummary;
 import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.exception.KieServicesException;
 import org.kie.server.api.model.KieContainerResource;
@@ -738,7 +737,7 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
             queryClient.registerQuery(query);
             processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_SIGNAL_PROCESS, parameters);
 
-            List<ExecutionErrorInstance> errors = processAdminClient.getErrors(CONTAINER_ID, false, 0, 10);
+            List<ExecutionErrorInstance> errors = processAdminClient.getErrorsByProcessInstance(CONTAINER_ID, processInstanceId , false, 0, 10);
             assertNotNull(errors);
             assertEquals(0, errors.size());
 
@@ -750,6 +749,7 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
             }
 
             errors = queryClient.query(query.getName(), QueryServicesClient.QUERY_MAP_ERROR, 0, 10, ExecutionErrorInstance.class);
+            errors = filterErrorsByProcessInstanceId(errors, processInstanceId);
             assertNotNull(errors);
             assertEquals(1, errors.size());
             ExecutionErrorInstance errorInstance = errors.get(0);
@@ -775,7 +775,7 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
 
             processAdminClient.acknowledgeError(CONTAINER_ID, errorInstance.getErrorId());
 
-            errors = processAdminClient.getErrors(CONTAINER_ID, false, 0, 10);
+            errors = processAdminClient.getErrorsByProcessInstance(CONTAINER_ID, processInstanceId, false, 0, 10);
             assertNotNull(errors);
             assertEquals(0, errors.size());
 
@@ -812,7 +812,8 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
                 "po.entity_id as POTOWNER, t.FORMNAME AS FORMNAME, p.processinstancedescription as PROCESSINSTANCEDESCRIPTION, t.subject as SUBJECT, t.deploymentid as DEPLOYMENTID " +
                 "from TASK t " +
                 "inner join PEOPLEASSIGNMENTS_POTOWNERS po on t.id=po.task_id " +
-                "inner join PROCESSINSTANCELOG p on t.processinstanceid = p.processinstanceid");
+                "inner join PROCESSINSTANCELOG p on t.processinstanceid = p.processinstanceid " +
+                "WHERE t.processinstanceid = " + pid);
         query.setTarget("CUSTOM");
         
         try {
@@ -822,6 +823,12 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
             List<TaskWithProcessDescription> tasks = queryClient.query(query.getName(), QueryServicesClient.QUERY_MAP_TASK_WITH_PO, 0, 10, TaskWithProcessDescription.class);
             assertNotNull(tasks);
             assertEquals(1, tasks.size());
+
+            TaskWithProcessDescription task = tasks.get(0);
+            assertEquals("First task", task.getName());
+            assertEquals(1, task.getPotentialOwners().size());
+            assertEquals("yoda", task.getPotentialOwners().get(0));
+            assertEquals("Very nice process description", task.getProcessInstanceDescription());
             
         } finally {
             processClient.abortProcessInstance(CONTAINER_ID, pid);
@@ -851,7 +858,8 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
                 "from TASK t " +
                 "inner join PEOPLEASSIGNMENTS_POTOWNERS po on t.id=po.task_id " +
                 "inner join PROCESSINSTANCELOG p on t.processinstanceid = p.processinstanceid " +
-                "inner join TASKVARIABLEIMPL d on t.id=d.taskid");
+                "inner join TASKVARIABLEIMPL d on t.id=d.taskid " +
+                "WHERE t.processinstanceid = " + pid);
         query.setTarget("CUSTOM");
         
         try {
@@ -861,7 +869,18 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
             List<TaskWithProcessDescription> tasks = queryClient.query(query.getName(), QueryServicesClient.QUERY_MAP_TASK_WITH_MODIF, 0, 10, TaskWithProcessDescription.class);
             assertNotNull(tasks);
             assertEquals(1, tasks.size());
-            
+
+            TaskWithProcessDescription task = tasks.get(0);
+            assertEquals("First task", task.getName());
+            assertEquals(1, task.getPotentialOwners().size());
+            assertEquals("yoda", task.getPotentialOwners().get(0));
+            assertEquals("Very nice process description", task.getProcessInstanceDescription());
+            assertEquals("waiting for signal", task.getInputData().get("_string"));
+            Object person = task.getInputData().get("_person");
+            assertEquals(person, "Person{name='" + CONTAINER_ID + "'}");
+            assertNotNull(task.getLastModificationDate());
+            assertNotNull(task.getLastModificationUser());
+
         } finally {
             processClient.abortProcessInstance(CONTAINER_ID, pid);
             queryClient.unregisterQuery(query.getName());

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/SLAComplianceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/SLAComplianceIntegrationTest.java
@@ -30,11 +30,13 @@ import java.util.stream.Collectors;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.kie.api.KieServices;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.NodeInstance;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.api.model.instance.TaskSummary;
+import org.kie.server.integrationtests.category.UnstableOnJenkinsPrBuilder;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.KieServerSynchronization;
 
@@ -54,6 +56,7 @@ public class SLAComplianceIntegrationTest extends JbpmKieServerBaseIntegrationTe
     }
 
     @Test
+    @Category({UnstableOnJenkinsPrBuilder.class})
     public void testSLAonProcessViolated() throws Exception {
         Long pid = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK_WITH_SLA, new HashMap<>());
         assertProcessInstance(pid, STATE_ACTIVE, SLA_PENDING);
@@ -119,6 +122,7 @@ public class SLAComplianceIntegrationTest extends JbpmKieServerBaseIntegrationTe
     }
 
     @Test
+    @Category({UnstableOnJenkinsPrBuilder.class})
     public void testSLAonUserTaskViolated() throws Exception {
         Long pid = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK_WITH_SLA_ON_TASK, new HashMap<>());
         assertProcessInstance(pid, STATE_ACTIVE, SLA_NA);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/admin/ProcessInstanceAdminServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/admin/ProcessInstanceAdminServiceIntegrationTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.kie.api.KieServices;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.admin.ExecutionErrorInstance;
@@ -29,6 +30,7 @@ import org.kie.server.api.model.admin.TimerInstance;
 import org.kie.server.api.model.instance.NodeInstance;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.api.exception.KieServicesException;
+import org.kie.server.integrationtests.category.UnstableOnJenkinsPrBuilder;
 import org.kie.server.integrationtests.jbpm.JbpmKieServerBaseIntegrationTest;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.KieServerSynchronization;
@@ -253,6 +255,7 @@ public class ProcessInstanceAdminServiceIntegrationTest extends JbpmKieServerBas
     }
 
     @Test
+    @Category({UnstableOnJenkinsPrBuilder.class})
     public void testErrorHandlingFailedToSignal() throws Exception {
 
         Map<String, Object> parameters = new HashMap<String, Object>();

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/admin/ProcessInstanceAdminServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/admin/ProcessInstanceAdminServiceIntegrationTest.java
@@ -218,6 +218,7 @@ public class ProcessInstanceAdminServiceIntegrationTest extends JbpmKieServerBas
             // expected as the variable to configure timer duration is invalid
         }
         List<ExecutionErrorInstance> errors = processAdminClient.getErrors(CONTAINER_ID, false, 0, 10);
+        errors = filterErrorsByProcessId(errors, PROCESS_ID_TIMER);
         assertNotNull(errors);
         assertEquals(1, errors.size());
 
@@ -239,6 +240,7 @@ public class ProcessInstanceAdminServiceIntegrationTest extends JbpmKieServerBas
         processAdminClient.acknowledgeError(CONTAINER_ID, errorInstance.getErrorId());
 
         errors = processAdminClient.getErrors(CONTAINER_ID, false, 0, 10);
+        errors = filterErrorsByProcessId(errors, PROCESS_ID_TIMER);
         assertNotNull(errors);
         assertEquals(0, errors.size());
 
@@ -259,7 +261,7 @@ public class ProcessInstanceAdminServiceIntegrationTest extends JbpmKieServerBas
         try {
             processInstanceId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_SIGNAL_PROCESS, parameters);
 
-            List<ExecutionErrorInstance> errors = processAdminClient.getErrors(CONTAINER_ID, false, 0, 10);
+            List<ExecutionErrorInstance> errors = processAdminClient.getErrorsByProcessInstance(CONTAINER_ID, processInstanceId, false, 0, 10);
             assertNotNull(errors);
             assertEquals(0, errors.size());
 
@@ -296,7 +298,7 @@ public class ProcessInstanceAdminServiceIntegrationTest extends JbpmKieServerBas
 
             processAdminClient.acknowledgeError(CONTAINER_ID, errorInstance.getErrorId());
 
-            errors = processAdminClient.getErrors(CONTAINER_ID, false, 0, 10);
+            errors = processAdminClient.getErrorsByProcessInstance(CONTAINER_ID, processInstanceId, false, 0, 10);
             assertNotNull(errors);
             assertEquals(0, errors.size());
 
@@ -335,6 +337,7 @@ public class ProcessInstanceAdminServiceIntegrationTest extends JbpmKieServerBas
             // expected as the variable to configure timer duration is invalid
         }
         List<ExecutionErrorInstance> errors = processAdminClient.getErrors(CONTAINER_ID, false, 0, 10);
+        errors = filterErrorsByProcessId(errors, PROCESS_ID_TIMER);
         assertNotNull(errors);
         assertEquals(2, errors.size());
 
@@ -353,6 +356,7 @@ public class ProcessInstanceAdminServiceIntegrationTest extends JbpmKieServerBas
         processAdminClient.acknowledgeError(CONTAINER_ID, errorInstance.getErrorId(), errorInstance2.getErrorId());
 
         errors = processAdminClient.getErrors(CONTAINER_ID, false, 0, 10);
+        errors = filterErrorsByProcessId(errors, PROCESS_ID_TIMER);
         assertNotNull(errors);
         assertEquals(0, errors.size());
 


### PR DESCRIPTION
Backport of #1490.

Should be merged after #1491.