### PR TITLE
Fix NPE in tests

### DIFF
--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/java/org/kie/server/springboot/samples/KieServerTest.java
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/java/org/kie/server/springboot/samples/KieServerTest.java
@@ -110,7 +110,9 @@ public class KieServerTest {
     
     @After
     public void cleanup() {
-        kieServicesClient.disposeContainer(containerId);        
+        if (kieServicesClient != null) {
+            kieServicesClient.disposeContainer(containerId);
+        }
     }
     
     @Test


### PR DESCRIPTION
When kieServicesClient fails to initialize in the @Before method NPE is thrown from @After method, which leads to spurious setup method failures [like these](https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/KIE/job/master/job/release/job/buildAndDeployLocally-kieReleases-master/18)