### PR TITLE
JBPM-7834: Provide OpenShiftStartupStrategy - Enhancements related to RHPAM templates and others

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/storage/KieServerStateRepositoryUtils.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/storage/KieServerStateRepositoryUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.services.impl.storage;
+
+import java.util.Properties;
+
+import org.kie.server.api.model.KieServerConfig;
+import org.kie.server.api.model.KieServerConfigItem;
+
+public class KieServerStateRepositoryUtils {
+
+    private KieServerStateRepositoryUtils() {
+        throw new IllegalStateException("Utility class");
+      }
+
+    public static void populateWithSystemProperties(KieServerConfig config) {
+        // populate the config state with system properties that are valid to kie server
+        populateWithProperties(config, System.getProperties());
+    }
+
+    public static void populateWithProperties(KieServerConfig config, Properties properties) {
+        // populate the config state with properties that are valid to kie server
+        for (String property : properties.stringPropertyNames()) {
+
+            if (property.startsWith("org.kie.server") || property.startsWith("org.kie.executor")) {
+                KieServerConfigItem configItem = new KieServerConfigItem(property, properties.getProperty(property), String.class.getName());
+                config.addConfigItem(configItem);
+            }
+        }
+    }
+
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/storage/file/KieServerStateFileInit.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/storage/file/KieServerStateFileInit.java
@@ -31,6 +31,8 @@ import org.kie.server.api.model.KieServerConfig;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.services.impl.KieServerContainerDeployment;
 import org.kie.server.services.impl.storage.KieServerState;
+import org.kie.server.services.impl.storage.KieServerStateRepository;
+import org.kie.server.services.impl.storage.KieServerStateRepositoryUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,7 +64,7 @@ public class KieServerStateFileInit {
                     serverStateFile,
                     KieServerStateFileInit.class.getSimpleName()));
         }
-        KieServerStateFileRepository repository = new KieServerStateFileRepository(serverRepoDir);
+        KieServerStateRepository repository = new KieServerStateFileRepository(serverRepoDir);
         KieServerState serverState = new KieServerState();
 
         KieServerConfig config = new KieServerConfig();
