### PR TITLE
JBPM-8120 - Case Data is inserted twice in springboot

### DIFF
--- a/kie-spring/src/main/java/org/kie/spring/jbpm/services/SpringTransactionalCommandService.java
+++ b/kie-spring/src/main/java/org/kie/spring/jbpm/services/SpringTransactionalCommandService.java
@@ -22,9 +22,12 @@ import javax.persistence.EntityManagerFactory;
 import org.drools.persistence.api.TransactionManager;
 import org.jbpm.shared.services.impl.TransactionalCommandService;
 import org.kie.api.command.Command;
+import org.springframework.orm.jpa.EntityManagerFactoryInfo;
+import org.springframework.orm.jpa.EntityManagerHolder;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.AbstractPlatformTransactionManager;
 import org.springframework.transaction.support.DefaultTransactionDefinition;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
  *
@@ -91,6 +94,17 @@ public class SpringTransactionalCommandService extends TransactionalCommandServi
         if (sharedEntityManager != null) {
             return sharedEntityManager;
         }
+
+        EntityManagerHolder emHolder = ((EntityManagerHolder) TransactionSynchronizationManager.getResource("cmdEM"));
+        if (emHolder != null) {
+            EntityManager em = emHolder.getEntityManager();
+            EntityManagerFactory nativeEmf = ((EntityManagerFactoryInfo) emf).getNativeEntityManagerFactory();
+            if (em != null && em.isOpen() && em.getEntityManagerFactory().equals(nativeEmf)) {
+
+                return em;
+            }
+        }
+
         return super.getEntityManager(command);
     }
 }


### PR DESCRIPTION
Hi @mswiderski,

please see my investigation in [JBPM-8120](https://issues.jboss.org/browse/JBPM-8120). I tried to do the same as we do in https://github.com/kiegroup/jbpm/blob/00a53b1f4d0524aef9ac5fa43cac83aed141e2c7/jbpm-services/jbpm-shared-services/src/main/java/org/jbpm/shared/services/impl/TransactionalCommandService.java#L101. I have also left there an option to use sharedEntityManager should a user need it. Locally it worked for me, I have also tested -all and -jbpm modules with springboot with one configuration (JAXB). Full test run will be done as a part of a nightly build. In case you have any suggestions for improvement, feel free to alter this PR.

Test coverage is provided by [CaseRuntimeDataServiceIntegrationTest#testGetCaseInstanceDataItems](https://github.com/kiegroup/droolsjbpm-integration/blob/master/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/cases/CaseRuntimeDataServiceIntegrationTest.java#L1858).

Depends on kiegroup/jbpm/pull/1410