### PR TITLE
PLANNER-614: Rename getContainers() to getSolverInstances()

### DIFF
--- a/kie-server-parent/kie-server-api/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-api/src/build/revapi-config.json
@@ -203,6 +203,24 @@
           "methodName": "setLastModificationUser",
           "elementKind": "method",
           "justification": "JBPM-6890: Adding the customTaskID as a unique identifier for an active"
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method java.util.List<org.kie.server.api.model.instance.SolverInstance> org.kie.server.api.model.instance.SolverInstanceList::getContainers()",
+          "package": "org.kie.server.api.model.instance",
+          "classSimpleName": "SolverInstanceList",
+          "methodName": "getContainers",
+          "elementKind": "method",
+          "justification": "PLANNER-614: Fix method name. Method renamed to getSolverInstances()"
+        },
+        {
+          "code": "java.method.removed",
+          "old": "method void org.kie.server.api.model.instance.SolverInstanceList::setContainers(java.util.List<org.kie.server.api.model.instance.SolverInstance>)",
+          "package": "org.kie.server.api.model.instance",
+          "classSimpleName": "SolverInstanceList",
+          "methodName": "setContainers",
+          "elementKind": "method",
+          "justification": "PLANNER-614: Fix method name. Method renamed to setSolverInstances()"
         }
       ]
     }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/SolverInstanceList.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/SolverInstanceList.java
@@ -43,11 +43,11 @@ public class SolverInstanceList {
         this.solvers = solvers;
     }
 
-    public List<SolverInstance> getContainers() {
+    public List<SolverInstance> getSolverInstances() {
         return solvers;
     }
 
-    public void setContainers(List<SolverInstance> solvers) {
+    public void setSolverInstances(List<SolverInstance> solvers) {
         this.solvers = solvers;
     }
 

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/SolverServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/SolverServicesClientImpl.java
@@ -77,8 +77,8 @@ public class SolverServicesClientImpl
             }
             solverInstanceList = response.getResult();
         }
-        if (solverInstanceList != null && solverInstanceList.getContainers() != null) {
-            return new ArrayList<>(solverInstanceList.getContainers());
+        if (solverInstanceList != null && solverInstanceList.getSolverInstances() != null) {
+            return new ArrayList<>(solverInstanceList.getSolverInstances());
         }
 
         return Collections.emptyList();

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/jms/OptaPlannerJmsResponseHandlerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/jms/OptaPlannerJmsResponseHandlerIntegrationTest.java
@@ -122,8 +122,8 @@ public class OptaPlannerJmsResponseHandlerIntegrationTest extends OptaplannerKie
         assertThat(solverInstanceList).isNull();
         SolverInstanceList solverList = responseCallback.get(SolverInstanceList.class);
         assertThat(solverList).isNotNull();
-        assertThat(solverList.getContainers()).isNotNull().isNotEmpty().hasSize(1);
-        solver = solverList.getContainers().get(0);
+        assertThat(solverList.getSolverInstances()).isNotNull().isNotEmpty().hasSize(1);
+        solver = solverList.getSolverInstances().get(0);
         assertThat(solver.getSolverId()).isEqualTo(SOLVER_1_ID);
         assertThat(solver.getStatus()).isEqualTo(SolverInstance.SolverStatus.NOT_SOLVING);
 
@@ -155,7 +155,7 @@ public class OptaPlannerJmsResponseHandlerIntegrationTest extends OptaplannerKie
         assertThat(response).isNull();
         solverList = responseCallback.get(SolverInstanceList.class);
         assertThat(solverList).isNotNull();
-        assertThat(solverList.getContainers()).isNullOrEmpty();
+        assertThat(solverList.getSolverInstances()).isNullOrEmpty();
     }
 
     @Test


### PR DESCRIPTION
I _believe_ this doesn't break any user-facing API:

1. The method name doesn't affect marshalling output. JSON, JAXB and XStream formats are unchanged after the rename. Just for the record:

## JSON
```json
{
  "solver" : [ {
    "container-id" : "employeerostering_1.0.0-SNAPSHOT",
    "solver-id" : "solver1",
    "solver-config-file" : "employeerostering/employeerostering/EmployeeRosteringSolverConfig.solver.xml",
    "status" : "NOT_SOLVING",
    "score" : {
      "value" : null,
      "scoreClass" : null
    },
    "best-solution" : null
  } ]
}
```
## JAXB
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<solvers>
    <solver>
        <container-id>employeerostering_1.0.0-SNAPSHOT</container-id>
        <solver-id>solver1</solver-id>
        <solver-config-file>employeerostering/employeerostering/EmployeeRosteringSolverConfig.solver.xml</solver-config-file>
        <status>NOT_SOLVING</status>
        <score/>
    </solver>
</solvers>
```
## XStream
```xml
<org.kie.server.api.model.instance.SolverInstanceList>
  <solvers>
    <solver-instance>
      <container-id>employeerostering_1.0.0-SNAPSHOT</container-id>
      <solver-id>solver1</solver-id>
      <solver-config-file>employeerostering/employeerostering/EmployeeRosteringSolverConfig.solver.xml</solver-config-file>
      <status>NOT_SOLVING</status>
      <score/>
    </solver-instance>
  </solvers>
</org.kie.server.api.model.instance.SolverInstanceList>
```
2. Remote Java client is unaffected because the renamed method is not exposed in its API.