### PR TITLE
JBPM-8149: Add jaxb-xjc artifact as replacement of xjc removal in Jav…

### DIFF
--- a/kie-server-parent/kie-server-wars/kie-server/pom.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/pom.xml
@@ -299,6 +299,11 @@
       <groupId>org.kie</groupId>
       <artifactId>kie-security</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-xjc</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee7-container.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee7-container.xml
@@ -75,6 +75,8 @@
         <include>com.google.inject.extensions:guice-servlet</include>
         
         <include>xerces:xercesImpl</include>
+
+        <include>com.sun.xml.bind:jaxb-xjc</include>
       </includes>
       <excludes>
         <exclude>org.jboss.resteasy:*</exclude>


### PR DESCRIPTION
…a 11

Checked on WildFly with Java 8 and 11, WLS and WAS on Java 8 and Tomcat 9 on Java 11. Passing everywhere.