### PR TITLE
[JBPM-7834] Provide OpenShiftStartupStrategy

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
@@ -41,6 +41,9 @@ public class KieServerConstants {
     public static final String KIE_SERVER_JAAS_DOMAIN = "org.kie.server.domain";
     public static final String KIE_SERVER_CONTROLLER = "org.kie.server.controller";
     public static final String KIE_SERVER_STATE_REPO = "org.kie.server.repo";
+    public static final String KIE_SERVER_STATE_REPO_TYPE_DEFAULT = "KieServerStateFileRepository";
+    public static final String KIE_SERVER_STATE_REPO_TYPE_CLOUD = "KieServerStateCloudRepository";
+    public static final String KIE_SERVER_STATE_REPO_TYPE_OPENSHIFT = "KieServerStateOpenShiftRepository";
     public static final String KIE_SERVER_CONTAINER_DEPLOYMENT = "org.kie.server.container.deployment";
     public static final String KIE_SERVER_CONTAINER_LOCATOR = "org.kie.server.container.locator";
     public static final String KIE_SERVER_ACTIVATE_POLICIES = "org.kie.server.policy.activate";

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerEnvironment.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerEnvironment.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -21,16 +21,17 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-
 public class KieServerEnvironment {
-    
+
     private static final Pattern VERSION_PAT = Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)([\\.-].*)?");
     private static Version version;
-    private static String serverId = System.getProperty(KieServerConstants.KIE_SERVER_ID);
-    private static String name = System.getProperty(KieServerConstants.KIE_SERVER_ID);
+    private static String serverId = System.getProperty(KieServerConstants.KIE_SERVER_ID, System.getenv("KIE_SERVER_ID"));
+    private static String name;
     private static String contextRoot;
 
     static {
+        name = serverId;
+
         String kieServerString = KieServerEnvironment.class.getPackage().getImplementationVersion();
         if (kieServerString == null) {
             InputStream is = null;
@@ -41,7 +42,7 @@ public class KieServerEnvironment {
                 kieServerString = properties.get("kie.server.version").toString();
 
                 is.close();
-            } catch ( IOException e ) {
+            } catch (IOException e) {
                 throw new RuntimeException(e);
             } finally {
                 if (is != null) {
@@ -55,14 +56,14 @@ public class KieServerEnvironment {
         }
 
         Matcher m = VERSION_PAT.matcher(kieServerString);
-        if( m.matches() ) {
+        if (m.matches()) {
             try {
-                version = new Version( Integer.parseInt(m.group(1)), 
-                        Integer.parseInt(m.group(2)), 
-                        Integer.parseInt(m.group(3)),
-                        m.group(4) );
+                version = new Version(Integer.parseInt(m.group(1)),
+                                      Integer.parseInt(m.group(2)),
+                                      Integer.parseInt(m.group(3)),
+                                      m.group(4));
             } catch (NumberFormatException e) {
-                version = new Version(0,0,0,null);
+                version = new Version(0, 0, 0, null);
             }
         }
 
@@ -82,7 +83,7 @@ public class KieServerEnvironment {
             System.setProperty(KieServerConstants.KIE_SERVER_ID, serverIdIn);
         }
     }
-    
+
     public static String getServerName() {
         return name;
     }
@@ -91,12 +92,12 @@ public class KieServerEnvironment {
         name = nameIn;
     }
 
-	public static String getContextRoot() {
-		return contextRoot;
-	}
+    public static String getContextRoot() {
+        return contextRoot;
+    }
 
-	public static void setContextRoot(String contextRootIn) {
-		contextRoot = contextRootIn;
-	}
-    
+    public static void setContextRoot(String contextRootIn) {
+        contextRoot = contextRootIn;
+    }
+
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/StartupStrategy.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/StartupStrategy.java
@@ -18,6 +18,7 @@ package org.kie.server.services.api;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.services.impl.ContainerManager;
 import org.kie.server.services.impl.KieServerImpl;
@@ -30,5 +31,9 @@ public interface StartupStrategy {
     default Set<KieContainerResource> prepareContainers(Set<KieContainerResource> containers) {
         // be default do nothing
         return containers;
+    }
+    
+    default String getRepositoryType() {
+        return KieServerConstants.KIE_SERVER_STATE_REPO_TYPE_DEFAULT;
     }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/StartupStrategyProvider.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/StartupStrategyProvider.java
@@ -32,9 +32,12 @@ public class StartupStrategyProvider {
     private static StartupStrategyProvider INSTANCE = new StartupStrategyProvider();
 
     private Map<String, StartupStrategy> foundStrategies = new HashMap<>();
-    private String strategyName = System.getProperty(KieServerConstants.KIE_SERVER_STARTUP_STRATEGY, ControllerBasedStartupStrategy.class.getSimpleName());
-
+    private String strategyName = System.getProperty(KieServerConstants.KIE_SERVER_STARTUP_STRATEGY, 
+                                                     System.getenv("KIE_SERVER_STARTUP_STRATEGY"));
     private StartupStrategyProvider() {
+        if (strategyName == null || strategyName.length() == 0) {
+            strategyName = ControllerBasedStartupStrategy.class.getSimpleName();
+        }
 
         strategies.forEach( s -> {
                     foundStrategies.put(s.getClass().getSimpleName(), s);

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/.gitignore
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/.gitignore
@@ -1,0 +1,11 @@
+/target
+/local
+*.tlog
+
+# Eclipse, Netbeans and IntelliJ files
+/.*
+!.gitignore
+/nbproject
+/*.ipr
+/*.iws
+/*.iml

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/pom.xml
@@ -1,0 +1,156 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.kie.server</groupId>
+    <artifactId>kie-server-services</artifactId>
+    <version>7.16.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>kie-server-services-openshift</artifactId>
+  <packaging>jar</packaging>
+
+  <name>KIE :: Execution Server :: Services :: OpenShift</name>
+  <description>KIE Execution Server Services</description>
+
+  <properties>
+    <java.module.name>org.kie.server.services.openshift</java.module.name>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-client-bom</artifactId>
+        <version>${version.kubernetes-client}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- Override fabric8 dependencies specified from parent pom with newer 
+        version -->
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-model</artifactId>
+        <version>${version.kubernetes-client}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-client</artifactId>
+        <version>${version.kubernetes-client}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>openshift-client</artifactId>
+        <version>${version.kubernetes-client}</version>
+      </dependency>
+
+      <!-- Added back excluded dependency from parent pom due to required 
+        by test run -->
+      <dependency>
+        <groupId>org.yaml</groupId>
+        <artifactId>snakeyaml</artifactId>
+        <version>${version.org.yaml.snakeyaml}</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- kie server dependencies -->
+    <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-controller-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-commons</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-services-common</artifactId>
+    </dependency>
+    <!-- log -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.thoughtworks.xstream</groupId>
+      <artifactId>xstream</artifactId>
+    </dependency>
+
+    <!-- fabric8 kubernetes and openshift java client dependencies -->
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>openshift-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-server-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>openshift-server-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.surefire.plugin}</version>
+        <configuration>
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
+          <environmentVariables>
+            <KUBERNETES_MASTER />
+            <KUBERNETES_API_VERSION />
+            <KUBERNETES_TRUST_CERTIFICATES />
+            <KUBERNETES_CERTS_CA_FILE />
+            <KUBERNETES_CERTS_CA_DATA />
+            <KUBERNETES_CERTS_CLIENT_FILE />
+            <KUBERNETES_CERTS_CLIENT_DATA />
+            <KUBERNETES_CERTS_CLIENT_KEY_FILE />
+            <KUBERNETES_CERTS_CLIENT_KEY_DATA />
+            <KUBERNETES_CERTS_CLIENT_KEY_ALGO />
+            <KUBERNETES_CERTS_CLIENT_KEY_PASSPHRASE />
+            <KUBERNETES_AUTH_BASIC_USERNAME />
+            <KUBERNETES_AUTH_BASIC_PASSWORD />
+            <KUBERNETES_AUTH_TRYKUBECONFIG />
+            <KUBERNETES_AUTH_TRYSERVICEACCOUNT />
+            <KUBERNETES_AUTH_TOKEN />
+            <KUBERNETES_WATCH_RECONNECTINTERVAL />
+            <KUBERNETES_WATCH_RECONNECTLIMIT />
+            <KUBERNETES_REQUEST_TIMEOUT />
+            <KUBERNETES_NAMESPACE />
+            <KUBERNETES_TLS_VERSIONS>TLSv1.2,TLSv1.1,TLSv1</KUBERNETES_TLS_VERSIONS>
+          </environmentVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/api/KieServerReadinessProbe.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/api/KieServerReadinessProbe.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.services.openshift.api;
+
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import org.kie.server.services.impl.KieServerLocator;
+
+public interface KieServerReadinessProbe {
+
+    default boolean isKieServerReady() {
+        return KieServerLocator.getInstance().isKieServerReady();
+    }
+
+    /**
+     * @param dc
+     * @return true if there are no ongoing DeploymentConfig activities, such as rollout and scale etc.
+     */
+    default boolean isDCStable(DeploymentConfig dc) {
+        return "True".equals(dc.getStatus().getConditions().get(0).getStatus()) && dc.getStatus().getUnavailableReplicas() == 0;
+    }
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/impl/OpenShiftStartupStrategy.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/impl/OpenShiftStartupStrategy.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.services.openshift.impl;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.controller.api.model.KieServerSetup;
+import org.kie.server.services.api.StartupStrategy;
+import org.kie.server.services.impl.ContainerManager;
+import org.kie.server.services.impl.KieServerImpl;
+import org.kie.server.services.impl.storage.KieServerState;
+import org.kie.server.services.openshift.api.KieServerReadinessProbe;
+import org.kie.server.services.openshift.impl.storage.cloud.CloudClientFactory;
+import org.kie.server.services.openshift.impl.storage.cloud.KieServerStateCloudRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OpenShiftStartupStrategy implements StartupStrategy {
+
+    private static final String KIE_SERVER_ROLLOUT_IN_PROGRESS = "kieserver-rollout-in-progress";
+    private static final String KIE_SERVER_INSTANCE_ID = "kieserver-" + UUID.randomUUID().toString();
+    private static final String ROLLOUT_TRIGGER_TIMESTAMP = "services.server.kie.org/openshift-startup-strategy.changeTimestamp";
+    private static final Logger logger = LoggerFactory.getLogger(OpenShiftStartupStrategy.class);
+
+    private static Supplier<OpenShiftClient> clouldClientHelper = () -> (new CloudClientFactory() {}).createOpenShiftClient();
+
+    private static class WatchRunner implements Runnable, KieServerReadinessProbe {
+
+        private boolean isWatchRunning = true;
+        private String kieServerId;
+
+        public WatchRunner(String serverId) {
+            kieServerId = serverId;
+        }
+
+        @Override
+        public void run() {
+            try (OpenShiftClient client = clouldClientHelper.get()) {
+                logger.info("Watching ConfigMap in namespace: [{}]", client.getNamespace());
+                try (Watch watchable = client.configMaps().watch(new Watcher<ConfigMap>() {
+                    @Override
+                    public void eventReceived(Action action, ConfigMap kieServerState) {
+                        logger.debug("Event - Action: {}, {} on ConfigMap ",
+                                    action, kieServerState.getMetadata().getName());
+
+                        DeploymentConfig dc = client.deploymentConfigs().withName(kieServerId).get();
+                        if (kieServerId.equals(kieServerState.getMetadata().getName()) 
+                                && action.equals(Action.MODIFIED) 
+                                && isRolloutRequired(client, kieServerId, isDCStable(dc))) {
+
+                            ObjectMeta md = dc.getSpec().getTemplate().getMetadata();
+                            Map<String, String> ann = md.getAnnotations() == null ? new HashMap<>() : md.getAnnotations();
+                            md.setAnnotations(ann);
+                            ann.put(ROLLOUT_TRIGGER_TIMESTAMP,
+                                    ZonedDateTime.now().format(DateTimeFormatter.ISO_INSTANT));
+                            client.deploymentConfigs().createOrReplace(dc);
+
+                            logger.info("Updated DeploymentConfig: {}", md.getName());
+                        } else {
+                            logger.debug("Event - Ignored");
+                        }
+                    }
+
+                    @Override
+                    public void onClose(KubernetesClientException cause) {
+                        logger.info("Watcher closed.");
+                        if (cause != null) {
+                            logger.info(cause.getMessage());
+                        }
+                    }
+                })) {
+                    logger.info("Watcher created");
+
+                    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                        synchronized (this) {
+                            isWatchRunning = false;
+                            notifyAll();
+                            logger.info("ShutdownHook sent notifyAll");
+                        }
+                    }));
+
+                    synchronized (this) {
+                        while (isWatchRunning && !Thread.currentThread().isInterrupted()) {
+                            logger.info("WatchRunner thread run");
+                            try {
+                                wait();
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                logger.error("WatchRunner thread being interrupted", e);
+                            }
+                            logger.info("WatchRunner thread being notified");
+                        }
+                        logger.info("WatchRunner thread exits");
+                    }
+                }
+            } catch (KubernetesClientException kce) {
+                logger.error("WatchRunner thread failed", kce);
+            }
+        }
+
+        private static boolean isRolloutRequired(OpenShiftClient client, String kieServerId, boolean isDCStable) {
+            boolean pullTrigger = false;
+            String triggerName = KIE_SERVER_ROLLOUT_IN_PROGRESS + "-" + kieServerId;
+            ConfigMap cm = client.configMaps().withName(kieServerId).get();
+            Map<String, String> ann = cm.getMetadata().getAnnotations();
+
+            if (ann != null && ann.containsKey(KieServerStateCloudRepository.ROLLOUT_REQUIRED)) {
+                try {
+                    if (isDCStable) {
+                        // Create temporary rollout-in-progress configmap only if there is no DC activities.
+                        client.configMaps().create(new ConfigMapBuilder()
+                                                   .withNewMetadata()
+                                                     .withName(triggerName)
+                                                     .withLabels(Collections.singletonMap(KIE_SERVER_INSTANCE_ID, kieServerId))
+                                                   .endMetadata()
+                                                   .build());
+                        pullTrigger = true;
+                        logger.info("KieServer: {}, DC rollout - Begin", KIE_SERVER_INSTANCE_ID);
+                    } else {
+                        logger.info("KieServer: {}, DC rollout - In progress", KIE_SERVER_INSTANCE_ID);
+                    }
+                    
+                    /**
+                     * Cleanup the configmap annotation related to rollout-in-progress
+                     */
+                    ann.remove(KieServerStateCloudRepository.ROLLOUT_REQUIRED);
+                    client.configMaps().createOrReplace(cm);
+                } catch (KubernetesClientException kce) {
+                    logger.info("Mark DC rollout failed", kce);
+                }
+            }
+            return pullTrigger;
+        }
+    }
+
+    @Override
+    public void startup(KieServerImpl kieServer,
+                        ContainerManager containerManager,
+                        KieServerState currentState,
+                        AtomicBoolean kieServerActive) {
+
+        String kieServerId = currentState.getConfiguration()
+                                         .getConfigItem(KieServerConstants.KIE_SERVER_ID).getValue();
+
+        try (OpenShiftClient client = clouldClientHelper.get()) {
+
+            Set<KieContainerResource> containers = prepareContainers(currentState.getContainers());
+            containerManager.installContainersSync(kieServer, containers, currentState, new KieServerSetup());
+
+            new Thread(new WatchRunner(kieServerId)).start();
+
+            clearRollout(client, kieServerId);
+        }
+    }
+
+    private static void clearRollout(OpenShiftClient client, String kieServerId) {
+        String triggerName = KIE_SERVER_ROLLOUT_IN_PROGRESS + "-" + kieServerId;
+
+        // Cleanup the configmap related to rollout-in-progress if needed
+        if (client.configMaps().withName(triggerName).delete())
+            logger.info("Kie server: {}, DC rollout - End", KIE_SERVER_INSTANCE_ID);
+    }
+    
+    @Override
+    public String getRepositoryType() {
+        return KieServerConstants.KIE_SERVER_STATE_REPO_TYPE_OPENSHIFT;
+    }
+
+    @Override
+    public String toString() {
+        return "OpenShiftStartupStrategy - deploys only kie containers defined from OpenShift ConfigMap, ignores kie containers given by controller";
+    }
+
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/impl/storage/cloud/CloudClientConstants.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/impl/storage/cloud/CloudClientConstants.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.services.openshift.impl.storage.cloud;
+
+public class CloudClientConstants {
+    public static final String DEFAULT_TOKEN_LOCATION = "/var/run/secrets/kubernetes.io/serviceaccount/token";
+    public static final String ENV_VAR_API_SERVICE_HOST = "KUBERNETES_SERVICE_HOST";
+    public static final String ENV_VAR_API_SERVER_PORT = "KUBERNETES_SERVICE_PORT";
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/impl/storage/cloud/CloudClientFactory.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/impl/storage/cloud/CloudClientFactory.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.services.openshift.impl.storage.cloud;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.client.DefaultOpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public interface CloudClientFactory {
+
+    default OpenShiftClient createOpenShiftClient() {
+        return new DefaultOpenShiftClient(setupConfig());
+    }
+
+    default KubernetesClient createKubernetesClient() {
+        return new DefaultKubernetesClient(setupConfig());
+    }
+
+    default Config setupConfig() {
+        final Logger logger = LoggerFactory.getLogger(CloudClientFactory.class);
+        String masterUrl = System.getProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY);
+        String token = System.getProperty(Config.KUBERNETES_OAUTH_TOKEN_SYSTEM_PROPERTY);
+
+        if (masterUrl == null) {
+            masterUrl = new StringBuilder("https://")
+                    .append(System.getenv(CloudClientConstants.ENV_VAR_API_SERVICE_HOST))
+                    .append(":")
+                    .append(System.getenv(CloudClientConstants.ENV_VAR_API_SERVER_PORT))
+                    .toString();
+            System.setProperty(Config.KUBERNETES_MASTER_SYSTEM_PROPERTY, masterUrl);
+            logger.debug("MasterUrl: {}", masterUrl);
+        }
+        
+        if (token == null || token.length() == 0) {
+            try {
+                token = new String(Files.readAllBytes(Paths.get(CloudClientConstants.DEFAULT_TOKEN_LOCATION)));
+            } catch (IOException e) {
+                logger.error("Load kubenetes oauth token failed.", e);
+            }
+            System.setProperty(Config.KUBERNETES_OAUTH_TOKEN_SYSTEM_PROPERTY, token);
+            logger.debug("Token: [{}]", token);
+        }
+
+        return new ConfigBuilder().withMasterUrl(masterUrl).withOauthToken(token).build();
+    }
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateCloudRepository.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateCloudRepository.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.services.openshift.impl.storage.cloud;
+
+import java.util.function.Function;
+
+import javax.validation.constraints.NotNull;
+
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieServerConfigItem;
+import org.kie.server.services.impl.storage.KieServerState;
+import org.kie.server.services.impl.storage.KieServerStateRepository;
+import org.kie.server.services.openshift.api.KieServerReadinessProbe;
+import org.kie.soup.commons.xstream.XStreamUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KieServerStateCloudRepository implements KieServerStateRepository,
+                                           KieServerReadinessProbe, CloudClientFactory {
+
+    public static final String ROLLOUT_REQUIRED = "services.server.kie.org/openshift-startup-strategy.rolloutRequired";
+    public static final String CFG_MAP_DATA_KEY = "kie-server-state";
+    public static final String CFG_MAP_LABEL_NAME = "services.server.kie.org/kie-server-state";
+    public static final String CFG_MAP_LABEL_VALUE = "USED";
+    
+    protected static final String STATE_CHANGE_TIMESTAMP = "services.server.kie.org/kie-server-state.changeTimestamp";
+    private static final Logger logger = LoggerFactory.getLogger(KieServerStateCloudRepository.class);
+
+    protected final XStream xs;
+    
+    public static XStream initializeXStream() {
+        XStream xs = XStreamUtils.createTrustingXStream(new PureJavaReflectionProvider());
+        String[] voidDeny = {"void.class", "Void.class"};
+        xs.denyTypes(voidDeny);
+        xs.alias(CFG_MAP_DATA_KEY, KieServerState.class);
+        xs.alias("container", KieContainerResource.class);
+        xs.alias("config-item", KieServerConfigItem.class);
+
+        return xs;
+    }
+
+    public KieServerStateCloudRepository() {
+        xs = initializeXStream();
+    }
+
+    @Override
+    @NotNull
+    public KieServerState load(@NotNull String serverId) {
+        KieServerState kieServerState = processKieServerState(client -> {
+            ConfigMap cm = client.configMaps().withName(serverId).get();
+            if (cm == null) {
+                throw new IllegalStateException(("KieServerId: [" + serverId + "], not found. Please create an associated ConfigMap with configuration first."));
+            }
+            return (KieServerState) xs.fromXML(cm.getData().get(CFG_MAP_DATA_KEY));
+        });
+
+        if (kieServerState == null || !retrieveKieServerId(kieServerState).equals(serverId)) {
+            throw new IllegalStateException("Invalid KieServerId: " + serverId + ", or inconsistent state data.");
+        }
+
+        return kieServerState;
+    }
+
+    @Override
+    public void store(String serverId, KieServerState kieServerState) {
+        /**
+         * To be implemented for supporting pure Kubernetes cluster deployment.
+         */
+        throw new UnsupportedOperationException();
+    }
+
+    protected String retrieveKieServerId(KieServerState kieServerState) {
+        String kssServerId = null;
+        try {
+            kssServerId = kieServerState.getConfiguration().getConfigItemValue(KieServerConstants.KIE_SERVER_ID);
+        } catch (Exception e) {
+            logger.error("Failed to retrieve server id from KieServerState", e);
+        }
+        if (kssServerId == null || kssServerId.length() == 0) {
+            throw new IllegalArgumentException("Invalid KieServerId: Can not be null or empty.");
+        }
+        return kssServerId;
+    }
+
+    private <R> R processKieServerState(Function<KubernetesClient, R> func) {
+        R result = null;
+        try (KubernetesClient client = createKubernetesClient()) {
+            result = func.apply(client);
+        } catch (IllegalStateException ise) {
+            logger.error("Processing KieServerState failed.", ise);
+            throw ise;
+        } catch (Exception e) {
+            logger.error("Processing KieServerState failed.", e);
+        }
+        return result;
+    }
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepository.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepository.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.services.openshift.impl.storage.cloud;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.validation.constraints.NotNull;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.kie.server.services.impl.storage.KieServerState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KieServerStateOpenShiftRepository extends KieServerStateCloudRepository {
+
+    private static final Logger logger = LoggerFactory.getLogger(KieServerStateOpenShiftRepository.class);
+
+    public synchronized void create(@NotNull KieServerState kieServerState) {
+        String serverId = retrieveKieServerId(kieServerState);
+        processKieServerStateByOpenShift(client -> {
+            ConfigMap cm = client.configMaps().withName(serverId).get();
+
+            String stateXML = xs.toXML(kieServerState);
+            if (cm != null) {
+                logger.info("Create new ConfigMap action ignored. ConfigMap for KieServer [{}] exists.", serverId);
+                return null;
+            }
+
+            client.configMaps().create(new ConfigMapBuilder()
+                                       .withNewMetadata()
+                                         .withName(serverId)
+                                         .withLabels(Collections.singletonMap(CFG_MAP_LABEL_NAME, CFG_MAP_LABEL_VALUE))
+                                       .endMetadata()
+                                       .withData(Collections.singletonMap(CFG_MAP_DATA_KEY, stateXML))
+                                       .build());
+            return null;
+        });
+    }
+
+    public List<String> retrieveAllKieServerIds() {
+        return processKieServerStateByOpenShift(client -> {
+            return client.configMaps().withLabel(CFG_MAP_LABEL_NAME, CFG_MAP_LABEL_VALUE).list().getItems()
+                         .stream()
+                         .map(cfg -> cfg.getMetadata().getName())
+                         .collect(Collectors.toList());
+        });
+    }
+
+    public List<KieServerState> retrieveAllKieServerStates() {
+        return processKieServerStateByOpenShift(client -> {
+            return client.configMaps().withLabel(CFG_MAP_LABEL_NAME, CFG_MAP_LABEL_VALUE).list().getItems()
+                         .stream()
+                         .map(cfg -> (KieServerState) xs.fromXML(cfg.getData().get(CFG_MAP_DATA_KEY)))
+                         .collect(Collectors.toList());
+        });
+    }
+
+    public boolean exists(String id) {
+        return processKieServerStateByOpenShift(client -> client.configMaps().withName(id).get() != null);
+    }
+
+    public KieServerState delete(String id) {
+        KieServerState state = load(id);
+        boolean isUnsupported = processKieServerStateByOpenShift(client -> {
+            if (client.deploymentConfigs().withName(id).get() == null) {
+                client.configMaps().withName(id).delete();
+            } else {
+                return true;
+            }
+            return false;
+        });
+
+        if (isUnsupported) {
+            logger.error("Can not delete attached KieServerState with id [{}].", id);
+            throw new UnsupportedOperationException("Can not delete attached KieServerState with id [" + id + "]");
+        }
+        return state;
+    }
+
+    @Override
+    public synchronized void store(@NotNull String serverId, @NotNull KieServerState kieServerState) {
+        if (!retrieveKieServerId(kieServerState).equals(serverId)) {
+            throw new IllegalArgumentException("Invalid KieServerId: Id does not match with KieServerState.");
+        }
+
+        processKieServerStateByOpenShift(client -> {
+            DeploymentConfig dc = client.deploymentConfigs().withName(serverId).get();
+            ConfigMap cm = client.configMaps().withName(serverId).get();
+            String stateXML = xs.toXML(kieServerState);
+            if (cm == null) {
+                throw new IllegalStateException("KieServerState ConfigMap must exist before update.");
+            } else {
+                cm.setData(Collections.singletonMap(CFG_MAP_DATA_KEY, stateXML));
+            }
+
+            ObjectMeta md = cm.getMetadata();
+            Map<String, String> ann = md.getAnnotations() == null ? new ConcurrentHashMap<>() : md.getAnnotations();
+            md.setAnnotations(ann);
+            ann.put(STATE_CHANGE_TIMESTAMP,
+                    ZonedDateTime.now().format(DateTimeFormatter.ISO_INSTANT));
+
+            if (isKieServerReady()) {
+                if (isDCStable(dc)) {
+                    ann.put(ROLLOUT_REQUIRED, "true");
+                    client.configMaps().createOrReplace(cm);
+                } else {
+                    throw new UnsupportedOperationException(
+                            "Updating KieServerState is not supported if there is in-progress DeploymentConfig activities.");
+                }
+            }
+            return null;
+        });
+    }
+
+    private <R> R processKieServerStateByOpenShift(Function<OpenShiftClient, R> func) {
+        R result = null;
+        try (OpenShiftClient client = createOpenShiftClient()) {
+            result = func.apply(client);
+        } catch (UnsupportedOperationException uoe) {
+            logger.error("Processing KieServerState failed - Unsupported", uoe);
+            throw uoe;
+        } catch (IllegalStateException ise) {
+            logger.error("Processing KieServerState failed - Missing required configuration", ise);
+            throw ise;
+        } catch (Exception e) {
+            logger.error("Processing KieServerState failed.", e);
+        }
+        return result;
+    }
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/resources/META-INF/services/org.kie.server.services.api.StartupStrategy
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/resources/META-INF/services/org.kie.server.services.api.StartupStrategy
@@ -1,0 +1,1 @@
+org.kie.server.services.openshift.impl.OpenShiftStartupStrategy

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/resources/META-INF/services/org.kie.server.services.impl.storage.KieServerStateRepository
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/resources/META-INF/services/org.kie.server.services.impl.storage.KieServerStateRepository
@@ -1,0 +1,1 @@
+org.kie.server.services.openshift.impl.storage.cloud.KieServerStateOpenShiftRepository

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryTest.java
@@ -1,0 +1,465 @@
+/**
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.server.services.openshift.impl.storage.cloud;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import com.thoughtworks.xstream.XStream;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ConfigMapList;
+import io.fabric8.kubernetes.api.model.DoneableConfigMap;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.client.server.mock.OpenShiftServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.services.impl.StartupStrategyProvider;
+import org.kie.server.services.impl.storage.KieServerState;
+import org.kie.server.services.impl.storage.KieServerStateRepository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.kie.server.services.openshift.impl.storage.cloud.KieServerStateCloudRepository.initializeXStream;
+
+public class KieServerStateOpenShiftRepositoryTest {
+
+    private static final String KIE_SERVER_STARTUP_IN_PROGRESS_KEY_PREFIX = "org.kie.server.services/";
+    private static final String KIE_SERVER_STARTUP_IN_PROGRESS_VALUE = "kie.server.startup_in_progress";
+
+    // Must match the the kie server id specified at test file
+    private static final String TEST_KIE_SERVER_ID = "myapp2-kieserver";
+    private static XStream xs = initializeXStream();
+    private static Supplier<OpenShiftClient> clouldClientHelper = () -> (new CloudClientFactory() {
+    }).createOpenShiftClient();
+
+    /**
+     *  Must match current project name associated with OpenShift login
+     *  if test against real OCP/K8S cluster
+     */
+    private String testNamespace = "myproject";
+    private OpenShiftClient client;
+    private KieServerStateOpenShiftRepository repo;
+
+    @Rule
+    public OpenShiftServer server = new OpenShiftServer(false, true);
+
+    @Before
+    public void setup() {
+
+        /**
+         *  Get fabric8 client and connect to real OpenShift/Kubernetes server
+         *  Require to set the following environment properties to run:
+         *  	KUBERNETES_MASTER
+         *  	KUBERNETES_AUTH_TOKEN
+         *  	KIE_SERVER_ID (Value doesn't matter)
+         */
+        if (System.getenv("KIE_SERVER_ID") != null) {
+            System.setProperty(KieServerConstants.KIE_SERVER_STARTUP_STRATEGY, "OpenShiftStartupStrategy");
+            // If KIE_SERVER_ID is set, connect to real OCP/K8S server
+            client = clouldClientHelper.get();
+        } else {
+            // Get client from MockKubernetes Server
+            client = server.getOpenshiftClient();
+
+            // The default namespace for MockKubernetes Server is 'test'
+            testNamespace = "test";
+        }
+
+        // Load testing KieServerState ConfigMap data into mock server from file
+        ConfigMap cfm = client.configMaps()
+                              .load(KieServerStateOpenShiftRepositoryTest.class
+                              .getResourceAsStream("/test-kieserver-state-config-map.yml")).get();
+
+        client.configMaps().inNamespace(testNamespace).createOrReplace(cfm);
+
+        // Create cloud repository instance with mock K8S server test client
+        repo = new KieServerStateOpenShiftRepository() {
+
+            @Override
+            public OpenShiftClient createOpenShiftClient() {
+                return client;
+            }
+
+            @Override
+            public KubernetesClient createKubernetesClient() {
+                return client;
+            }
+
+            @Override
+            public boolean isKieServerReady() {
+                return true;
+            }
+        };
+
+        repo.load(TEST_KIE_SERVER_ID);
+    }
+
+    @Test
+    public void testLiteralConfigMap() throws InterruptedException {
+        HashMap<String, String> data = new HashMap<>();
+        data.put("foo", "bar");
+        data.put("cheese", "gouda");
+
+        Map<String, String> ant = new ConcurrentHashMap<>();
+        ant.put("services.server.kie.org/kie-server-state.changeTimestamp",
+                ZonedDateTime.now().format(DateTimeFormatter.ISO_INSTANT));
+
+        Map<String, String> lab = new ConcurrentHashMap<>();
+        lab.put("startup_in_progress", "kieserverId");
+
+        client.configMaps().inNamespace(testNamespace)
+              .createOrReplace(new ConfigMapBuilder()
+                                                     .withNewMetadata()
+                                                     .withName("cfg1")
+                                                     .endMetadata()
+                                                     .addToData(data).build());
+
+        try {
+            client.configMaps().inNamespace(testNamespace)
+                  .create(new ConfigMapBuilder()
+                                                .withNewMetadata()
+                                                .withName("cfg1")
+                                                .withLabels(lab)
+                                                .withAnnotations(ant)
+                                                .endMetadata()
+                                                .addToData(data).build());
+        } catch (Exception e) {
+            // If test against real cluster, second create will fail
+        }
+
+        // If test against real cluster, uncomment out the following
+        //        assertTrue(client.configMaps().inNamespace(testNamespace)
+        //                   .withLabel("startup_in_progress", "kieserverId")
+        //                   .list().getItems().isEmpty());
+
+        client.configMaps().inNamespace(testNamespace)
+              .createOrReplace(new ConfigMapBuilder()
+                                                     .withNewMetadata()
+                                                     .withName("cfg2")
+                                                     .withLabels(lab)
+                                                     .withAnnotations(ant)
+                                                     .endMetadata()
+                                                     .addToData(data).build());
+
+        ConfigMapList cfgList = client.configMaps().inNamespace(testNamespace)
+                                      .withLabel("startup_in_progress", "kieserverid")
+                                      .list();
+
+        Map<String, String> keys = client.configMaps()
+                                         .inNamespace(testNamespace)
+                                         .withName("cfg1").get().getData();
+
+        assertEquals("gouda", keys.get("cheese"));
+        assertEquals("bar", keys.get("foo"));
+
+        client.configMaps().inNamespace(testNamespace).delete(cfgList.getItems());
+
+        assertTrue(client.configMaps().inNamespace(testNamespace)
+                         .withLabel("startup_in_progress", "kieserverid")
+                         .list().getItems().isEmpty());
+    }
+
+    @Test
+    public void testKieServerStateConfigMap() throws InterruptedException {
+        Resource<ConfigMap, DoneableConfigMap> configMapResource = client.configMaps().inNamespace(testNamespace)
+                                                                         .withName(TEST_KIE_SERVER_ID);
+
+        ConfigMap configMap = configMapResource.get();
+        assertEquals(TEST_KIE_SERVER_ID, configMap.getMetadata().getName());
+
+        Map<String, String> data = configMap.getData();
+
+        // Avoid attribute name having '.' as it confuses jsonpath
+        String srvStateInXML = data.get(KieServerStateCloudRepository.CFG_MAP_DATA_KEY);
+        KieServerState kieServerState = (KieServerState) xs.fromXML(srvStateInXML);
+
+        assertNotNull(kieServerState);
+        assertEquals(TEST_KIE_SERVER_ID,
+                     kieServerState.getConfiguration().getConfigItem(KieServerConstants.KIE_SERVER_ID).getValue());
+
+        // Since KubenetesClient is AutoCloseable, try-with-resource can be used
+        assertTrue(client instanceof AutoCloseable);
+    }
+
+    @Test
+    public void testStoreAndLoad() throws InterruptedException {
+        // Retrieve the seeded KSSConfigMap and Store it under new name
+        String srvStateInXML = client.configMaps().inNamespace(testNamespace)
+                                     .withName(TEST_KIE_SERVER_ID).get().getData().get(KieServerStateCloudRepository.CFG_MAP_DATA_KEY);
+        KieServerState kieServerState = (KieServerState) xs.fromXML(srvStateInXML);
+
+        assertNotNull(kieServerState);
+        
+        /**
+         * At normal situation, DC will not be null otherwise there will no KieServer Pod running
+         */
+        createDummyDC();
+        repo.store(TEST_KIE_SERVER_ID, kieServerState);
+        assertNotNull(client.configMaps().inNamespace(testNamespace)
+                            .withName(TEST_KIE_SERVER_ID).get());
+
+        KieServerState kssLoaded = repo.load(TEST_KIE_SERVER_ID);
+        assertNotNull(kssLoaded);
+        assertEquals(TEST_KIE_SERVER_ID,
+                     kssLoaded.getConfiguration().getConfigItem(KieServerConstants.KIE_SERVER_ID).getValue());
+
+        KieContainerResource[] kcr = kssLoaded.getContainers()
+                                              .<KieContainerResource> toArray(new KieContainerResource[]{});
+
+        assertEquals(2, kcr.length);
+        assertEquals("mortgages_1.0.0-SNAPSHOT", kcr[0].getContainerId());
+        assertEquals("mortgage-process_1.0.0-SNAPSHOT", kcr[1].getContainerId());
+    }
+
+    @Test
+    public void testStoreAndLoadWithRolloutTrigger() throws InterruptedException {
+        // Retrieve the seeded KSSConfigMap and Store it under new name
+        String srvStateInXML = client.configMaps().inNamespace(testNamespace)
+                                     .withName(TEST_KIE_SERVER_ID).get().getData().get(KieServerStateCloudRepository.CFG_MAP_DATA_KEY);
+        KieServerState kieServerState = (KieServerState) xs.fromXML(srvStateInXML);
+
+        repo.store(TEST_KIE_SERVER_ID, kieServerState);
+        assertNotNull(client.configMaps().inNamespace(testNamespace)
+                            .withName(TEST_KIE_SERVER_ID)
+                            .get()
+                            .getMetadata()
+                            .getAnnotations()
+                            .containsKey(KieServerStateCloudRepository.ROLLOUT_REQUIRED));
+
+    }
+
+    @Test(expected = Exception.class)
+    public void testLoadWithNullServerId() {
+        repo.load(null);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testLoadWithInvalidServerId() {
+        repo.load("dummy");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStoreWithEmptyKieServerState() {
+        repo.store("dummy", new KieServerState());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStoreWithMissMatchingServerId() {
+        KieServerState kss = repo.load(TEST_KIE_SERVER_ID);
+        repo.store("dummy", kss);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testStoreWithoutPreSeededConfigMap() {
+        KieServerState kss = repo.load(TEST_KIE_SERVER_ID);
+
+        // Remove the configmap created at Setup to set a no pre-seeded scenario
+        client.configMaps().inNamespace(testNamespace).withName(TEST_KIE_SERVER_ID).delete();
+
+        repo.store(TEST_KIE_SERVER_ID, kss);
+    }
+
+    @Test
+    public void testAnnotation() {
+
+        String kieServer1 = KIE_SERVER_STARTUP_IN_PROGRESS_KEY_PREFIX + UUID.randomUUID().toString();
+        String kieServer2 = KIE_SERVER_STARTUP_IN_PROGRESS_KEY_PREFIX + UUID.randomUUID().toString();
+
+        ConfigMap cm = client.configMaps().withName(TEST_KIE_SERVER_ID).get();
+        ObjectMeta md = cm.getMetadata();
+        Map<String, String> ann = md.getAnnotations() == null ? new HashMap<>() : md.getAnnotations();
+        md.setAnnotations(ann);
+        ann.put(kieServer1, KIE_SERVER_STARTUP_IN_PROGRESS_VALUE);
+        ann.put(kieServer2, KIE_SERVER_STARTUP_IN_PROGRESS_VALUE);
+        client.configMaps().createOrReplace(cm);
+
+        assertNotNull(client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata().getAnnotations());
+        assertTrue(client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata()
+                         .getAnnotations().containsKey(kieServer1));
+        assertTrue(client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata()
+                         .getAnnotations().containsKey(kieServer2));
+        assertTrue(
+                   client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata()
+                         .getAnnotations().containsValue(KIE_SERVER_STARTUP_IN_PROGRESS_VALUE));
+
+        ann.remove(kieServer1);
+        client.configMaps().createOrReplace(cm);
+
+        assertTrue(
+                   client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata()
+                         .getAnnotations().containsValue(KIE_SERVER_STARTUP_IN_PROGRESS_VALUE));
+
+        ann.remove(kieServer2);
+        client.configMaps().createOrReplace(cm);
+
+        assertFalse(
+                    client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata()
+                          .getAnnotations().containsValue(KIE_SERVER_STARTUP_IN_PROGRESS_VALUE));
+
+    }
+
+    @Test
+    public void testNPEWhenNoServiceProviderConfig() {
+        ServiceLoader<KieServerStateRepository> serverStateRepos = ServiceLoader.load(KieServerStateRepository.class);
+        assertNotNull(serverStateRepos);
+
+        String repoType = StartupStrategyProvider.get().getStrategy().getRepositoryType();
+        for (KieServerStateRepository repo : serverStateRepos) {
+            assertNotNull(repo);
+            assertNotNull(repo.getClass().getSimpleName());
+            if (repo.getClass().getSimpleName().equals(repoType)) {
+                fail("Unexpected repo type: " + repoType);
+            }
+        }
+    }
+
+    @Test
+    public void testCreateAndLoad() {
+        // Retrieve the seeded KSSConfigMap and Store it under new name
+        String srvStateInXML = client.configMaps().inNamespace(testNamespace)
+                                     .withName(TEST_KIE_SERVER_ID).get().getData().get(KieServerStateCloudRepository.CFG_MAP_DATA_KEY);
+        KieServerState kieServerState = (KieServerState) xs.fromXML(srvStateInXML);
+
+        assertNotNull(kieServerState);
+
+        kieServerState.getConfiguration()
+                      .getConfigItem(KieServerConstants.KIE_SERVER_ID).setValue(TEST_KIE_SERVER_ID + "_NEW");
+
+        repo.create(kieServerState);
+        assertNotNull(client.configMaps().inNamespace(testNamespace)
+                            .withName(TEST_KIE_SERVER_ID + "_NEW").get());
+
+        assertNotNull(repo.load(TEST_KIE_SERVER_ID + "_NEW"));
+    }
+
+    @Test
+    public void testDeleteAndExists() {
+        assertTrue(repo.exists(TEST_KIE_SERVER_ID));
+        repo.delete(TEST_KIE_SERVER_ID);
+        assertTrue(!repo.exists(TEST_KIE_SERVER_ID));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testDeleteAttachedKieServerStateIsNotAllowed() {
+        assertTrue(repo.exists(TEST_KIE_SERVER_ID));
+        // Create a dummy DeploymentConfig to simulate attached KieServeState scenario
+        createDummyDC();
+        repo.delete(TEST_KIE_SERVER_ID);
+    }
+
+ 
+    @Test
+    public void testRetrieveAllKieServerIdsAndStates() {
+        KieServerState state = repo.load(TEST_KIE_SERVER_ID);
+        state.getConfiguration()
+             .getConfigItem(KieServerConstants.KIE_SERVER_ID).setValue(TEST_KIE_SERVER_ID + "_1");
+        // Create new KieServer    
+        repo.create(state);
+
+        state.getConfiguration()
+             .getConfigItem(KieServerConstants.KIE_SERVER_ID).setValue(TEST_KIE_SERVER_ID + "_2");
+        // Create new KieServer    
+        repo.create(state);
+
+        List<String> kIds = repo.retrieveAllKieServerIds();
+        assertEquals(3, kIds.size());
+        assertTrue(kIds.contains(TEST_KIE_SERVER_ID));
+        assertTrue(kIds.contains(TEST_KIE_SERVER_ID + "_1"));
+        assertTrue(kIds.contains(TEST_KIE_SERVER_ID + "_2"));
+
+        List<KieServerState> kStates = repo.retrieveAllKieServerStates();
+        assertEquals(3, kStates.size());
+
+        repo.delete(TEST_KIE_SERVER_ID);
+        repo.delete(TEST_KIE_SERVER_ID + "_1");
+        repo.delete(TEST_KIE_SERVER_ID + "_2");
+
+        assertEquals(0, repo.retrieveAllKieServerIds().size());
+        assertEquals(0, repo.retrieveAllKieServerStates().size());
+    }
+
+    @Test
+    public void testRetrieveAllKieServerIdsAndStatesWithContaminatedCF() {
+        // Adding a contaminated configmap which does not include required label
+        ConfigMap cfm = client.configMaps()
+                .load(KieServerStateOpenShiftRepositoryTest.class
+                .getResourceAsStream("/test-kieserver-state-config-map-without-label.yml")).get();
+
+        client.configMaps().inNamespace(testNamespace).createOrReplace(cfm);
+        
+        // Now there are two configmaps in the test namespace
+        assertEquals(2, client.configMaps().list().getItems().size());
+        
+        // But still have only 1 valid KieServerState
+        List<String> kIds = repo.retrieveAllKieServerIds();
+        assertEquals(1, kIds.size());
+
+        List<KieServerState> kStates = repo.retrieveAllKieServerStates();
+        assertEquals(1, kStates.size());
+    }
+
+    @After
+    public void tearDown() {
+        client.configMaps().inNamespace(testNamespace).delete();
+        client.close();
+    }
+
+    protected void createDummyDC() {
+        client.deploymentConfigs().inNamespace(testNamespace).createOrReplaceWithNew()
+              .withNewMetadata()
+                .withName(TEST_KIE_SERVER_ID)
+              .endMetadata()
+              .withNewSpec()
+                .withReplicas(0)
+                  .addNewTrigger()
+                    .withType("ConfigChange")
+                  .endTrigger()
+                .withNewTemplate()
+                  .withNewMetadata()
+                    .addToLabels("app", "kieserver")
+                  .endMetadata()
+                  .withNewSpec()
+                    .addNewContainer()
+                      .withName("kieserver")
+                      .withImage("kiserver")
+                      .addNewPort()
+                        .withContainerPort(80)
+                      .endPort()
+                    .endContainer()
+                  .endSpec()
+                .endTemplate()
+              .endSpec()
+              .done();
+    }
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/resources/test-kieserver-state-config-map-without-label.yml
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/resources/test-kieserver-state-config-map-without-label.yml
@@ -1,0 +1,183 @@
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# To test extract KieServerState data, use the following oc command example:
+# oc get configmap -o=jsonpath='{range .items[?(@.metadata.name=="contaminated-kieserver")]}{.data.kie-server-state}{"\n"}{end}'
+#
+# To manually test dc rollout triggered by KieServerState change, touch ConfigMap with this annotation
+#   oc annotate cm/contaminated-kieserver services.server.kie.org/openshift-startup-strategy.rolloutRequired=true
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: contaminated-kieserver
+  annotations:
+    test.annotation: must_be_kept
+data:
+  kie-server-state: |
+    <kie-server-state>
+      <controllers>
+        <string>ws://172.30.111.77:8080/websocket/controller</string>
+      </controllers>
+      <configuration>
+        <configItems>
+          <config-item>
+            <name>org.kie.server.persistence.ds</name>
+            <value>java:/jboss/datasources/ExampleDS</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.repo</name>
+            <value>/home/jboss/.kie/repository</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.sync.deploy</name>
+            <value>true</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.location</name>
+            <value>http://contaminated-kieserver-myproject.127.0.0.1.nip.io:80/services/rest/server</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.domain</name>
+            <value>other</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.bypass.auth.user</name>
+            <value>false</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.persistence.tm</name>
+            <value>org.hibernate.engine.transaction.jta.platform.internal.JBossAppServerJtaPlatform</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.controller.user</name>
+            <value>controllerUser</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.controller</name>
+            <value>ws://172.30.111.77:8080/websocket/controller</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.user</name>
+            <value>executionUser</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.pwd</name>
+            <value>RedHat</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.id</name>
+            <value>contaminated-kieserver</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.persistence.dialect</name>
+            <value>org.hibernate.dialect.H2Dialect</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.controller.pwd</name>
+            <value>RedHat</value>
+            <type>java.lang.String</type>
+          </config-item>
+        </configItems>
+      </configuration>
+      <containers>
+        <container>
+          <containerId>mortgages_1.0.0-SNAPSHOT</containerId>
+          <releaseId>
+            <groupId>mortgages</groupId>
+            <artifactId>mortgages</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+          </releaseId>
+          <status>STARTED</status>
+          <scanner>
+            <status>STOPPED</status>
+          </scanner>
+          <configItems>
+            <config-item>
+              <name>KBase</name>
+              <value></value>
+              <type>BPM</type>
+            </config-item>
+            <config-item>
+              <name>KSession</name>
+              <value></value>
+              <type>BPM</type>
+            </config-item>
+            <config-item>
+              <name>MergeMode</name>
+              <value>MERGE_COLLECTIONS</value>
+              <type>BPM</type>
+            </config-item>
+            <config-item>
+              <name>RuntimeStrategy</name>
+              <value>SINGLETON</value>
+              <type>BPM</type>
+            </config-item>
+          </configItems>
+          <messages/>
+          <containerAlias>mortgages</containerAlias>
+        </container>
+        <container>
+          <containerId>mortgage-process_1.0.0-SNAPSHOT</containerId>
+          <releaseId>
+            <groupId>mortgage-process</groupId>
+            <artifactId>mortgage-process</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+          </releaseId>
+          <status>STARTED</status>
+          <scanner>
+            <status>STOPPED</status>
+          </scanner>
+          <configItems>
+            <config-item>
+              <name>KBase</name>
+              <value></value>
+              <type>BPM</type>
+            </config-item>
+            <config-item>
+              <name>KSession</name>
+              <value></value>
+              <type>BPM</type>
+            </config-item>
+            <config-item>
+              <name>MergeMode</name>
+              <value>MERGE_COLLECTIONS</value>
+              <type>BPM</type>
+            </config-item>
+            <config-item>
+              <name>RuntimeStrategy</name>
+              <value>PER_PROCESS_INSTANCE</value>
+              <type>BPM</type>
+            </config-item>
+          </configItems>
+          <messages/>
+          <containerAlias>mortgage-process</containerAlias>
+        </container>
+      </containers>
+    </kie-server-state>

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/resources/test-kieserver-state-config-map.yml
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/resources/test-kieserver-state-config-map.yml
@@ -1,0 +1,185 @@
+#
+# Copyright (C) 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# To test extract KieServerState data, use the following oc command example:
+# oc get configmap -o=jsonpath='{range .items[?(@.metadata.name=="myapp2-kieserver")]}{.data.kie-server-state}{"\n"}{end}'
+#
+# To manually test dc rollout triggered by KieServerState change, touch ConfigMap with this annotation
+#   oc annotate cm/myapp2-kieserver services.server.kie.org/openshift-startup-strategy.rolloutRequired=true
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: myapp2-kieserver
+  labels:
+    services.server.kie.org/kie-server-state: USED
+  annotations:
+    test.annotation: must_be_kept
+data:
+  kie-server-state: |
+    <kie-server-state>
+      <controllers>
+        <string>ws://172.30.111.77:8080/websocket/controller</string>
+      </controllers>
+      <configuration>
+        <configItems>
+          <config-item>
+            <name>org.kie.server.persistence.ds</name>
+            <value>java:/jboss/datasources/ExampleDS</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.repo</name>
+            <value>/home/jboss/.kie/repository</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.sync.deploy</name>
+            <value>true</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.location</name>
+            <value>http://myapp2-kieserver-myproject.127.0.0.1.nip.io:80/services/rest/server</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.domain</name>
+            <value>other</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.bypass.auth.user</name>
+            <value>false</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.persistence.tm</name>
+            <value>org.hibernate.engine.transaction.jta.platform.internal.JBossAppServerJtaPlatform</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.controller.user</name>
+            <value>controllerUser</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.controller</name>
+            <value>ws://172.30.111.77:8080/websocket/controller</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.user</name>
+            <value>executionUser</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.pwd</name>
+            <value>RedHat</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.id</name>
+            <value>myapp2-kieserver</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.persistence.dialect</name>
+            <value>org.hibernate.dialect.H2Dialect</value>
+            <type>java.lang.String</type>
+          </config-item>
+          <config-item>
+            <name>org.kie.server.controller.pwd</name>
+            <value>RedHat</value>
+            <type>java.lang.String</type>
+          </config-item>
+        </configItems>
+      </configuration>
+      <containers>
+        <container>
+          <containerId>mortgages_1.0.0-SNAPSHOT</containerId>
+          <releaseId>
+            <groupId>mortgages</groupId>
+            <artifactId>mortgages</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+          </releaseId>
+          <status>STARTED</status>
+          <scanner>
+            <status>STOPPED</status>
+          </scanner>
+          <configItems>
+            <config-item>
+              <name>KBase</name>
+              <value></value>
+              <type>BPM</type>
+            </config-item>
+            <config-item>
+              <name>KSession</name>
+              <value></value>
+              <type>BPM</type>
+            </config-item>
+            <config-item>
+              <name>MergeMode</name>
+              <value>MERGE_COLLECTIONS</value>
+              <type>BPM</type>
+            </config-item>
+            <config-item>
+              <name>RuntimeStrategy</name>
+              <value>SINGLETON</value>
+              <type>BPM</type>
+            </config-item>
+          </configItems>
+          <messages/>
+          <containerAlias>mortgages</containerAlias>
+        </container>
+        <container>
+          <containerId>mortgage-process_1.0.0-SNAPSHOT</containerId>
+          <releaseId>
+            <groupId>mortgage-process</groupId>
+            <artifactId>mortgage-process</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+          </releaseId>
+          <status>STARTED</status>
+          <scanner>
+            <status>STOPPED</status>
+          </scanner>
+          <configItems>
+            <config-item>
+              <name>KBase</name>
+              <value></value>
+              <type>BPM</type>
+            </config-item>
+            <config-item>
+              <name>KSession</name>
+              <value></value>
+              <type>BPM</type>
+            </config-item>
+            <config-item>
+              <name>MergeMode</name>
+              <value>MERGE_COLLECTIONS</value>
+              <type>BPM</type>
+            </config-item>
+            <config-item>
+              <name>RuntimeStrategy</name>
+              <value>PER_PROCESS_INSTANCE</value>
+              <type>BPM</type>
+            </config-item>
+          </configItems>
+          <messages/>
+          <containerAlias>mortgage-process</containerAlias>
+        </container>
+      </containers>
+    </kie-server-state>

--- a/kie-server-parent/kie-server-services/pom.xml
+++ b/kie-server-parent/kie-server-services/pom.xml
@@ -23,6 +23,7 @@
     <module>kie-server-services-case-mgmt</module>
     <module>kie-server-services-dmn</module>
     <module>kie-server-services-swagger</module>
+    <module>kie-server-services-openshift</module>
   </modules>
 
 </project>


### PR DESCRIPTION
By leveraging OpenShift/K8S API server service, a group of individual KieServers can have a consistent and single view of KieServerState. With the help of fabric8.io's OpenShift/Kubernetes java client, changes to the KieServerState data structure which is managed by OCP/K8S API Server can be monitored/watched and change event will be used to trigger an OpenShift DeploymentConfig rollout for automatically refreshing the Pods and in turn its hosted KieServer instances. Due to the smart Routing capability of OCP/K8S, KieServer API calls will not be interrupted providing there are more than one KieServer instances are provisioned. Last, given a group of KieServer instances are manged by one(1) DeploymentConfig which is associated with one(1) ConfigMap for managing KieServerState data, and fronted by one(1) smart Route, existing KieServer API should be sufficient to unanimously manage KieServer group as one unit without replying on KieServerControllers.

Related Link:
**https://issues.jboss.org/browse/JBPM-7834**
