### PR TITLE
Remove Narayana version override from kie-spring-boot

### DIFF
--- a/kie-spring-boot/pom.xml
+++ b/kie-spring-boot/pom.xml
@@ -36,7 +36,6 @@
     <version.spring-boot>1.5.12.RELEASE</version.spring-boot>
     <version.cxf.jaxrs>3.1.11</version.cxf.jaxrs>
     <version.me.snowdrop.narayana>1.0.1</version.me.snowdrop.narayana>
-    <version.org.jboss.narayana.tomcat>5.9.0.Final</version.org.jboss.narayana.tomcat>
     <version.org.apache.commons-dbcp2>2.4.0</version.org.apache.commons-dbcp2>
   </properties>
 


### PR DESCRIPTION
@mswiderski  7.14.x backport is probably not relevant anymore, right?