### PR TITLE
Remove drools.compiler.lnglevel from test kjars

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
@@ -10,7 +10,6 @@
     <!-- The version is set during the Maven build (this file is a filtered resource) -->
     <version.org.kie>${version.org.kie}</version.org.kie>
     <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>${version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec}</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>
-    <drools.compiler.lnglevel>1.6</drools.compiler.lnglevel>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-case-id-generator/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-case-id-generator/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
@@ -9,7 +9,6 @@
   <properties>
     <!-- The version is set during the Maven build (this file is a filtered resource) -->
     <version.org.kie>${version.org.kie}</version.org.kie>
-    <drools.compiler.lnglevel>1.6</drools.compiler.lnglevel>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
@@ -9,7 +9,6 @@
   <properties>
     <!-- The version is set during the Maven build (this file is a filtered resource) -->
     <version.org.kie>${version.org.kie}</version.org.kie>
-    <drools.compiler.lnglevel>1.6</drools.compiler.lnglevel>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
@@ -9,7 +9,6 @@
   <properties>
     <!-- The version is set during the Maven build (this file is a filtered resource) -->
     <version.org.kie>${version.org.kie}</version.org.kie>
-    <drools.compiler.lnglevel>1.6</drools.compiler.lnglevel>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
@@ -9,7 +9,6 @@
   <properties>
     <!-- The version is set during the Maven build (this file is a filtered resource) -->
     <version.org.kie>${version.org.kie}</version.org.kie>
-    <drools.compiler.lnglevel>1.6</drools.compiler.lnglevel>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
@@ -10,7 +10,6 @@
     <!-- The version is set during the Maven build (this file is a filtered resource) -->
     <version.org.kie>${version.org.kie}</version.org.kie>
     <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>${version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec}</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>
-    <drools.compiler.lnglevel>1.6</drools.compiler.lnglevel>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
@@ -12,7 +12,6 @@
     <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>${version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec}</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>
     <version.javax.jws>${version.javax.jws}</version.javax.jws>
     <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>${version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec}</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>
-    <drools.compiler.lnglevel>1.6</drools.compiler.lnglevel>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
@@ -12,7 +12,6 @@
     <version.org.codehaus.jackson>${version.org.codehaus.jackson}</version.org.codehaus.jackson>
     <version.org.javassist>${version.org.javassist}</version.org.javassist>
     <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>${version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec}</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>
-    <drools.compiler.lnglevel>1.6</drools.compiler.lnglevel>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
@@ -10,7 +10,6 @@
     <!-- The version is set during the Maven build (this file is a filtered resource) -->
     <version.org.kie>${version.org.kie}</version.org.kie>
     <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>${version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec}</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>
-    <drools.compiler.lnglevel>1.6</drools.compiler.lnglevel>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 


### PR DESCRIPTION
As it isn't needed currently.
@rsynek FYI