### PR TITLE
JBPM-8154: Exclude tools.jar from kubernetes-server-mock

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/pom.xml
@@ -103,6 +103,12 @@
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-server-mock</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.fabric8</groupId>


### PR DESCRIPTION
As it is not available for Java 11.

@rhtevan Please take a look.
Checked on Java 8 and 11, both compile and pass unit tests.