@@ -70,7 +72,7 @@ public class KieServerStateFileInit {
         properties.putAll(System.getProperties());
         properties.put(KIE_SERVER_STATE_REPO, serverRepo);
         properties.put(KIE_SERVER_ID, serverId);
-        repository.populateWithProperties(config, properties);
+        KieServerStateRepositoryUtils.populateWithProperties(config, properties);
         serverState.setConfiguration(config);
 
         Set<KieContainerResource> containers = new LinkedHashSet<KieContainerResource>();

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/storage/file/KieServerStateFileRepository.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/storage/file/KieServerStateFileRepository.java
@@ -20,19 +20,18 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider;
-
 import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieServerConfig;
 import org.kie.server.api.model.KieServerConfigItem;
 import org.kie.server.services.impl.storage.KieServerState;
 import org.kie.server.services.impl.storage.KieServerStateRepository;
+import org.kie.server.services.impl.storage.KieServerStateRepositoryUtils;
 import org.kie.soup.commons.xstream.XStreamUtils;
 
 public class KieServerStateFileRepository implements KieServerStateRepository {
@@ -100,31 +99,15 @@ public class KieServerStateFileRepository implements KieServerStateRepository {
                     kieServerState.setControllers(controllers);
                 }
 
-                populateWithSystemProperties(kieServerState.getConfiguration());
+                KieServerStateRepositoryUtils.populateWithSystemProperties(kieServerState.getConfiguration());
             } else {
                 KieServerConfig config = new KieServerConfig();
-                populateWithSystemProperties(config);
+                KieServerStateRepositoryUtils.populateWithSystemProperties(config);
                 kieServerState.setConfiguration(config);
             }
             knownStates.put(serverId, kieServerState);
 
             return kieServerState;
-        }
-    }
-
-    protected void populateWithSystemProperties(KieServerConfig config) {
-        // populate the config state with system properties that are valid to kie server
-        populateWithProperties(config, System.getProperties());
-    }
-
-    void populateWithProperties(KieServerConfig config, Properties properties) {
-        // populate the config state with properties that are valid to kie server
-        for (String property : properties.stringPropertyNames()) {
-
-            if (property.startsWith("org.kie.server") || property.startsWith("org.kie.executor")) {
-                KieServerConfigItem configItem = new KieServerConfigItem(property, properties.getProperty(property), String.class.getName());
-                config.addConfigItem(configItem);
-            }
         }
     }
 

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerStateTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerStateTest.java
@@ -82,7 +82,7 @@ public class KieServerStateTest {
 
     @Test
     public void testLoadKieServerStateWithProperties() {
-        KieServerStateFileRepository repository = new KieServerStateFileRepository(REPOSITORY_DIR);
+        KieServerStateRepository repository = new KieServerStateFileRepository(REPOSITORY_DIR);
 
         System.setProperty(KieServerConstants.CFG_PERSISTANCE_DIALECT, "org.hibernate.dialect.PostgreSQLDialect");
         System.setProperty(KieServerConstants.CFG_PERSISTANCE_DS, "jdbc/jbpm");

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/storage/file/KieServerStateFileInitTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/storage/file/KieServerStateFileInitTest.java
@@ -32,6 +32,7 @@ import org.kie.api.builder.ReleaseId;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieServerConfig;
 import org.kie.server.services.impl.storage.KieServerState;
+import org.kie.server.services.impl.storage.KieServerStateRepository;
 
 public class KieServerStateFileInitTest {
 
@@ -88,7 +89,7 @@ public class KieServerStateFileInitTest {
         File serverStateFile = KieServerStateFileInit.init();
         String serverRepo = getServerRepo(serverStateFile);
         String serverId = getServerId(serverStateFile);
-        KieServerStateFileRepository repository = new KieServerStateFileRepository(new File(serverRepo));
+        KieServerStateRepository repository = new KieServerStateFileRepository(new File(serverRepo));
         KieServerState serverState = repository.load(getServerId(serverStateFile));
 
         KieServerConfig config = serverState.getConfiguration();

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateCloudRepository.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateCloudRepository.java
@@ -15,14 +15,8 @@
 
 package org.kie.server.services.openshift.impl.storage.cloud;
 
-import java.util.function.Function;
-
-import javax.validation.constraints.NotNull;
-
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider;
-import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieServerConfigItem;
@@ -33,19 +27,19 @@ import org.kie.soup.commons.xstream.XStreamUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class KieServerStateCloudRepository implements KieServerStateRepository,
-                                           KieServerReadinessProbe, CloudClientFactory {
+public abstract class KieServerStateCloudRepository implements KieServerStateRepository,
+                                                    KieServerReadinessProbe, CloudClientFactory {
 
     public static final String ROLLOUT_REQUIRED = "services.server.kie.org/openshift-startup-strategy.rolloutRequired";
     public static final String CFG_MAP_DATA_KEY = "kie-server-state";
     public static final String CFG_MAP_LABEL_NAME = "services.server.kie.org/kie-server-state";
     public static final String CFG_MAP_LABEL_VALUE = "USED";
-    
+
     protected static final String STATE_CHANGE_TIMESTAMP = "services.server.kie.org/kie-server-state.changeTimestamp";
     private static final Logger logger = LoggerFactory.getLogger(KieServerStateCloudRepository.class);
 
     protected final XStream xs;
-    
+
     public static XStream initializeXStream() {
         XStream xs = XStreamUtils.createTrustingXStream(new PureJavaReflectionProvider());
         String[] voidDeny = {"void.class", "Void.class"};
@@ -61,32 +55,6 @@ public class KieServerStateCloudRepository implements KieServerStateRepository,
         xs = initializeXStream();
     }
 
-    @Override
-    @NotNull
-    public KieServerState load(@NotNull String serverId) {
-        KieServerState kieServerState = processKieServerState(client -> {
-            ConfigMap cm = client.configMaps().withName(serverId).get();
-            if (cm == null) {
-                throw new IllegalStateException(("KieServerId: [" + serverId + "], not found. Please create an associated ConfigMap with configuration first."));
-            }
-            return (KieServerState) xs.fromXML(cm.getData().get(CFG_MAP_DATA_KEY));
-        });
-
-        if (kieServerState == null || !retrieveKieServerId(kieServerState).equals(serverId)) {
-            throw new IllegalStateException("Invalid KieServerId: " + serverId + ", or inconsistent state data.");
-        }
-
-        return kieServerState;
-    }
-
-    @Override
-    public void store(String serverId, KieServerState kieServerState) {
-        /**
-         * To be implemented for supporting pure Kubernetes cluster deployment.
-         */
-        throw new UnsupportedOperationException();
-    }
-
     protected String retrieveKieServerId(KieServerState kieServerState) {
         String kssServerId = null;
         try {
@@ -98,18 +66,5 @@ public class KieServerStateCloudRepository implements KieServerStateRepository,
             throw new IllegalArgumentException("Invalid KieServerId: Can not be null or empty.");
         }
         return kssServerId;
-    }
-
-    private <R> R processKieServerState(Function<KubernetesClient, R> func) {
-        R result = null;
-        try (KubernetesClient client = createKubernetesClient()) {
-            result = func.apply(client);
-        } catch (IllegalStateException ise) {
-            logger.error("Processing KieServerState failed.", ise);
-            throw ise;
-        } catch (Exception e) {
-            logger.error("Processing KieServerState failed.", e);
-        }
-        return result;
     }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryEnhancedTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryEnhancedTest.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.services.openshift.impl.storage.cloud;
+
+import org.junit.Test;
+import org.kie.server.api.KieServerConstants;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class KieServerStateOpenShiftRepositoryEnhancedTest extends KieServerStateOpenShiftRepositoryTest {
+
+    @Test(expected = IllegalStateException.class)
+    public void testLoadWithNoInitCMandMissMatchedServerId() {
+        assertNotNull(client.configMaps().withName(TEST_KIE_SERVER_ID).delete());
+        System.setProperty(KieServerConstants.KIE_SERVER_ID, TEST_KIE_SERVER_ID);
+        assertEquals(TEST_KIE_SERVER_ID, repo.load(TEST_KIE_SERVER_ID)
+                                             .getConfiguration().getConfigItemValue(KieServerConstants.KIE_SERVER_ID));
+
+        System.setProperty(KieServerConstants.KIE_SERVER_ID, "wrongId");
+        repo.load(TEST_KIE_SERVER_ID)
+            .getConfiguration().getConfigItemValue(KieServerConstants.KIE_SERVER_ID);
+    }
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryRegularTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryRegularTest.java
@@ -1,0 +1,351 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.services.openshift.impl.storage.cloud;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ConfigMapList;
+import io.fabric8.kubernetes.api.model.DoneableConfigMap;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import org.junit.Test;
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.services.impl.StartupStrategyProvider;
+import org.kie.server.services.impl.storage.KieServerState;
+import org.kie.server.services.impl.storage.KieServerStateRepository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class KieServerStateOpenShiftRepositoryRegularTest extends KieServerStateOpenShiftRepositoryTest {
+
+    @Test
+    public void testLiteralConfigMap() throws InterruptedException {
+        HashMap<String, String> data = new HashMap<>();
+        data.put("foo", "bar");
+        data.put("cheese", "gouda");
+    
+        Map<String, String> ant = new ConcurrentHashMap<>();
+        ant.put("services.server.kie.org/kie-server-state.changeTimestamp",
+                ZonedDateTime.now().format(DateTimeFormatter.ISO_INSTANT));
+    
+        Map<String, String> lab = new ConcurrentHashMap<>();
+        lab.put("startup_in_progress", "kieserverId");
+    
+        client.configMaps().inNamespace(testNamespace)
+              .createOrReplace(new ConfigMapBuilder()
+                                                     .withNewMetadata()
+                                                     .withName("cfg1")
+                                                     .endMetadata()
+                                                     .addToData(data).build());
+    
+        try {
+            client.configMaps().inNamespace(testNamespace)
+                  .create(new ConfigMapBuilder()
+                                                .withNewMetadata()
+                                                .withName("cfg1")
+                                                .withLabels(lab)
+                                                .withAnnotations(ant)
+                                                .endMetadata()
+                                                .addToData(data).build());
+        } catch (Exception e) {
+            // If test against real cluster, second create will fail
+        }
+    
+        // If test against real cluster, uncomment out the following
+        //        assertTrue(client.configMaps().inNamespace(testNamespace)
+        //                   .withLabel("startup_in_progress", "kieserverId")
+        //                   .list().getItems().isEmpty());
+    
+        client.configMaps().inNamespace(testNamespace)
+              .createOrReplace(new ConfigMapBuilder()
+                                                     .withNewMetadata()
+                                                     .withName("cfg2")
+                                                     .withLabels(lab)
+                                                     .withAnnotations(ant)
+                                                     .endMetadata()
+                                                     .addToData(data).build());
+    
+        ConfigMapList cfgList = client.configMaps().inNamespace(testNamespace)
+                                      .withLabel("startup_in_progress", "kieserverid")
+                                      .list();
+    
+        Map<String, String> keys = client.configMaps()
+                                         .inNamespace(testNamespace)
+                                         .withName("cfg1").get().getData();
+    
+        assertEquals("gouda", keys.get("cheese"));
+        assertEquals("bar", keys.get("foo"));
+    
+        client.configMaps().inNamespace(testNamespace).delete(cfgList.getItems());
+    
+        assertTrue(client.configMaps().inNamespace(testNamespace)
+                         .withLabel("startup_in_progress", "kieserverid")
+                         .list().getItems().isEmpty());
+    }
+
+    @Test
+    public void testKieServerStateConfigMap() throws InterruptedException {
+        Resource<ConfigMap, DoneableConfigMap> configMapResource = client.configMaps().inNamespace(testNamespace)
+                                                                         .withName(TEST_KIE_SERVER_ID);
+    
+        ConfigMap configMap = configMapResource.get();
+        assertEquals(TEST_KIE_SERVER_ID, configMap.getMetadata().getName());
+    
+        Map<String, String> data = configMap.getData();
+    
+        // Avoid attribute name having '.' as it confuses jsonpath
+        String srvStateInXML = data.get(KieServerStateCloudRepository.CFG_MAP_DATA_KEY);
+        KieServerState kieServerState = (KieServerState) xs.fromXML(srvStateInXML);
+    
+        assertNotNull(kieServerState);
+        assertEquals(TEST_KIE_SERVER_ID,
+                     kieServerState.getConfiguration().getConfigItem(KieServerConstants.KIE_SERVER_ID).getValue());
+    
+    }
+
+    @Test
+    public void testStoreAndLoad() throws InterruptedException {
+        // Retrieve the seeded KSSConfigMap and Store it under new name
+        String srvStateInXML = client.configMaps().inNamespace(testNamespace)
+                                     .withName(TEST_KIE_SERVER_ID).get().getData().get(KieServerStateCloudRepository.CFG_MAP_DATA_KEY);
+        KieServerState kieServerState = (KieServerState) xs.fromXML(srvStateInXML);
+    
+        assertNotNull(kieServerState);
+        
+        /**
+         * At normal situation, DC will not be null otherwise there will no KieServer Pod running
+         */
+        createDummyDC();
+        repo.store(TEST_KIE_SERVER_ID, kieServerState);
+        assertNotNull(client.configMaps().inNamespace(testNamespace)
+                            .withName(TEST_KIE_SERVER_ID).get());
+    
+        KieServerState kssLoaded = repo.load(TEST_KIE_SERVER_ID);
+        assertNotNull(kssLoaded);
+        assertEquals(TEST_KIE_SERVER_ID,
+                     kssLoaded.getConfiguration().getConfigItem(KieServerConstants.KIE_SERVER_ID).getValue());
+    
+        KieContainerResource[] kcr = kssLoaded.getContainers()
+                                              .<KieContainerResource> toArray(new KieContainerResource[]{});
+    
+        assertEquals(2, kcr.length);
+        assertEquals("mortgages_1.0.0-SNAPSHOT", kcr[0].getContainerId());
+        assertEquals("mortgage-process_1.0.0-SNAPSHOT", kcr[1].getContainerId());
+    }
+
+    @Test
+    public void testStoreAndLoadWithRolloutTrigger() throws InterruptedException {
+        // Retrieve the seeded KSSConfigMap and Store it under new name
+        String srvStateInXML = client.configMaps().inNamespace(testNamespace)
+                                     .withName(TEST_KIE_SERVER_ID).get().getData().get(KieServerStateCloudRepository.CFG_MAP_DATA_KEY);
+        KieServerState kieServerState = (KieServerState) xs.fromXML(srvStateInXML);
+    
+        repo.store(TEST_KIE_SERVER_ID, kieServerState);
+        assertTrue(client.configMaps().inNamespace(testNamespace)
+                            .withName(TEST_KIE_SERVER_ID)
+                            .get()
+                            .getMetadata()
+                            .getAnnotations()
+                            .containsKey(KieServerStateCloudRepository.ROLLOUT_REQUIRED));
+    
+    }
+
+    @Test
+    public void testLoadWithNullServerId() {
+        assertNull(repo.load(null));
+    }
+
+    @Test
+    public void testLoadWithInvalidServerId() {
+        assertNull(repo.load("dummy"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStoreWithEmptyKieServerState() {
+        repo.store("dummy", new KieServerState());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testStoreWithMissMatchingServerId() {
+        KieServerState kss = repo.load(TEST_KIE_SERVER_ID);
+        repo.store("dummy", kss);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testStoreWithoutPreSeededConfigMap() {
+        KieServerState kss = repo.load(TEST_KIE_SERVER_ID);
+    
+        // Remove the configmap created at Setup to set a no pre-seeded scenario
+        client.configMaps().inNamespace(testNamespace).withName(TEST_KIE_SERVER_ID).delete();
+    
+        repo.store(TEST_KIE_SERVER_ID, kss);
+    }
+
+    @Test
+    public void testAnnotation() {
+    
+        String kieServer1 = KIE_SERVER_STARTUP_IN_PROGRESS_KEY_PREFIX + UUID.randomUUID().toString();
+        String kieServer2 = KIE_SERVER_STARTUP_IN_PROGRESS_KEY_PREFIX + UUID.randomUUID().toString();
+    
+        ConfigMap cm = client.configMaps().withName(TEST_KIE_SERVER_ID).get();
+        ObjectMeta md = cm.getMetadata();
+        Map<String, String> ann = md.getAnnotations() == null ? new HashMap<>() : md.getAnnotations();
+        md.setAnnotations(ann);
+        ann.put(kieServer1, KIE_SERVER_STARTUP_IN_PROGRESS_VALUE);
+        ann.put(kieServer2, KIE_SERVER_STARTUP_IN_PROGRESS_VALUE);
+        client.configMaps().createOrReplace(cm);
+    
+        assertNotNull(client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata().getAnnotations());
+        assertTrue(client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata()
+                         .getAnnotations().containsKey(kieServer1));
+        assertTrue(client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata()
+                         .getAnnotations().containsKey(kieServer2));
+        assertTrue(
+                   client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata()
+                         .getAnnotations().containsValue(KIE_SERVER_STARTUP_IN_PROGRESS_VALUE));
+    
+        ann.remove(kieServer1);
+        client.configMaps().createOrReplace(cm);
+    
+        assertTrue(
+                   client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata()
+                         .getAnnotations().containsValue(KIE_SERVER_STARTUP_IN_PROGRESS_VALUE));
+    
+        ann.remove(kieServer2);
+        client.configMaps().createOrReplace(cm);
+    
+        assertFalse(
+                    client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata()
+                          .getAnnotations().containsValue(KIE_SERVER_STARTUP_IN_PROGRESS_VALUE));
+    
+    }
+
+    @Test
+    public void testNPEWhenNoServiceProviderConfig() {
+        ServiceLoader<KieServerStateRepository> serverStateRepos = ServiceLoader.load(KieServerStateRepository.class);
+        assertNotNull(serverStateRepos);
+    
+        String repoType = StartupStrategyProvider.get().getStrategy().getRepositoryType();
+        for (KieServerStateRepository repo : serverStateRepos) {
+            assertNotNull(repo);
+            assertNotNull(repo.getClass().getSimpleName());
+            if (repo.getClass().getSimpleName().equals(repoType)) {
+                fail("Unexpected repo type: " + repoType);
+            }
+        }
+    }
+
+    @Test
+    public void testCreateAndLoad() {
+        // Retrieve the seeded KSSConfigMap and Store it under new name
+        String srvStateInXML = client.configMaps().inNamespace(testNamespace)
+                                     .withName(TEST_KIE_SERVER_ID).get().getData().get(KieServerStateCloudRepository.CFG_MAP_DATA_KEY);
+        KieServerState kieServerState = (KieServerState) xs.fromXML(srvStateInXML);
+    
+        assertNotNull(kieServerState);
+    
+        kieServerState.getConfiguration()
+                      .getConfigItem(KieServerConstants.KIE_SERVER_ID).setValue(TEST_KIE_SERVER_ID + "_NEW");
+    
+        repo.create(kieServerState);
+        assertNotNull(client.configMaps().inNamespace(testNamespace)
+                            .withName(TEST_KIE_SERVER_ID + "_NEW").get());
+    
+        assertNotNull(repo.load(TEST_KIE_SERVER_ID + "_NEW"));
+    }
+
+    @Test
+    public void testDeleteAndExists() {
+        assertTrue(repo.exists(TEST_KIE_SERVER_ID));
+        repo.delete(TEST_KIE_SERVER_ID);
+        assertTrue(!repo.exists(TEST_KIE_SERVER_ID));
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void testDeleteAttachedKieServerStateIsNotAllowed() {
+        assertTrue(repo.exists(TEST_KIE_SERVER_ID));
+        // Create a dummy DeploymentConfig to simulate attached KieServeState scenario
+        createDummyDC();
+        repo.delete(TEST_KIE_SERVER_ID);
+    }
+
+    @Test
+    public void testRetrieveAllKieServerIdsAndStates() {
+        KieServerState state = repo.load(TEST_KIE_SERVER_ID);
+        state.getConfiguration()
+             .getConfigItem(KieServerConstants.KIE_SERVER_ID).setValue(TEST_KIE_SERVER_ID + "_1");
+        // Create new KieServer    
+        repo.create(state);
+    
+        state.getConfiguration()
+             .getConfigItem(KieServerConstants.KIE_SERVER_ID).setValue(TEST_KIE_SERVER_ID + "_2");
+        // Create new KieServer    
+        repo.create(state);
+    
+        List<String> kIds = repo.retrieveAllKieServerIds();
+        assertEquals(3, kIds.size());
+        assertTrue(kIds.contains(TEST_KIE_SERVER_ID));
+        assertTrue(kIds.contains(TEST_KIE_SERVER_ID + "_1"));
+        assertTrue(kIds.contains(TEST_KIE_SERVER_ID + "_2"));
+    
+        List<KieServerState> kStates = repo.retrieveAllKieServerStates();
+        assertEquals(3, kStates.size());
+    
+        repo.delete(TEST_KIE_SERVER_ID);
+        repo.delete(TEST_KIE_SERVER_ID + "_1");
+        repo.delete(TEST_KIE_SERVER_ID + "_2");
+    
+        assertEquals(0, repo.retrieveAllKieServerIds().size());
+        assertEquals(0, repo.retrieveAllKieServerStates().size());
+    }
+
+    @Test
+    public void testRetrieveAllKieServerIdsAndStatesWithContaminatedCF() {
+        // Adding a contaminated configmap which does not include required label
+        ConfigMap cfm = client.configMaps()
+                .load(KieServerStateOpenShiftRepositoryTest.class
+                .getResourceAsStream("/test-kieserver-state-config-map-without-label.yml")).get();
+    
+        client.configMaps().inNamespace(testNamespace).createOrReplace(cfm);
+        
+        // Now there are two configmaps in the test namespace
+        assertEquals(2, client.configMaps().list().getItems().size());
+        
+        // But still have only 1 valid KieServerState
+        List<String> kIds = repo.retrieveAllKieServerIds();
+        assertEquals(1, kIds.size());
+    
+        List<KieServerState> kStates = repo.retrieveAllKieServerStates();
+        assertEquals(1, kStates.size());
+    }
+
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryTest.java
@@ -13,63 +13,42 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.kie.server.services.openshift.impl.storage.cloud;
 
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.ServiceLoader;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import com.thoughtworks.xstream.XStream;
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
-import io.fabric8.kubernetes.api.model.ConfigMapList;
-import io.fabric8.kubernetes.api.model.DoneableConfigMap;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.server.mock.OpenShiftServer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
 import org.kie.server.api.KieServerConstants;
-import org.kie.server.api.model.KieContainerResource;
-import org.kie.server.services.impl.StartupStrategyProvider;
-import org.kie.server.services.impl.storage.KieServerState;
-import org.kie.server.services.impl.storage.KieServerStateRepository;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.kie.server.services.openshift.impl.storage.cloud.KieServerStateCloudRepository.initializeXStream;
 
 public class KieServerStateOpenShiftRepositoryTest {
 
-    private static final String KIE_SERVER_STARTUP_IN_PROGRESS_KEY_PREFIX = "org.kie.server.services/";
-    private static final String KIE_SERVER_STARTUP_IN_PROGRESS_VALUE = "kie.server.startup_in_progress";
+    protected static final String KIE_SERVER_STARTUP_IN_PROGRESS_KEY_PREFIX = "org.kie.server.services/";
+    protected static final String KIE_SERVER_STARTUP_IN_PROGRESS_VALUE = "kie.server.startup_in_progress";
 
     // Must match the the kie server id specified at test file
-    private static final String TEST_KIE_SERVER_ID = "myapp2-kieserver";
-    private static XStream xs = initializeXStream();
-    private static Supplier<OpenShiftClient> clouldClientHelper = () -> (new CloudClientFactory() {
+    protected static final String TEST_KIE_SERVER_ID = "myapp2-kieserver";
+    protected static XStream xs = initializeXStream();
+    protected static Supplier<OpenShiftClient> clouldClientHelper = () -> (new CloudClientFactory() {
     }).createOpenShiftClient();
 
     /**
      *  Must match current project name associated with OpenShift login
      *  if test against real OCP/K8S cluster
      */
-    private String testNamespace = "myproject";
-    private OpenShiftClient client;
-    private KieServerStateOpenShiftRepository repo;
+    protected String testNamespace = "myproject";
+    protected OpenShiftClient client;
+    protected KieServerStateOpenShiftRepository repo;
 
     @Rule
     public OpenShiftServer server = new OpenShiftServer(false, true);
@@ -120,317 +99,19 @@ public class KieServerStateOpenShiftRepositoryTest {
             public boolean isKieServerReady() {
                 return true;
             }
+            
+            @Override
+            public boolean isDCStable(DeploymentConfig dc) {
+                return true;
+            }
         };
 
         repo.load(TEST_KIE_SERVER_ID);
     }
 
-    @Test
-    public void testLiteralConfigMap() throws InterruptedException {
-        HashMap<String, String> data = new HashMap<>();
-        data.put("foo", "bar");
-        data.put("cheese", "gouda");
-
-        Map<String, String> ant = new ConcurrentHashMap<>();
-        ant.put("services.server.kie.org/kie-server-state.changeTimestamp",
-                ZonedDateTime.now().format(DateTimeFormatter.ISO_INSTANT));
-
-        Map<String, String> lab = new ConcurrentHashMap<>();
-        lab.put("startup_in_progress", "kieserverId");
-
-        client.configMaps().inNamespace(testNamespace)
-              .createOrReplace(new ConfigMapBuilder()
-                                                     .withNewMetadata()
-                                                     .withName("cfg1")
-                                                     .endMetadata()
-                                                     .addToData(data).build());
-
-        try {
-            client.configMaps().inNamespace(testNamespace)
-                  .create(new ConfigMapBuilder()
-                                                .withNewMetadata()
-                                                .withName("cfg1")
-                                                .withLabels(lab)
-                                                .withAnnotations(ant)
-                                                .endMetadata()
-                                                .addToData(data).build());
-        } catch (Exception e) {
-            // If test against real cluster, second create will fail
-        }
-
-        // If test against real cluster, uncomment out the following
-        //        assertTrue(client.configMaps().inNamespace(testNamespace)
-        //                   .withLabel("startup_in_progress", "kieserverId")
-        //                   .list().getItems().isEmpty());
-
-        client.configMaps().inNamespace(testNamespace)
-              .createOrReplace(new ConfigMapBuilder()
-                                                     .withNewMetadata()
-                                                     .withName("cfg2")
-                                                     .withLabels(lab)
-                                                     .withAnnotations(ant)
-                                                     .endMetadata()
-                                                     .addToData(data).build());
-
-        ConfigMapList cfgList = client.configMaps().inNamespace(testNamespace)
-                                      .withLabel("startup_in_progress", "kieserverid")
-                                      .list();
-
-        Map<String, String> keys = client.configMaps()
-                                         .inNamespace(testNamespace)
-                                         .withName("cfg1").get().getData();
-
-        assertEquals("gouda", keys.get("cheese"));
-        assertEquals("bar", keys.get("foo"));
-
-        client.configMaps().inNamespace(testNamespace).delete(cfgList.getItems());
-
-        assertTrue(client.configMaps().inNamespace(testNamespace)
-                         .withLabel("startup_in_progress", "kieserverid")
-                         .list().getItems().isEmpty());
-    }
-
-    @Test
-    public void testKieServerStateConfigMap() throws InterruptedException {
-        Resource<ConfigMap, DoneableConfigMap> configMapResource = client.configMaps().inNamespace(testNamespace)
-                                                                         .withName(TEST_KIE_SERVER_ID);
-
-        ConfigMap configMap = configMapResource.get();
-        assertEquals(TEST_KIE_SERVER_ID, configMap.getMetadata().getName());
-
-        Map<String, String> data = configMap.getData();
-
-        // Avoid attribute name having '.' as it confuses jsonpath
-        String srvStateInXML = data.get(KieServerStateCloudRepository.CFG_MAP_DATA_KEY);
-        KieServerState kieServerState = (KieServerState) xs.fromXML(srvStateInXML);
-
-        assertNotNull(kieServerState);
-        assertEquals(TEST_KIE_SERVER_ID,
-                     kieServerState.getConfiguration().getConfigItem(KieServerConstants.KIE_SERVER_ID).getValue());
-
-        // Since KubenetesClient is AutoCloseable, try-with-resource can be used
-        assertTrue(client instanceof AutoCloseable);
-    }
-
-    @Test
-    public void testStoreAndLoad() throws InterruptedException {
-        // Retrieve the seeded KSSConfigMap and Store it under new name
-        String srvStateInXML = client.configMaps().inNamespace(testNamespace)
-                                     .withName(TEST_KIE_SERVER_ID).get().getData().get(KieServerStateCloudRepository.CFG_MAP_DATA_KEY);
-        KieServerState kieServerState = (KieServerState) xs.fromXML(srvStateInXML);
-
-        assertNotNull(kieServerState);
-        
-        /**
-         * At normal situation, DC will not be null otherwise there will no KieServer Pod running
-         */
-        createDummyDC();
-        repo.store(TEST_KIE_SERVER_ID, kieServerState);
-        assertNotNull(client.configMaps().inNamespace(testNamespace)
-                            .withName(TEST_KIE_SERVER_ID).get());
-
-        KieServerState kssLoaded = repo.load(TEST_KIE_SERVER_ID);
-        assertNotNull(kssLoaded);
-        assertEquals(TEST_KIE_SERVER_ID,
-                     kssLoaded.getConfiguration().getConfigItem(KieServerConstants.KIE_SERVER_ID).getValue());
-
-        KieContainerResource[] kcr = kssLoaded.getContainers()
-                                              .<KieContainerResource> toArray(new KieContainerResource[]{});
-
-        assertEquals(2, kcr.length);
-        assertEquals("mortgages_1.0.0-SNAPSHOT", kcr[0].getContainerId());
-        assertEquals("mortgage-process_1.0.0-SNAPSHOT", kcr[1].getContainerId());
-    }
-
-    @Test
-    public void testStoreAndLoadWithRolloutTrigger() throws InterruptedException {
-        // Retrieve the seeded KSSConfigMap and Store it under new name
-        String srvStateInXML = client.configMaps().inNamespace(testNamespace)
-                                     .withName(TEST_KIE_SERVER_ID).get().getData().get(KieServerStateCloudRepository.CFG_MAP_DATA_KEY);
-        KieServerState kieServerState = (KieServerState) xs.fromXML(srvStateInXML);
-
-        repo.store(TEST_KIE_SERVER_ID, kieServerState);
-        assertNotNull(client.configMaps().inNamespace(testNamespace)
-                            .withName(TEST_KIE_SERVER_ID)
-                            .get()
-                            .getMetadata()
-                            .getAnnotations()
-                            .containsKey(KieServerStateCloudRepository.ROLLOUT_REQUIRED));
-
-    }
-
-    @Test(expected = Exception.class)
-    public void testLoadWithNullServerId() {
-        repo.load(null);
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testLoadWithInvalidServerId() {
-        repo.load("dummy");
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testStoreWithEmptyKieServerState() {
-        repo.store("dummy", new KieServerState());
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testStoreWithMissMatchingServerId() {
-        KieServerState kss = repo.load(TEST_KIE_SERVER_ID);
-        repo.store("dummy", kss);
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testStoreWithoutPreSeededConfigMap() {
-        KieServerState kss = repo.load(TEST_KIE_SERVER_ID);
-
-        // Remove the configmap created at Setup to set a no pre-seeded scenario
-        client.configMaps().inNamespace(testNamespace).withName(TEST_KIE_SERVER_ID).delete();
-
-        repo.store(TEST_KIE_SERVER_ID, kss);
-    }
-
-    @Test
-    public void testAnnotation() {
-
-        String kieServer1 = KIE_SERVER_STARTUP_IN_PROGRESS_KEY_PREFIX + UUID.randomUUID().toString();
-        String kieServer2 = KIE_SERVER_STARTUP_IN_PROGRESS_KEY_PREFIX + UUID.randomUUID().toString();
-
-        ConfigMap cm = client.configMaps().withName(TEST_KIE_SERVER_ID).get();
-        ObjectMeta md = cm.getMetadata();
-        Map<String, String> ann = md.getAnnotations() == null ? new HashMap<>() : md.getAnnotations();
-        md.setAnnotations(ann);
-        ann.put(kieServer1, KIE_SERVER_STARTUP_IN_PROGRESS_VALUE);
-        ann.put(kieServer2, KIE_SERVER_STARTUP_IN_PROGRESS_VALUE);
-        client.configMaps().createOrReplace(cm);
-
-        assertNotNull(client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata().getAnnotations());
-        assertTrue(client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata()
-                         .getAnnotations().containsKey(kieServer1));
-        assertTrue(client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata()
-                         .getAnnotations().containsKey(kieServer2));
-        assertTrue(
-                   client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata()
-                         .getAnnotations().containsValue(KIE_SERVER_STARTUP_IN_PROGRESS_VALUE));
-
-        ann.remove(kieServer1);
-        client.configMaps().createOrReplace(cm);
-
-        assertTrue(
-                   client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata()
-                         .getAnnotations().containsValue(KIE_SERVER_STARTUP_IN_PROGRESS_VALUE));
-
-        ann.remove(kieServer2);
-        client.configMaps().createOrReplace(cm);
-
-        assertFalse(
-                    client.configMaps().withName(TEST_KIE_SERVER_ID).get().getMetadata()
-                          .getAnnotations().containsValue(KIE_SERVER_STARTUP_IN_PROGRESS_VALUE));
-
-    }
-
-    @Test
-    public void testNPEWhenNoServiceProviderConfig() {
-        ServiceLoader<KieServerStateRepository> serverStateRepos = ServiceLoader.load(KieServerStateRepository.class);
-        assertNotNull(serverStateRepos);
-
-        String repoType = StartupStrategyProvider.get().getStrategy().getRepositoryType();
-        for (KieServerStateRepository repo : serverStateRepos) {
-            assertNotNull(repo);
-            assertNotNull(repo.getClass().getSimpleName());
-            if (repo.getClass().getSimpleName().equals(repoType)) {
-                fail("Unexpected repo type: " + repoType);
-            }
-        }
-    }
-
-    @Test
-    public void testCreateAndLoad() {
-        // Retrieve the seeded KSSConfigMap and Store it under new name
-        String srvStateInXML = client.configMaps().inNamespace(testNamespace)
-                                     .withName(TEST_KIE_SERVER_ID).get().getData().get(KieServerStateCloudRepository.CFG_MAP_DATA_KEY);
-        KieServerState kieServerState = (KieServerState) xs.fromXML(srvStateInXML);
-
-        assertNotNull(kieServerState);
-
-        kieServerState.getConfiguration()
-                      .getConfigItem(KieServerConstants.KIE_SERVER_ID).setValue(TEST_KIE_SERVER_ID + "_NEW");
-
-        repo.create(kieServerState);
-        assertNotNull(client.configMaps().inNamespace(testNamespace)
-                            .withName(TEST_KIE_SERVER_ID + "_NEW").get());
-
-        assertNotNull(repo.load(TEST_KIE_SERVER_ID + "_NEW"));
-    }
-
-    @Test
-    public void testDeleteAndExists() {
-        assertTrue(repo.exists(TEST_KIE_SERVER_ID));
-        repo.delete(TEST_KIE_SERVER_ID);
-        assertTrue(!repo.exists(TEST_KIE_SERVER_ID));
-    }
-
-    @Test(expected = UnsupportedOperationException.class)
-    public void testDeleteAttachedKieServerStateIsNotAllowed() {
-        assertTrue(repo.exists(TEST_KIE_SERVER_ID));
-        // Create a dummy DeploymentConfig to simulate attached KieServeState scenario
-        createDummyDC();
-        repo.delete(TEST_KIE_SERVER_ID);
-    }
-
- 
-    @Test
-    public void testRetrieveAllKieServerIdsAndStates() {
-        KieServerState state = repo.load(TEST_KIE_SERVER_ID);
-        state.getConfiguration()
-             .getConfigItem(KieServerConstants.KIE_SERVER_ID).setValue(TEST_KIE_SERVER_ID + "_1");
-        // Create new KieServer    
-        repo.create(state);
-
-        state.getConfiguration()
-             .getConfigItem(KieServerConstants.KIE_SERVER_ID).setValue(TEST_KIE_SERVER_ID + "_2");
-        // Create new KieServer    
-        repo.create(state);
-
-        List<String> kIds = repo.retrieveAllKieServerIds();
-        assertEquals(3, kIds.size());
-        assertTrue(kIds.contains(TEST_KIE_SERVER_ID));
-        assertTrue(kIds.contains(TEST_KIE_SERVER_ID + "_1"));
-        assertTrue(kIds.contains(TEST_KIE_SERVER_ID + "_2"));
-
-        List<KieServerState> kStates = repo.retrieveAllKieServerStates();
-        assertEquals(3, kStates.size());
-
-        repo.delete(TEST_KIE_SERVER_ID);
-        repo.delete(TEST_KIE_SERVER_ID + "_1");
-        repo.delete(TEST_KIE_SERVER_ID + "_2");
-
-        assertEquals(0, repo.retrieveAllKieServerIds().size());
-        assertEquals(0, repo.retrieveAllKieServerStates().size());
-    }
-
-    @Test
-    public void testRetrieveAllKieServerIdsAndStatesWithContaminatedCF() {
-        // Adding a contaminated configmap which does not include required label
-        ConfigMap cfm = client.configMaps()
-                .load(KieServerStateOpenShiftRepositoryTest.class
-                .getResourceAsStream("/test-kieserver-state-config-map-without-label.yml")).get();
-
-        client.configMaps().inNamespace(testNamespace).createOrReplace(cfm);
-        
-        // Now there are two configmaps in the test namespace
-        assertEquals(2, client.configMaps().list().getItems().size());
-        
-        // But still have only 1 valid KieServerState
-        List<String> kIds = repo.retrieveAllKieServerIds();
-        assertEquals(1, kIds.size());
-
-        List<KieServerState> kStates = repo.retrieveAllKieServerStates();
-        assertEquals(1, kStates.size());
-    }
-
     @After
     public void tearDown() {
+        System.clearProperty(KieServerConstants.KIE_SERVER_ID);
         client.configMaps().inNamespace(testNamespace).delete();
         client.close();
     }


### PR DESCRIPTION
Further enhancements to OpenShiftStartupStrategy (See PR https://github.com/kiegroup/droolsjbpm-integration/pull/1611) to allow minimum changes to existing RHPAM Template and initialization scripts. It includes the following:

- Automatically create initial KieServerState ConfigMap with configuration data from System properties.

- Refactored KieServerImple class, and added call to store() method within active/deactive KieContainer methods so as to trigger DC rollouts.

- Minor optimizations to OpenShiftStartupStrategy and test case classes.