### PR TITLE
Rename profiles after wildfly14 upgrade

### DIFF
--- a/camel-container-tests/camel-container-integration-tests/pom.xml
+++ b/camel-container-tests/camel-container-integration-tests/pom.xml
@@ -132,7 +132,7 @@
             <artifactId>cargo-maven2-plugin</artifactId>
             <configuration>
               <container>
-                <containerId>wildfly11x</containerId>
+                <containerId>wildfly14x</containerId>
                 <home>${project.build.directory}/application-server/wildfly-${version.org.wildfly}</home>
                 <type>installed</type>
               </container>
@@ -204,7 +204,7 @@
             <artifactId>cargo-maven2-plugin</artifactId>
             <configuration>
               <container>
-                <containerId>wildfly11x</containerId>
+                <containerId>wildfly14x</containerId>
                 <home>${project.build.directory}/application-server</home>
                 <type>installed</type>
               </container>

--- a/kie-server-parent/kie-server-tests/README.md
+++ b/kie-server-parent/kie-server-tests/README.md
@@ -11,7 +11,7 @@ Tests are run very easily using the command
 ```mvn clean install -P<container-profile> <container-specific-params>```
 
 where `<container-profile>` is simply a particular container. Another container-specific parameters may also be configured (see the table below).
-WildFly10, EAP 7 and Tomcat 8 do not have to be pre-installed, they will be downloaded automatically (in case of EAP 7, download URL has to be provided).
+WildFly14, EAP 7 and Tomcat 8 do not have to be pre-installed, they will be downloaded automatically (in case of EAP 7, download URL has to be provided).
 Oracle WebLogic 12 and IBM WebSphere 9 have to be pre-installed and the installation path has to be provided using a Maven property `weblogic.home` or `websphere.home` respectively.
 Tests are executed using Failsafe plugin. To run specific test class use `-Dit.test=<Test class name>`
 Most of the tests can be executed locally as JUnit tests, in this case embedded server is used and only REST endpoints are tested.
@@ -20,7 +20,7 @@ The following table lists all currently supported combinations of parameters:
 
 | Container to run    | \<container-profile\> | \<container-specific params\>             |
 | -----------------   | --------------------- | ----------------------------------------- |
-|     WildFly10       | wildfly10             | *none*                                    |
+|     WildFly14       | wildfly               | *none*                                    |
 |     EAP 7           | eap7                  | eap7.download.url                         |
 |     Tomcat 9        | tomcat9               | *none*                                    |
 | Oracle WebLogic 12  | oracle-wls-12         | weblogic.home                             |

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
@@ -364,11 +364,7 @@
       <id>tomcat9</id>
     </profile>
     <profile>
-      <id>wildfly10</id>
-    </profile>
-    <profile>
-      <!-- temporary hack to let it test on jenkins <id>wildfly14</id>-->
-      <id>wildfly11</id>
+      <id>wildfly</id>
     </profile>
     <profile>
       <id>eap7</id>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
@@ -280,18 +280,7 @@
       </dependencies>
     </profile>
     <profile>
-      <id>wildfly10</id>
-      <dependencies>
-        <dependency>
-          <groupId>io.undertow</groupId>
-          <artifactId>undertow-websockets-jsr</artifactId>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-    <profile>
-      <!-- temporary hack to let it test on jenkins <id>wildfly14</id>-->
-      <id>wildfly11</id>
+      <id>wildfly</id>
       <dependencies>
         <dependency>
           <groupId>io.undertow</groupId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/pom.xml
@@ -282,11 +282,7 @@
       <id>tomcat9</id>
     </profile>
     <profile>
-      <id>wildfly10</id>
-    </profile>
-    <profile>
-      <!-- temporary hack to let it test on jenkins <id>wildfly14</id>-->
-      <id>wildfly11</id>
+      <id>wildfly</id>
     </profile>
     <profile>
       <id>eap7</id>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
@@ -283,11 +283,7 @@
       <id>tomcat9</id>
     </profile>
     <profile>
