### PR TITLE
Remove redundant bean declaration from Keycloak Springboot sample

### DIFF
--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/jbpm-spring-boot-autoconfiguration/src/main/java/org/jbpm/springboot/autoconfigure/JBPMAutoConfiguration.java
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/jbpm-spring-boot-autoconfiguration/src/main/java/org/jbpm/springboot/autoconfigure/JBPMAutoConfiguration.java
@@ -288,7 +288,7 @@ public class JBPMAutoConfiguration {
     
     @Bean
     @ConditionalOnMissingBean(name = "userGroupCallback")
-    public UserGroupCallback userGroupCallback(IdentityProvider identityProvider) throws IOException {
+    public UserGroupCallback userGroupCallback(IdentityProvider identityProvider) {
         return new SpringSecurityUserGroupCallback(identityProvider);
     }
     

--- a/kie-spring-boot/kie-spring-boot-samples/keycloak-kie-server-spring-boot-sample/src/main/java/org/kie/server/springboot/samples/KieServerApplication.java
+++ b/kie-spring-boot/kie-spring-boot-samples/keycloak-kie-server-spring-boot-sample/src/main/java/org/kie/server/springboot/samples/KieServerApplication.java
@@ -51,10 +51,4 @@ public class KieServerApplication {
             }
         };
     }
-
-    // override user group callback to take advantage of keycloak managed roles
-    @Bean
-    public UserGroupCallback userGroupCallback(IdentityProvider identityProvider) {        
-        return new SpringSecurityUserGroupCallback(identityProvider);
-    }
 }


### PR DESCRIPTION
related to kiegroup/kie-docs#1240

Bean is already declared in [JBPMAutoConfiguration.java](https://github.com/kiegroup/droolsjbpm-integration/blob/15b8555ccdd4dc1ef31d6fdc3c446dbf1f6259b4/kie-spring-boot/kie-spring-boot-autoconfiguration/jbpm-spring-boot-autoconfiguration/src/main/java/org/jbpm/springboot/autoconfigure/JBPMAutoConfiguration.java#L289-L293).