### PR TITLE
[DROOLS-2740] Move ExecutableCommand to public API

### DIFF
--- a/jbpm-simulation/src/main/java/org/jbpm/simulation/impl/SimulateProcessPathCommand.java
+++ b/jbpm-simulation/src/main/java/org/jbpm/simulation/impl/SimulateProcessPathCommand.java
@@ -15,20 +15,20 @@
 
 package org.jbpm.simulation.impl;
 
-import org.drools.core.command.impl.ExecutableCommand;
+import java.util.ArrayList;
+import java.util.List;
+
 import org.drools.core.command.impl.RegistryContext;
 import org.drools.core.event.DefaultProcessEventListener;
 import org.drools.core.time.SessionPseudoClock;
 import org.jbpm.simulation.SimulationContext;
 import org.jbpm.simulation.SimulationInfo;
 import org.jbpm.simulation.impl.events.ProcessInstanceEndSimulationEvent;
+import org.kie.api.command.ExecutableCommand;
 import org.kie.api.event.process.ProcessStartedEvent;
 import org.kie.api.runtime.Context;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessInstance;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class SimulateProcessPathCommand implements ExecutableCommand<KieSession> {
 

--- a/kie-camel/src/main/java/org/kie/camel/embedded/component/KieExecuteProducer.java
+++ b/kie-camel/src/main/java/org/kie/camel/embedded/component/KieExecuteProducer.java
@@ -35,10 +35,10 @@ import org.apache.camel.Endpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.RuntimeCamelException;
 import org.apache.camel.impl.DefaultProducer;
-import org.drools.core.command.impl.ExecutableCommand;
 import org.drools.core.command.runtime.BatchExecutionCommandImpl;
 import org.drools.core.util.StringUtils;
 import org.kie.api.command.Command;
+import org.kie.api.command.ExecutableCommand;
 import org.kie.api.runtime.CommandExecutor;
 import org.kie.api.runtime.ExecutionResults;
 

--- a/kie-infinispan/drools-infinispan-persistence/src/main/java/org/drools/persistence/infinispan/InfinispanJDKTimerService.java
+++ b/kie-infinispan/drools-infinispan-persistence/src/main/java/org/drools/persistence/infinispan/InfinispanJDKTimerService.java
@@ -16,7 +16,11 @@
 
 package org.drools.persistence.infinispan;
 
-import org.drools.core.command.impl.ExecutableCommand;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.drools.core.time.InternalSchedulerService;
 import org.drools.core.time.Job;
 import org.drools.core.time.JobContext;
@@ -26,15 +30,11 @@ import org.drools.core.time.Trigger;
 import org.drools.core.time.impl.DefaultTimerJobInstance;
 import org.drools.core.time.impl.JDKTimerService;
 import org.drools.core.time.impl.TimerJobInstance;
+import org.kie.api.command.ExecutableCommand;
 import org.kie.api.runtime.Context;
 import org.kie.api.runtime.ExecutableRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Collection;
-import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A default Scheduler implementation that uses the

--- a/kie-infinispan/drools-infinispan-persistence/src/main/java/org/drools/persistence/infinispan/JDKCallableJobCommand.java
+++ b/kie-infinispan/drools-infinispan-persistence/src/main/java/org/drools/persistence/infinispan/JDKCallableJobCommand.java
@@ -15,7 +15,7 @@
 
 package org.drools.persistence.infinispan;
 
-import org.drools.core.command.impl.ExecutableCommand;
+import org.kie.api.command.ExecutableCommand;
 import org.kie.api.runtime.Context;
 
 public class JDKCallableJobCommand

--- a/kie-infinispan/drools-infinispan-persistence/src/main/java/org/drools/persistence/infinispan/ManualPersistInterceptor.java
+++ b/kie-infinispan/drools-infinispan-persistence/src/main/java/org/drools/persistence/infinispan/ManualPersistInterceptor.java
@@ -17,13 +17,13 @@ package org.drools.persistence.infinispan;
 
 import org.drools.core.command.SingleSessionCommandService;
 import org.drools.core.command.impl.AbstractInterceptor;
-import org.drools.core.command.impl.ExecutableCommand;
 import org.drools.core.fluent.impl.InternalExecutable;
 import org.drools.persistence.PersistableRunner;
 import org.drools.persistence.api.PersistenceContext;
 import org.drools.persistence.api.PersistenceContextManager;
 import org.drools.persistence.api.SessionMarshallingHelper;
 import org.drools.persistence.info.SessionInfo;
+import org.kie.api.command.ExecutableCommand;
 import org.kie.api.runtime.Context;
 import org.kie.api.runtime.Executable;
 import org.kie.api.runtime.KieSession;

--- a/kie-infinispan/drools-infinispan-persistence/src/test/java/org/drools/persistence/jta/TransactionTestCommand.java
+++ b/kie-infinispan/drools-infinispan-persistence/src/test/java/org/drools/persistence/jta/TransactionTestCommand.java
@@ -15,9 +15,11 @@
  */
 package org.drools.persistence.jta;
 
+import java.io.Serializable;
+import java.util.HashMap;
+
 import bitronix.tm.TransactionManagerServices;
 import org.drools.core.base.MapGlobalResolver;
-import org.drools.core.command.impl.ExecutableCommand;
 import org.drools.core.command.impl.RegistryContext;
 import org.drools.core.impl.EnvironmentFactory;
 import org.drools.core.impl.InternalKnowledgeBase;
@@ -25,15 +27,13 @@ import org.drools.core.impl.KnowledgeBaseFactory;
 import org.drools.persistence.infinispan.marshaller.InfinispanPlaceholderResolverStrategy;
 import org.infinispan.Cache;
 import org.infinispan.manager.DefaultCacheManager;
+import org.kie.api.command.ExecutableCommand;
 import org.kie.api.runtime.Context;
 import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.EnvironmentName;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
-
-import java.io.Serializable;
-import java.util.HashMap;
 
 import static org.drools.persistence.jta.JtaTransactionManagerTest.COMMAND_ENTITY_MANAGER;
 import static org.drools.persistence.jta.JtaTransactionManagerTest.COMMAND_ENTITY_MANAGER_FACTORY;

--- a/kie-infinispan/drools-infinispan-persistence/src/test/java/org/drools/persistence/session/RuleFlowGroupRollbackTest.java
+++ b/kie-infinispan/drools-infinispan-persistence/src/test/java/org/drools/persistence/session/RuleFlowGroupRollbackTest.java
@@ -15,8 +15,11 @@
  */
 package org.drools.persistence.session;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
 import org.drools.core.command.impl.CommandBasedStatefulKnowledgeSession;
-import org.drools.core.command.impl.ExecutableCommand;
 import org.drools.core.command.impl.RegistryContext;
 import org.drools.core.common.InternalAgenda;
 import org.drools.core.impl.InternalKnowledgeBase;
@@ -26,6 +29,7 @@ import org.drools.persistence.util.PersistenceUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.kie.api.command.ExecutableCommand;
 import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.Context;
 import org.kie.api.runtime.Environment;
@@ -33,10 +37,6 @@ import org.kie.api.runtime.KieSession;
 import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
 import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 
 import static org.drools.persistence.util.PersistenceUtil.DROOLS_PERSISTENCE_UNIT_NAME;
 import static org.drools.persistence.util.PersistenceUtil.createEnvironment;

--- a/kie-infinispan/jbpm-infinispan-persistence/src/main/java/org/jbpm/persistence/ManualPersistProcessInterceptor.java
+++ b/kie-infinispan/jbpm-infinispan-persistence/src/main/java/org/jbpm/persistence/ManualPersistProcessInterceptor.java
@@ -15,9 +15,10 @@
 
 package org.jbpm.persistence;
 
+import java.util.Collection;
+
 import org.drools.core.command.SingleSessionCommandService;
 import org.drools.core.command.impl.AbstractInterceptor;
-import org.drools.core.command.impl.ExecutableCommand;
 import org.drools.core.command.runtime.process.AbortProcessInstanceCommand;
 import org.drools.core.command.runtime.process.AbortWorkItemCommand;
 import org.drools.core.command.runtime.process.CompleteWorkItemCommand;
@@ -34,12 +35,11 @@ import org.jbpm.persistence.api.ProcessPersistenceContextManager;
 import org.jbpm.persistence.processinstance.ProcessInstanceInfo;
 import org.jbpm.process.instance.ProcessInstance;
 import org.kie.api.command.Command;
+import org.kie.api.command.ExecutableCommand;
 import org.kie.api.runtime.Context;
 import org.kie.api.runtime.Executable;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.RequestContext;
-
-import java.util.Collection;
 
 public class ManualPersistProcessInterceptor extends AbstractInterceptor {
 

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/BaseKieServerClientKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/BaseKieServerClientKarafIntegrationTest.java
@@ -16,10 +16,15 @@
 
 package org.kie.karaf.itest.kieserver;
 
-import org.drools.core.command.impl.ExecutableCommand;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.drools.core.command.runtime.BatchExecutionCommandImpl;
 import org.drools.core.command.runtime.rule.FireAllRulesCommand;
 import org.drools.core.command.runtime.rule.InsertObjectCommand;
+import org.kie.api.command.ExecutableCommand;
 import org.kie.karaf.itest.AbstractKarafIntegrationTest;
 import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.KieContainerResource;
@@ -41,13 +46,11 @@ import org.ops4j.pax.exam.karaf.options.LogLevelOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.Assert.*;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
 /**
  * These tests aims at verifying if KieServerClient can run on Karaf.

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieContainerCommandServiceImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieContainerCommandServiceImpl.java
@@ -15,9 +15,15 @@
 
 package org.kie.server.services.impl;
 
-import org.drools.core.command.impl.ExecutableCommand;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.drools.core.command.runtime.BatchExecutionCommandImpl;
 import org.kie.api.command.Command;
+import org.kie.api.command.ExecutableCommand;
 import org.kie.api.runtime.CommandExecutor;
 import org.kie.api.runtime.ExecutionResults;
 import org.kie.server.api.commands.CallContainerCommand;
@@ -42,12 +48,6 @@ import org.kie.server.services.api.KieServerRegistry;
 import org.kie.server.services.impl.locator.ContainerLocatorProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class KieContainerCommandServiceImpl implements KieContainerCommandService<ExecutionResults> {
 

--- a/kie-server-parent/kie-server-services/kie-server-services-drools/src/main/java/org/kie/server/services/drools/DroolsKieContainerCommandServiceImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-drools/src/main/java/org/kie/server/services/drools/DroolsKieContainerCommandServiceImpl.java
@@ -15,9 +15,11 @@
 
 package org.kie.server.services.drools;
 
-import org.drools.core.command.impl.ExecutableCommand;
+import java.util.Arrays;
+
 import org.drools.core.command.runtime.BatchExecutionCommandImpl;
 import org.kie.api.command.Command;
+import org.kie.api.command.ExecutableCommand;
 import org.kie.api.runtime.ExecutionResults;
 import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.ServiceResponse;
@@ -28,8 +30,6 @@ import org.kie.server.services.impl.KieServerImpl;
 import org.kie.server.services.impl.locator.ContainerLocatorProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Arrays;
 
 public class DroolsKieContainerCommandServiceImpl extends KieContainerCommandServiceImpl {
 


### PR DESCRIPTION
@mariofusco 
Changed import to use public KIE API instead of the old Drools internal