### PR TITLE
[Drools-3236] Removed creation of m2e configuration file

### DIFF
--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.kie</groupId>
   <artifactId>kie-maven-plugin</artifactId>
-  <packaging>takari-maven-plugin</packaging>
+  <packaging>maven-plugin</packaging>
 
   <name>KIE :: Maven Plugin</name>
 
@@ -21,15 +21,6 @@
         <artifactId>maven-plugin-plugin</artifactId>
         <configuration>
           <goalPrefix>kie</goalPrefix>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>io.takari.maven.plugins</groupId>
-        <artifactId>takari-lifecycle-plugin</artifactId>
-        <version>${version.io.takari.maven.plugins.compiler}</version>
-        <extensions>true</extensions>
-        <configuration>
-          <proc>none</proc>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Removed takari plugin in the kie-maven plugin to avoid creation of the m2e file until we fix it in the takari code for the takari-maven-plugin