### PR TITLE
Cleanup allocated port when embedded server is turned off

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
@@ -195,6 +195,13 @@ public class TestConfig {
     }
 
     /**
+     * Cleanup Kie server allocated port so next time the embedded Kie server is created the new port is allocated.
+     */
+    public static void cleanKieServerAllocatedPort() {
+        ALLOCATED_PORT = null;
+    }
+
+    /**
      * Get allocated port of embedded REST server.
      *
      * @return HTTP port number.
@@ -213,6 +220,13 @@ public class TestConfig {
         }
 
         return CONTROLLER_ALLOCATED_PORT;
+    }
+
+    /**
+     * Cleanup Controller allocated port so next time the embedded Controller is created the new port is allocated.
+     */
+    public static void cleanControllerAllocatedPort() {
+        CONTROLLER_ALLOCATED_PORT = null;
     }
 
     /**

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieControllerExecutor.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieControllerExecutor.java
@@ -42,5 +42,6 @@ public class KieControllerExecutor {
         }
         controller.stop();
         controller = null;
+        TestConfig.cleanControllerAllocatedPort();
     }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerExecutor.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerExecutor.java
@@ -107,5 +107,6 @@ public class KieServerExecutor {
         ((KieServicesImpl) KieServices.Factory.get()).nullAllContainerIds();
         server.stop();
         server = null;
+        TestConfig.cleanKieServerAllocatedPort();
     }
 }


### PR DESCRIPTION
To avoid rare BindException failures caused by occupied port in case embedded server is used in test.