### PR TITLE
[JBPM-8153] Container is removed from UI even though it was not possible to stop it.

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
@@ -536,6 +536,7 @@ public class KieServerInstanceManager {
             KieContainerResource containerResource = serviceResponse.getResult();
             container.setResolvedReleasedId(containerResource.getResolvedReleaseId() == null ? containerResource.getReleaseId() : containerResource.getResolvedReleaseId());
             container.setMessages(containerResource.getMessages());
+            container.setStatus(containerResource.getStatus());
         }
     }
 


### PR DESCRIPTION
the status is not properly set in the resource response from the kie server