### PR TITLE
JBPM-8018 - CarInsuranceClaimCaseIntegration in Kie Server tests uses wrong data output name to map claimReport after calculation, JBPM-7987 - Spring auto registration doesn’t seem to work for AgendaEventListener

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-drools/src/main/java/org/kie/server/services/drools/DroolsKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-drools/src/main/java/org/kie/server/services/drools/DroolsKieServerExtension.java
@@ -51,9 +51,9 @@ public class DroolsKieServerExtension implements KieServerExtension {
     private static final Boolean disabled = Boolean.parseBoolean(System.getProperty(KieServerConstants.KIE_DROOLS_SERVER_EXT_DISABLED, "false"));
     private static final Boolean filterRemoteable = Boolean.parseBoolean(System.getProperty(KieServerConstants.KIE_DROOLS_FILTER_REMOTEABLE_CLASSES, "false"));
 
-    private RulesExecutionService rulesExecutionService;
-    private KieContainerCommandService batchCommandService;
-    private KieServerRegistry registry;
+    protected RulesExecutionService rulesExecutionService;
+    protected KieContainerCommandService batchCommandService;
+    protected KieServerRegistry registry;
 
     private List<Object> services = new ArrayList<Object>();
     private boolean initialized = false;

--- a/kie-server-parent/kie-server-services/kie-server-services-drools/src/main/java/org/kie/server/services/drools/RulesExecutionService.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-drools/src/main/java/org/kie/server/services/drools/RulesExecutionService.java
@@ -15,8 +15,13 @@
 
 package org.kie.server.services.drools;
 
+import java.util.List;
+
 import org.drools.core.command.runtime.BatchExecutionCommandImpl;
 import org.kie.api.command.BatchExecutionCommand;
+import org.kie.api.event.KieRuntimeEventManager;
+import org.kie.api.event.rule.AgendaEventListener;
+import org.kie.api.event.rule.RuleRuntimeEventListener;
 import org.kie.api.runtime.CommandExecutor;
 import org.kie.api.runtime.ExecutionResults;
 import org.kie.server.services.api.KieContainerInstance;
@@ -29,6 +34,9 @@ import org.kie.server.services.impl.KieContainerInstanceImpl;
 public class RulesExecutionService {
 
     private KieServerRegistry context;
+    
+    private List<AgendaEventListener> agendaEventListeners;
+    private List<RuleRuntimeEventListener> ruleRuntimeEventListeners;
 
     public RulesExecutionService(KieServerRegistry context) {
         this.context = context;
@@ -49,6 +57,7 @@ public class RulesExecutionService {
             }
 
             if (ks != null) {
+                applyListeners(ks);
                 ExecutionResults results = ks.execute(command);
 
                 return results;
@@ -58,5 +67,32 @@ public class RulesExecutionService {
         }
 
         throw new IllegalStateException("Unable to execute command " + command);
+    }
+    
+    protected void applyListeners(CommandExecutor ks) {
+        
+        if (ruleRuntimeEventListeners != null) {
+            ruleRuntimeEventListeners.forEach( listener ->((KieRuntimeEventManager) ks).addEventListener(listener));
+        }
+        
+        if (agendaEventListeners != null) {
+            agendaEventListeners.forEach( listener ->((KieRuntimeEventManager) ks).addEventListener(listener));
+        }
+    }
+
+    public List<AgendaEventListener> getAgendaEventListeners() {
+        return agendaEventListeners;
+    }
+
+    public void setAgendaEventListeners(List<AgendaEventListener> agendaEventListeners) {
+        this.agendaEventListeners = agendaEventListeners;
+    }
+
+    public List<RuleRuntimeEventListener> getRuleRuntimeEventListeners() {
+        return ruleRuntimeEventListeners;
+    }
+
+    public void setRuleRuntimeEventListeners(List<RuleRuntimeEventListener> ruleRuntimeEventListeners) {
+        this.ruleRuntimeEventListeners = ruleRuntimeEventListeners;
     }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/kjars-sources/case-insurance/src/main/resources/org/kie/server/testing/CarInsuranceClaimCase.bpmn2
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/filtered-resources/kjars-sources/case-insurance/src/main/resources/org/kie/server/testing/CarInsuranceClaimCase.bpmn2
@@ -362,7 +362,7 @@
         <bpmn2:ioSpecification id="_aVxzNmVZEeavbo3IsNuQ1g">
           <bpmn2:dataInput id="_C88DB70F-951D-4F4F-BE06-651EBFC184AB__claimReportInputX" drools:dtype="org.kie.server.testing.ClaimReport" name="Parameter"/>
           <bpmn2:dataInput id="_C88DB70F-951D-4F4F-BE06-651EBFC184AB__parameterTypeInputX" drools:dtype="String" name="ParameterType"/>
-          <bpmn2:dataOutput id="_C88DB70F-951D-4F4F-BE06-651EBFC184AB_claimReport_OutputX" drools:dtype="org.kie.server.testing.ClaimReport" name="name"/>
+          <bpmn2:dataOutput id="_C88DB70F-951D-4F4F-BE06-651EBFC184AB_claimReport_OutputX" drools:dtype="org.kie.server.testing.ClaimReport" name="Result"/>
           <bpmn2:inputSet id="_aVxzN2VZEeavbo3IsNuQ1g">
             <bpmn2:dataInputRefs>_C88DB70F-951D-4F4F-BE06-651EBFC184AB__claimReportInputX</bpmn2:dataInputRefs>
             <bpmn2:dataInputRefs>_C88DB70F-951D-4F4F-BE06-651EBFC184AB__parameterTypeInputX</bpmn2:dataInputRefs>

--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration-drools/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration-drools/pom.xml
@@ -26,6 +26,10 @@
     </dependency>
     
     <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-api</artifactId>
     </dependency>

--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration-drools/src/main/java/org/kie/server/springboot/autoconfiguration/drools/DroolsKieServerAutoConfiguration.java
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration-drools/src/main/java/org/kie/server/springboot/autoconfiguration/drools/DroolsKieServerAutoConfiguration.java
@@ -16,7 +16,13 @@
 
 package org.kie.server.springboot.autoconfiguration.drools;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.kie.api.event.rule.AgendaEventListener;
+import org.kie.api.event.rule.RuleRuntimeEventListener;
 import org.kie.server.services.api.KieServerExtension;
+import org.kie.server.services.api.KieServerRegistry;
 import org.kie.server.services.drools.DroolsKieServerExtension;
 import org.kie.server.services.impl.KieServerImpl;
 import org.kie.server.springboot.autoconfiguration.KieServerProperties;
@@ -41,8 +47,19 @@ public class DroolsKieServerAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean(name = "droolsServerExtension")
     @ConditionalOnProperty(name = "kieserver.drools.enabled")
-    public KieServerExtension droolsServerExtension() {
+    public KieServerExtension droolsServerExtension(Optional<List<AgendaEventListener>> agendaEventListeners,
+            Optional<List<RuleRuntimeEventListener>> ruleRuntimeEventListeners) {
 
-        return new DroolsKieServerExtension();
+        return new DroolsKieServerExtension() {
+
+            @Override
+            public void init(KieServerImpl kieServer, KieServerRegistry registry) {
+                super.init(kieServer, registry);
+                
+                rulesExecutionService.setAgendaEventListeners(agendaEventListeners.orElse(null));
+                rulesExecutionService.setRuleRuntimeEventListeners(ruleRuntimeEventListeners.orElse(null));
+            }
+            
+        };
     }
 }

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/java/org/kie/server/springboot/samples/RulesOnlyKieServerTest.java
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/java/org/kie/server/springboot/samples/RulesOnlyKieServerTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.springboot.samples;
+
+import static org.appformer.maven.integration.MavenRepository.getMavenRepository;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.appformer.maven.integration.MavenRepository;
+import org.drools.compiler.kie.builder.impl.InternalKieModule;
+import org.drools.core.io.impl.ClassPathResource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.Message;
+import org.kie.api.builder.ReleaseId;
+import org.kie.api.command.Command;
+import org.kie.api.command.KieCommands;
+import org.kie.api.runtime.ExecutionResults;
+import org.kie.server.api.marshalling.MarshallingFormat;
+import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieServiceResponse;
+import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.client.KieServicesConfiguration;
+import org.kie.server.client.KieServicesFactory;
+import org.kie.server.client.RuleServicesClient;
+import org.kie.server.springboot.samples.listeners.SampleAgendaEventListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.embedded.LocalServerPort;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = {KieServerApplication.class}, webEnvironment = WebEnvironment.RANDOM_PORT)
+@TestPropertySource(locations="classpath:application-rules.properties")
+public class RulesOnlyKieServerTest {
+    
+    static final String ARTIFACT_ID = "rules";
+    static final String GROUP_ID = "org.jbpm.test";
+    static final String VERSION = "1.0.0";
+
+    @LocalServerPort
+    private int port;    
+   
+    private String user = "john";
+    private String password = "john@pwd1";
+    
+    private String containerId = "rules";
+    
+    private KieServicesClient kieServicesClient;
+    
+    @Autowired
+    private SampleAgendaEventListener listener;
+    
+    @BeforeClass
+    public static void generalSetup() {
+        createKJar();
+    }
+
+    @Before
+    public void setup() {
+        listener.clear();
+        org.kie.server.api.model.ReleaseId releaseId = new org.kie.server.api.model.ReleaseId(GROUP_ID, ARTIFACT_ID, VERSION);
+        
+        String serverUrl = "http://localhost:" + port + "/rest/server";
+        KieServicesConfiguration configuration = KieServicesFactory.newRestConfiguration(serverUrl, user, password);
+        configuration.setTimeout(60000);
+        configuration.setMarshallingFormat(MarshallingFormat.JSON);
+        this.kieServicesClient =  KieServicesFactory.newKieServicesClient(configuration); 
+        
+        KieContainerResource resource = new KieContainerResource(containerId, releaseId);        
+        kieServicesClient.createContainer(containerId, resource);
+    }
+    
+    @After
+    public void cleanup() {
+        kieServicesClient.disposeContainer(containerId);       
+    }
+  
+    @Test
+    public void testInvokeRulesOnStateless() {
+        testInvokeRulesOn("defaultStatelessKieSession");
+    }
+    
+    @Test
+    public void testInvokeRulesOnStatefull() {
+        testInvokeRulesOn("defaultKieSession");
+    }
+    
+    private void testInvokeRulesOn(String ksessionName) {
+
+        List<Command<?>> commands = new ArrayList<Command<?>>();
+        KieCommands cmdFactory = KieServices.Factory.get().getCommands();
+        
+        commands.add(cmdFactory.newInsert("John"));
+        
+        commands.add(cmdFactory.newFireAllRules("fire-identifier"));
+        RuleServicesClient rulesClient = kieServicesClient.getServicesClient(RuleServicesClient.class);
+        ServiceResponse<ExecutionResults> reply = rulesClient.executeCommandsWithResults("rules", cmdFactory.newBatchExecution(commands, ksessionName));
+        if (!KieServiceResponse.ResponseType.SUCCESS.equals(reply.getType())){
+            throw new RuntimeException("executeRule failed with message: " + reply.getMsg());
+        }
+        ExecutionResults result = reply.getResult();
+        
+        assertNotNull(result);
+        
+        assertEquals(1, listener.getFired().size());
+        assertEquals("Your First Rule",listener.getFired().get(0));
+    }
+    
+    
+    private static void createKJar() {
+        KieServices kieServices = KieServices.get();
+        
+        ReleaseId releaseId = kieServices.newReleaseId(GROUP_ID, ARTIFACT_ID, VERSION);
+        KieFileSystem kfs = kieServices.newKieFileSystem();
+        kfs.generateAndWritePomXML(releaseId);
+        
+        byte[] pom = kfs.read("pom.xml");
+        
+        kfs.write("src/main/resources/sample-rule.drl", new ClassPathResource("sample-rules.drl"));
+        
+        KieBuilder kb = kieServices.newKieBuilder(kfs).buildAll();
+        if (kb.getResults().hasMessages(Message.Level.ERROR)) {
+            for (Message result : kb.getResults().getMessages()) {
+                System.out.println("Error: " + result.getText());
+            }
+            throw new RuntimeException("Unable to create KJar for requested conditions resources");
+        }
+        InternalKieModule kieModule = (InternalKieModule) kieServices.getRepository().getKieModule(releaseId);
+        byte[] kjar = kieModule.getBytes();
+                
+        MavenRepository repository = getMavenRepository();
+        repository.installArtifact(releaseId, kjar, pom);
+    }
+}

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/java/org/kie/server/springboot/samples/listeners/SampleAgendaEventListener.java
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/java/org/kie/server/springboot/samples/listeners/SampleAgendaEventListener.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.springboot.samples.listeners;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kie.api.event.rule.AfterMatchFiredEvent;
+import org.kie.api.event.rule.DefaultAgendaEventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SampleAgendaEventListener extends DefaultAgendaEventListener {
+
+    private List<String> fired = new ArrayList<>();
+
+    @Override
+    public void afterMatchFired(AfterMatchFiredEvent event) {
+        fired.add(event.getMatch().getRule().getName());
+    }
+
+    public List<String> getFired() {
+        return fired;
+    }
+
+    public void clear() {
+        this.fired.clear();
+    }
+}

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/resources/application-rules.properties
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/resources/application-rules.properties
@@ -1,0 +1,12 @@
+#
+# https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#common-application-properties
+#
+#server configuration
+server.port=8090
+
+kieserver.drools.enabled=true
+kieserver.dmn.enabled=true
+kieserver.jbpm.enabled=false
+kieserver.jbpmui.enabled=false
+kieserver.casemgmt.enabled=false
+kieserver.optaplanner.enabled=true

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/resources/sample-rules.drl
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/resources/sample-rules.drl
@@ -1,0 +1,10 @@
+package defaultPackge
+
+
+
+rule "Your First Rule"
+    when
+        $s : String()
+    then
+        System.out.println("Hello " + $s);
+end


### PR DESCRIPTION
@sutaakar have a look especially at the first commit (change in bpmn2) for the reported "regression" which actually turned out to be a bug in the case definition.