### PR TITLE
Reset all allocated ports for Kie server tests in @AfterClass

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
@@ -195,6 +195,15 @@ public class TestConfig {
     }
 
     /**
+     * Reset all allocated ports so they can be dynamically reallocated again, to avoid BindException: Address already in use (Bind failed).
+     */
+    public static void resetAllocatedPorts() {
+        ALLOCATED_PORT = null;
+        CONTROLLER_ALLOCATED_PORT = null;
+        ROUTER_ALLOCATED_PORT = null;
+    }
+
+    /**
      * Get allocated port of embedded REST server.
      *
      * @return HTTP port number.

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/KieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/KieServerBaseIntegrationTest.java
@@ -113,6 +113,7 @@ public abstract class KieServerBaseIntegrationTest {
             System.clearProperty(Context.INITIAL_CONTEXT_FACTORY);
         }
         router.stopKieRouter();
+        TestConfig.resetAllocatedPorts();
     }
 
     protected static void disposeAllContainers() {


### PR DESCRIPTION
@mswiderski Should hopefully help to get rid of port allocation failures.