### PR TITLE
[7.11.x] Stabilize SpringBoot tests

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
@@ -239,6 +239,7 @@
               <org.jbpm.ui.server.ext.disabled>true</org.jbpm.ui.server.ext.disabled>
               <org.optaplanner.server.ext.disabled>true</org.optaplanner.server.ext.disabled>
               <org.jbpm.case.server.ext.disabled>true</org.jbpm.case.server.ext.disabled>
+              <org.kie.swagger.server.ext.disabled>true</org.kie.swagger.server.ext.disabled>
             </systemPropertyVariables>
           </configuration>
         </plugin>
@@ -279,6 +280,7 @@
               <org.jbpm.ui.server.ext.disabled>true</org.jbpm.ui.server.ext.disabled>
               <org.optaplanner.server.ext.disabled>true</org.optaplanner.server.ext.disabled>
               <org.jbpm.case.server.ext.disabled>true</org.jbpm.case.server.ext.disabled>
+              <org.kie.swagger.server.ext.disabled>true</org.kie.swagger.server.ext.disabled>
               <kie.maven.settings.custom>${project.build.testOutputDirectory}/kie-server-testing-server-custom-settings.xml</kie.maven.settings.custom>
             </systemProperties>
           </container>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/KieServerIntegrationTest.java
@@ -53,9 +53,8 @@ public class KieServerIntegrationTest extends RestJmsSharedBaseIntegrationTest {
         assertEquals(getServerVersion(), info.getVersion());
 
         // Kie server has all extensions disabled, available just default capability.
-        assertEquals(2, info.getCapabilities().size());
+        assertEquals(1, info.getCapabilities().size());
         assertEquals("KieServer", info.getCapabilities().get(0));
-        assertEquals("Swagger", info.getCapabilities().get(1));
     }
 
     private String getServerVersion() {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/ProcessServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/ProcessServiceIntegrationTest.java
@@ -462,7 +462,7 @@ public class ProcessServiceIntegrationTest extends JbpmKieServerBaseIntegrationT
 
     @Test(expected = KieServicesException.class)
     public void testGetNonExistingProcessInstance() {
-        processClient.getProcessInstance(CONTAINER_ID, 9999l);
+        processClient.getProcessInstance(CONTAINER_ID, -9999l);
     }
 
     @Test

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -1096,6 +1096,8 @@
                         <outputDirectory>${project.build.directory}</outputDirectory>
                       </artifactItem>
                     </artifactItems>
+                    <!-- Always produce the -SNAPSHOT suffix instead of a timestamp -->
+                    <useBaseVersion>true</useBaseVersion>
                   </configuration>
                 </execution>
               </executions>


### PR DESCRIPTION
Small refinements as discussed + springboot test jar now has a name ending in -SNAPSHOT instead of a volatile timestamp, so it can be automatically tested with the latest SNAPSHOT version (before it couldn't locate the correct jar file).