-      <id>wildfly10</id>
-    </profile>
-    <profile>
-      <!-- temporary hack to let it test on jenkins <id>wildfly14</id>-->
-      <id>wildfly11</id>
+      <id>wildfly</id>
     </profile>
     <profile>
       <id>eap7</id>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
@@ -370,48 +370,7 @@
       <id>tomcat9</id>
     </profile>
     <profile>
-      <id>wildfly10</id>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.codehaus.cargo</groupId>
-              <artifactId>cargo-maven2-plugin</artifactId>
-              <configuration>
-                <deployables>
-                  <deployable>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>kie-server</artifactId>
-                    <!-- default, may be overridden in container specific 
-                      profiles -->
-                    <classifier>${kie.server.classifier}</classifier>
-                    <type>war</type>
-                    <properties>
-                      <context>${kie.server.context}</context>
-                    </properties>
-                    <pingURL>${kie.server.base.http.url}</pingURL>
-                    <pingTimeout>60000</pingTimeout>
-                  </deployable>
-                  <deployable>
-                    <groupId>${project.groupId}</groupId>
-                    <artifactId>kie-server-test-web-service</artifactId>                    
-                    <type>war</type>
-                    <properties>
-                      <context>kie-server-test-web-service</context>
-                    </properties>
-                    <pingURL>http://${container.hostname}:${container.port}/kie-server-test-web-service/AcmeDemoInterface?wsdl</pingURL>
-                    <pingTimeout>60000</pingTimeout>
-                  </deployable>
-                </deployables>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-    <profile>
-      <!-- temporary hack to let it test on jenkins <id>wildfly14</id>-->
-      <id>wildfly11</id>
+      <id>wildfly</id>
       <build>
         <pluginManagement>
           <plugins>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
@@ -269,11 +269,7 @@
       <id>tomcat9</id>
     </profile>
     <profile>
-      <id>wildfly10</id>
-    </profile>
-    <profile>
-      <!-- temporary hack to let it test on jenkins <id>wildfly14</id>-->
-      <id>wildfly11</id>
+      <id>wildfly</id>
     </profile>
     <profile>
       <id>eap7</id>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/pom.xml
@@ -321,11 +321,7 @@
       <id>tomcat9</id>
     </profile>
     <profile>
-      <id>wildfly10</id>
-    </profile>
-    <profile>
-      <!-- temporary hack to let it test on jenkins <id>wildfly14</id>-->
-      <id>wildfly11</id>
+      <id>wildfly</id>
     </profile>
     <profile>
       <id>eap7</id>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/pom.xml
@@ -350,11 +350,7 @@
       <id>tomcat9</id>
     </profile>
     <profile>
-      <id>wildfly10</id>
-    </profile>
-    <profile>
-      <!-- temporary hack to let it test on jenkins <id>wildfly14</id>-->
-      <id>wildfly11</id>
+      <id>wildfly</id>
     </profile>
     <profile>
       <id>eap7</id>

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -720,8 +720,7 @@
       </dependencies>
     </profile>    
     <profile>
-      <!-- temporary hack to let it test on jenkins id>wildfly14</id-->
-      <id>wildfly11</id>
+      <id>wildfly</id>
       <properties>        
         <kie.server.remoting.url>http-remoting://${container.hostname}:${container.port}</kie.server.remoting.url>
         <kie.server.context.factory>org.wildfly.naming.client.WildFlyInitialContextFactory</kie.server.context.factory>


### PR DESCRIPTION
Followup on wildfly14 migration.
I'm renaming the container profiles so they match reality.
I also removed `wildfly10` profiles as they seemed outdated (@sutaakar please check)

Should be merged with:
https://github.com/kiegroup/kie-jenkins-scripts/pull/365
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/875
https://github.com/kiegroup/jbpm/pull/1366
https://github.com/kiegroup/droolsjbpm-integration/pull/1627
https://github.com/kiegroup/kie-wb-distributions/pull/841