### PR TITLE
Fix test failure in WebSocketKieControllerRuleCapabilitiesIntegration…

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
@@ -82,6 +82,9 @@ public class TestConfig {
 
     private static final StringTestParameter JMS_SKIP = new StringTestParameter("jms.skip");
 
+    private static final StringTestParameter KIE_SERVER_REMOTE_REPO_DIR = new StringTestParameter("kie.server.testing.remote.repo.dir");
+    private static final StringTestParameter KIE_SERVER_LOCAL_REPO_DIR = new StringTestParameter("kie.server.testing.server.local.repo.dir");
+
     /**
      * Property holding datasource driver class FQCN to determine which DB the tests are currently run with
      */
@@ -460,6 +463,20 @@ public class TestConfig {
      */
     public static String getKieServerMavenSettings() {
         return TestConfig.KIE_SERVER_MAVEN_SETTINGS.getParameterValue();
+    }
+
+    /**
+     * @return Location of Kie server remote repo directory.
+     */
+    public static String getKieServerRemoteRepoDir() {
+        return TestConfig.KIE_SERVER_REMOTE_REPO_DIR.getParameterValue();
+    }
+
+    /**
+     * @return Location of Kie server local repo directory.
+     */
+    public static String getKieServerLocalRepoDir() {
+        return TestConfig.KIE_SERVER_LOCAL_REPO_DIR.getParameterValue();
     }
 
     /**

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerRuleCapabilitiesIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerRuleCapabilitiesIntegrationTest.java
@@ -18,11 +18,14 @@ package org.kie.server.integrationtests.controller;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieContainerStatus;
@@ -36,6 +39,7 @@ import org.kie.server.controller.api.model.spec.RuleConfig;
 import org.kie.server.controller.api.model.spec.ServerTemplate;
 import org.kie.server.controller.client.exception.KieServerControllerClientException;
 import org.kie.server.controller.impl.storage.InMemoryKieServerTemplateStorage;
+import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.KieServerSynchronization;
@@ -44,8 +48,8 @@ public abstract class KieControllerRuleCapabilitiesIntegrationTest<T extends Kie
 
     private KieServerInfo kieServerInfo;
 
-    @BeforeClass
-    public static void initialize() throws Exception {
+    @Before
+    public void initializeRemoteRepo() throws Exception {
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProject(ClassLoader.class.getResource("/kjars-sources/stateless-session-kjar").getFile());
     }
@@ -64,8 +68,15 @@ public abstract class KieControllerRuleCapabilitiesIntegrationTest<T extends Kie
     }
 
     @After
-    public void removeNewContainer() {
-        KieServerDeployer.removeLocalArtifact(RELEASE_ID_101);
+    public void cleanAllRepos() throws IOException {
+        File kieServerRemoteRepoDir = new File(TestConfig.getKieServerRemoteRepoDir());
+        File kieServerLocalRepoDir = new File(TestConfig.getKieServerLocalRepoDir());
+
+        FileUtils.deleteDirectory(kieServerRemoteRepoDir);
+        FileUtils.deleteDirectory(kieServerLocalRepoDir);
+
+        kieServerRemoteRepoDir.mkdir();
+        kieServerLocalRepoDir.mkdir();
     }
 
     @Test //RHPAM-479

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -332,6 +332,8 @@
                 <systemPropertyVariables>
                   <kie.server.server.deployment.settings.xml>${kie.server.server.deployment.settings.xml}</kie.server.server.deployment.settings.xml>
                   <jms.skip>${jms.skip}</jms.skip>
+                  <kie.server.testing.server.local.repo.dir>${kie.server.testing.server.local.repo.dir}</kie.server.testing.server.local.repo.dir>
+                  <kie.server.testing.remote.repo.dir>${kie.server.testing.remote.repo.dir}</kie.server.testing.remote.repo.dir>
                 </systemPropertyVariables>
               </configuration>
             </execution>


### PR DESCRIPTION
…Test

Some recent change (didn't identify it) caused failures in KieControllerRuleCapabilitiesIntegrationTest.testScanNow(). In this test class there are several test methods updating kjar and container from version 1.0.0 to 1.0.1. Cleanup was solved by deleting 1.0.1 kjar from Kie server local repo. It used to be sufficient as when container with LATEST version was created the Kie server seemed to check just its own local repo for kjars with appropriate versions.

Now the behavior is changed and Kie server checks also remote repos for latest kjar in case LATEST container is created. However deleting kjar with version 1.0.1 in remote repo is not enough as the versions are also stored in maven-metadata....xml and they are used by Kie server when resolving the version. Rather then deleting maven-metadata....xml I decided to completely delete repos as it is cleaner solution (Maven java client doesn't support artifact removal and I want to keep environment as consistent as possible).