### PR TITLE
DROOLS-3355: Improve Assembler/Weaver API

### DIFF
--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -159,6 +159,11 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-case-mgmt-cmmn</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.kie.soup</groupId>
       <artifactId>kie-soup-project-datamodel-api</artifactId>
       <scope>runtime</scope>


### PR DESCRIPTION
Adding CMMN to class path as not to break integration tests

JIRA: DROOLS-3448, because this is more of a patch to work around the way the test is run:

 - maven is started with a new class loader
 - the `kie.conf` for CMMNAssemblerService is in the class path of full downstream build, which depends on everything 
- because it is not a direct Maven dependency, it is not in the class loader of the Maven build
- CMMNAssemblerService is therefore loaded from the root classloader
- when `KieAssemblerService`s are processed, all assembler services are found in the maven classpath, so they are loaded from that class loader
- ClassCastException is raised when CMMNAssemblerService is used because it is not an instance of KieAssemblerService (really, it is: but the class `KieAssemblerService` has now been loaded from the maven class loader, while CMMNAssemblerService has been loaded from the root classloader)

Required by:

- kiegroup/droolsjbpm-knowledge#351
- kiegroup/drools#2181
- kiegroup/jbpm#1393
