### PR TITLE
missing imports for com.fasterxml.jackson upgrade

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/ServiceResponse.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/ServiceResponse.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamAsAttribute;
@@ -161,6 +162,7 @@ public class ServiceResponse<T> implements KieServiceResponse<T> {
             @XmlElement(name = "dmn-model-info-list" , type = DMNModelInfoList.class)
 
             })
+    @JsonProperty
     private T result;
 
     public ServiceResponse() {

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/commands/KieServerControllerDescriptorCommand.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/commands/KieServerControllerDescriptorCommand.java
@@ -24,6 +24,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.kie.server.api.model.KieServerCommand;
 import org.kie.server.api.model.ReleaseId;
@@ -56,6 +57,7 @@ public class KieServerControllerDescriptorCommand implements KieServerCommand {
             @XmlElement(name = "arguments", type = String.class),
             @XmlElement(name = "long", type = Long.class)
     })
+    @JsonProperty
     private List<Object> arguments;
 
     @XmlElement(name = "payload")

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/KieServerControllerServiceResponse.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/KieServerControllerServiceResponse.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.kie.server.api.model.KieServiceResponse;
 import org.kie.server.controller.api.model.runtime.ContainerList;
@@ -56,6 +57,7 @@ public class KieServerControllerServiceResponse<T> implements KieServiceResponse
             @XmlElement(name = "server-instance-key", type = ServerInstanceKey.class),
             @XmlElement(name = "container-details-list", type = ContainerList.class)
     })
+    @JsonProperty
     private T result;
 
     public KieServerControllerServiceResponse() {

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/notification/KieServerControllerNotification.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/notification/KieServerControllerNotification.java
@@ -23,6 +23,7 @@ import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.kie.server.controller.api.model.events.*;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @XmlRootElement(name = "notification")
 @XmlAccessorType(XmlAccessType.NONE)
@@ -39,6 +40,7 @@ public class KieServerControllerNotification {
             @XmlElement(name = "container-spec-updated", type = ContainerSpecUpdated.class)
     })
 
+    @JsonProperty
     private KieServerControllerEvent event;
 
     public KieServerControllerNotification() {


### PR DESCRIPTION
DON'T merge this:
This has to be merged together with 
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/830
https://github.com/kiegroup/appformer/pull/461
https://github.com/kiegroup/kie-soup/pull/58
when the new jboss-ip-bom 8.2.0.Final was released and kie reps upgraded to use this ip-bom