### PR TITLE
Ignore testErrorHandlingFailedToSignal test

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/admin/ProcessInstanceAdminServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/admin/ProcessInstanceAdminServiceIntegrationTest.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.kie.api.KieServices;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.admin.ExecutionErrorInstance;
@@ -29,6 +30,7 @@ import org.kie.server.api.model.admin.TimerInstance;
 import org.kie.server.api.model.instance.NodeInstance;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.api.exception.KieServicesException;
+import org.kie.server.integrationtests.category.UnstableOnJenkinsPrBuilder;
 import org.kie.server.integrationtests.jbpm.JbpmKieServerBaseIntegrationTest;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.KieServerSynchronization;
@@ -251,6 +253,7 @@ public class ProcessInstanceAdminServiceIntegrationTest extends JbpmKieServerBas
     }
 
     @Test
+    @Category({UnstableOnJenkinsPrBuilder.class})
     public void testErrorHandlingFailedToSignal() throws Exception {
 
         Map<String, Object> parameters = new HashMap<String, Object>();


### PR DESCRIPTION
This test was ignored by #1489 and unignored (by mistake) in #1490. Now it should be OK.