### PR TITLE
[7.7.x] Increase version of pax-exam

### DIFF
--- a/kie-osgi/kie-karaf-itests/pom.xml
+++ b/kie-osgi/kie-karaf-itests/pom.xml
@@ -12,6 +12,7 @@
   <name>KIE :: Karaf Integration Tests</name>
 
   <properties>
+    <version.org.ops4j.pax.exam>4.12.0</version.org.ops4j.pax.exam>
     <java.module.name>org.kie.karaf.itests.main</java.module.name>
   </properties>
 


### PR DESCRIPTION
It is necessary to use new version of pax-exam because Fuse 7.0 does not run with the older version.