### PR TITLE
[DROOLS-3177] Move RegistryContext to kie-internal

### DIFF
--- a/jbpm-simulation/src/main/java/org/jbpm/simulation/impl/SimulateProcessPathCommand.java
+++ b/jbpm-simulation/src/main/java/org/jbpm/simulation/impl/SimulateProcessPathCommand.java
@@ -18,7 +18,6 @@ package org.jbpm.simulation.impl;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.drools.core.command.impl.RegistryContext;
 import org.drools.core.event.DefaultProcessEventListener;
 import org.drools.core.time.SessionPseudoClock;
 import org.jbpm.simulation.SimulationContext;
@@ -29,6 +28,7 @@ import org.kie.api.event.process.ProcessStartedEvent;
 import org.kie.api.runtime.Context;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessInstance;
+import org.kie.internal.command.RegistryContext;
 
 public class SimulateProcessPathCommand implements ExecutableCommand<KieSession> {
 

--- a/kie-infinispan/drools-infinispan-persistence/src/test/java/org/drools/persistence/jta/TransactionTestCommand.java
+++ b/kie-infinispan/drools-infinispan-persistence/src/test/java/org/drools/persistence/jta/TransactionTestCommand.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 
 import bitronix.tm.TransactionManagerServices;
 import org.drools.core.base.MapGlobalResolver;
-import org.drools.core.command.impl.RegistryContext;
 import org.drools.core.impl.EnvironmentFactory;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.KnowledgeBaseFactory;
@@ -32,6 +31,7 @@ import org.kie.api.runtime.Context;
 import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.EnvironmentName;
 import org.kie.api.runtime.KieSession;
+import org.kie.internal.command.RegistryContext;
 import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
 

--- a/kie-infinispan/drools-infinispan-persistence/src/test/java/org/drools/persistence/session/RuleFlowGroupRollbackTest.java
+++ b/kie-infinispan/drools-infinispan-persistence/src/test/java/org/drools/persistence/session/RuleFlowGroupRollbackTest.java
@@ -20,7 +20,6 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.drools.core.command.impl.CommandBasedStatefulKnowledgeSession;
-import org.drools.core.command.impl.RegistryContext;
 import org.drools.core.common.InternalAgenda;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.KnowledgeBaseFactory;
@@ -36,6 +35,7 @@ import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.KieSession;
 import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.kie.internal.command.RegistryContext;
 import org.kie.internal.persistence.infinispan.InfinispanKnowledgeService;
 
 import static org.drools.persistence.util.PersistenceUtil.DROOLS_PERSISTENCE_UNIT_NAME;

--- a/kie-spring-boot/kie-spring-boot-samples/jbpm-spring-boot-sample-basic/src/test/java/org/jbpm/springboot/samples/ConfigurationTest.java
+++ b/kie-spring-boot/kie-spring-boot-samples/jbpm-spring-boot-sample-basic/src/test/java/org/jbpm/springboot/samples/ConfigurationTest.java
@@ -16,15 +16,10 @@
 
 package org.jbpm.springboot.samples;
 
-import static org.appformer.maven.integration.MavenRepository.getMavenRepository;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.util.Collection;
 
 import org.appformer.maven.integration.MavenRepository;
-import org.drools.core.command.impl.RegistryContext;
 import org.drools.persistence.jpa.processinstance.JPAWorkItemManager;
 import org.jbpm.kie.services.impl.KModuleDeploymentUnit;
 import org.jbpm.runtime.manager.impl.jpa.EntityManagerFactoryManager;
@@ -47,6 +42,7 @@ import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.manager.RuntimeManager;
 import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
+import org.kie.internal.command.RegistryContext;
 import org.kie.internal.runtime.manager.RuntimeManagerRegistry;
 import org.kie.internal.runtime.manager.context.EmptyContext;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,6 +52,10 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.appformer.maven.integration.MavenRepository.getMavenRepository;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = {JBPMApplication.class, TestAutoConfiguration.class}, webEnvironment = WebEnvironment.RANDOM_PORT)


### PR DESCRIPTION
As discussed I moved RegistryContext to kie-internal end updated usages.

@mariofusco @kkufova

PR list:
https://github.com/kiegroup/droolsjbpm-knowledge/pull/348
https://github.com/kiegroup/drools/pull/2174
https://github.com/kiegroup/drools-wb/pull/1012
https://github.com/kiegroup/jbpm/pull/1387
https://github.com/kiegroup/droolsjbpm-integration/pull/1657