### PR TITLE
AF-1685: Development Lifecycle Streamline

### DIFF
--- a/camel-container-tests/camel-container-integration-tests/pom.xml
+++ b/camel-container-tests/camel-container-integration-tests/pom.xml
@@ -177,6 +177,7 @@
                 <type>installed</type>
                 <systemProperties>
                   <kie.maven.settings.custom>${kie.maven.settings.custom}</kie.maven.settings.custom>
+                  <org.kie.server.mode>regular</org.kie.server.mode>
                 </systemProperties>
               </container>
               <deployables>
@@ -283,6 +284,7 @@
                 <type>installed</type>
                 <systemProperties>
                   <kie.maven.settings.custom>${kie.maven.settings.custom}</kie.maven.settings.custom>
+                  <org.kie.server.mode>regular</org.kie.server.mode>
                 </systemProperties>
               </container>
               <deployables>

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/blueprint/KieBlueprintScannerReimportIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/blueprint/KieBlueprintScannerReimportIntegrationTest.java
@@ -26,6 +26,8 @@ import java.util.Properties;
 
 import javax.inject.Inject;
 
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.kie.karaf.itest.AbstractKarafIntegrationTest;
 import org.kie.karaf.itest.util.KieScannerTestUtils;
 import org.kie.karaf.itest.util.TimerUtils;
@@ -38,6 +40,7 @@ import org.kie.api.KieServices;
 import org.kie.api.builder.KieScanner;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.runtime.KieSession;
+import org.kie.server.api.KieServerConstants;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -78,6 +81,16 @@ public class KieBlueprintScannerReimportIntegrationTest extends AbstractKarafInt
         kieScannerTestUtils.setUp();
         kieScannerTestUtils.createAndInstallKJar(RELEASE_ID, "rule_0");
         kieScannerTestUtils.tearDown();
+    }
+
+    @BeforeClass
+    public static void generalSetup() {
+        System.setProperty(KieServerConstants.KIE_SERVER_MODE, "regular");
+    }
+
+    @AfterClass
+    public static void generalCleanup() {
+        System.clearProperty(KieServerConstants.KIE_SERVER_MODE);
     }
 
     @After

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/camel/kiecamel/KieCamelBlueprintDTIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/camel/kiecamel/KieCamelBlueprintDTIntegrationTest.java
@@ -18,13 +18,16 @@ package org.kie.karaf.itest.camel.kiecamel;
 
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.bean.PojoProxyHelper;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.karaf.itest.AbstractKarafIntegrationTest;
 import org.kie.karaf.itest.camel.kiecamel.model.Cheese;
 import org.kie.karaf.itest.camel.kiecamel.proxy.CheeseAssessmentService;
 import org.kie.karaf.itest.camel.kiecamel.tools.CheeseFactory;
+import org.kie.server.api.KieServerConstants;
 import org.ops4j.pax.exam.Configuration;
 import org.ops4j.pax.exam.Option;
 import org.ops4j.pax.exam.junit.PaxExam;
@@ -73,6 +76,16 @@ public class KieCamelBlueprintDTIntegrationTest extends AbstractKarafIntegration
                 // (simulates for instance a bundle with domain classes used in rules)
                 wrappedBundle(mavenBundle().groupId("junit").artifactId("junit").versionAsInProject())
         };
+    }
+
+    @BeforeClass
+    public static void generalSetup() {
+        System.setProperty(KieServerConstants.KIE_SERVER_MODE, "regular");
+    }
+
+    @AfterClass
+    public static void generalCleanup() {
+        System.clearProperty(KieServerConstants.KIE_SERVER_MODE);
     }
 
     @Test(timeout = 60000)

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
@@ -148,5 +148,4 @@ public class KieServerConstants {
     public static final String SYSTEM_XSTREAM_ENABLED_PACKAGES = "org.kie.server.xstream.enabled.packages";
 
     public static final String RESET_CONTAINER_BEFORE_UPDATE = "resetBeforeUpdate";
-
 }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
@@ -1,17 +1,18 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.kie.server.api;
 
@@ -49,6 +50,7 @@ public class KieServerConstants {
     public static final String KIE_SERVER_ACTIVATE_POLICIES = "org.kie.server.policy.activate";
     public static final String KIE_SERVER_MGMT_API_DISABLED = "org.kie.server.mgmt.api.disabled";
     public static final String KIE_SERVER_STARTUP_STRATEGY = "org.kie.server.startup.strategy";
+    public static final String KIE_SERVER_MODE = "org.kie.server.mode";
 
     // configuration parameters
     public static final String CFG_PERSISTANCE_DS = "org.kie.server.persistence.ds";
@@ -101,6 +103,7 @@ public class KieServerConstants {
 
     public static final String KIE_SERVER_PARAM_MODULE_METADATA = "KieModuleMetaData";
     public static final String KIE_SERVER_PARAM_MESSAGES = "ContainerMessages";
+    public static final String KIE_SERVER_PARAM_RESET_BEFORE_UPDATE = "KieServerResetBeforeUpdate";
 
     public static final String KIE_SERVER_ROUTER = "org.kie.server.router";
     public static final String KIE_SERVER_ROUTER_ATTEMPT_INTERVAL = "org.kie.server.router.connect";
@@ -143,5 +146,7 @@ public class KieServerConstants {
 
     // System variable to store the enabled packages for the XStreamMarshaller
     public static final String SYSTEM_XSTREAM_ENABLED_PACKAGES = "org.kie.server.xstream.enabled.packages";
+
+    public static final String RESET_CONTAINER_BEFORE_UPDATE = "resetBeforeUpdate";
 
 }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/UpdateReleaseIdCommand.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/UpdateReleaseIdCommand.java
@@ -15,8 +15,9 @@
 
 package org.kie.server.api.commands;
 
+import java.util.Objects;
+
 import com.thoughtworks.xstream.annotations.XStreamAlias;
-import org.kie.server.api.model.KieScannerResource;
 import org.kie.server.api.model.KieServerCommand;
 import org.kie.server.api.model.ReleaseId;
 
@@ -38,13 +39,22 @@ public class UpdateReleaseIdCommand
     @XmlElement
     private ReleaseId releaseId;
 
+    @XStreamAlias("reset-before-update")
+    @XmlElement
+    private boolean resetBeforeUpdate;
+
     public UpdateReleaseIdCommand() {
         super();
     }
 
     public UpdateReleaseIdCommand(String containerId, ReleaseId releaseId) {
+        this(containerId, releaseId, false);
+    }
+
+    public UpdateReleaseIdCommand(String containerId, ReleaseId releaseId, boolean resetBeforeUpdate) {
         this.containerId = containerId;
         this.releaseId = releaseId;
+        this.resetBeforeUpdate = resetBeforeUpdate;
     }
 
     public String getContainerId() {
@@ -63,24 +73,31 @@ public class UpdateReleaseIdCommand
         this.releaseId = releaseId;
     }
 
+    public boolean isResetBeforeUpdate() {
+        return resetBeforeUpdate;
+    }
+
+    public void setResetBeforeUpdate(boolean resetBeforeUpdate) {
+        this.resetBeforeUpdate = resetBeforeUpdate;
+    }
+
     @Override
     public boolean equals(Object o) {
-        if ( this == o ) return true;
-        if ( !(o instanceof UpdateReleaseIdCommand) ) return false;
-
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         UpdateReleaseIdCommand that = (UpdateReleaseIdCommand) o;
-
-        if ( containerId != null ? !containerId.equals( that.containerId ) : that.containerId != null ) return false;
-        if ( releaseId != null ? !releaseId.equals( that.releaseId ) : that.releaseId != null ) return false;
-
-        return true;
+        return resetBeforeUpdate == that.resetBeforeUpdate &&
+                Objects.equals(containerId, that.containerId) &&
+                Objects.equals(releaseId, that.releaseId);
     }
 
     @Override
     public int hashCode() {
-        int result = containerId != null ? containerId.hashCode() : 0;
-        result = 31 * result + (releaseId != null ? releaseId.hashCode() : 0);
-        return result;
+        return Objects.hash(containerId, releaseId, resetBeforeUpdate);
     }
 
     @Override
@@ -88,6 +105,7 @@ public class UpdateReleaseIdCommand
         return "UpdateReleaseIdCommand{" +
                "containerId='" + containerId + '\'' +
                ", releaseId=" + releaseId +
+                ", resetBeforeUpdate=" + resetBeforeUpdate +
                '}';
     }
 }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/UpdateReleaseIdCommand.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/commands/UpdateReleaseIdCommand.java
@@ -29,7 +29,7 @@ import javax.xml.bind.annotation.*;
 public class UpdateReleaseIdCommand
         implements KieServerCommand {
 
-    private static final long serialVersionUID = -1803374525440238478L;
+    private static final long serialVersionUID = 1048407484222065032L;
 
     @XStreamAlias("container-id")
     @XmlAttribute(name = "container-id")

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/KieServerInfo.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/KieServerInfo.java
@@ -1,17 +1,18 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.kie.server.api.model;
 
@@ -34,6 +35,8 @@ public class KieServerInfo {
     private List<String> capabilities;
 
     private List<Message> messages;
+
+    private KieServerMode mode = KieServerMode.REGULAR;
     
     public KieServerInfo() {
         super();
@@ -46,12 +49,17 @@ public class KieServerInfo {
     }
 
     public KieServerInfo(String serverId, String name, String version, List<String> capabilities, String location) {
+        this(serverId, name, version, capabilities, location, KieServerMode.REGULAR);
+    }
+
+    public KieServerInfo(String serverId, String name, String version, List<String> capabilities, String location, KieServerMode mode) {
         super();
         this.serverId = serverId;
         this.name = name;
         this.version = version;
         this.capabilities = capabilities;
         this.location = location;
+        this.mode = mode;
     }
 
     @XmlElement(name="version")
@@ -108,6 +116,15 @@ public class KieServerInfo {
         this.messages = messages;
     }
 
+    @XmlElement(name="mode")
+    public KieServerMode getMode() {
+        return mode;
+    }
+
+    public void setMode(KieServerMode mode) {
+        this.mode = mode;
+    }
+
     @Override
     public String toString() {
         return "KieServerInfo{" +
@@ -115,8 +132,9 @@ public class KieServerInfo {
                 ", version='" + version + '\'' +
                 ", name='" + name + '\'' +
                 ", location='" + location + '\'' +
-                ", capabilities=" + capabilities +
-                ", messages=" + messages +
+                ", capabilities=" + capabilities + '\'' +
+                ", messages=" + messages + '\'' +
+                ", mode=" + mode +
                 '}';
     }
 }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/KieServerMode.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/KieServerMode.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.api.model;
+
+public enum KieServerMode {
+    REGULAR, DEVELOPMENT
+}

--- a/kie-server-parent/kie-server-api/src/main/resources/org/kie/server/api/KieServerAPI.gwt.xml
+++ b/kie-server-parent/kie-server-api/src/main/resources/org/kie/server/api/KieServerAPI.gwt.xml
@@ -17,6 +17,7 @@
     <include name="KieServerConfigItem.java"/>
     <include name="KieContainerResourceList.java"/>
     <include name="KieServerInfo.java"/>
+    <include name="KieServerMode.java"/>
   </source>
 
   <source path="exception">

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/build/revapi-config.json
@@ -17,7 +17,17 @@
   "ignores": {
     "revapi": {
       "_comment": "Changes between 7.14.0.Final and the current branch. These changes are desired and thus ignored.",
-      "ignore": []
+      "ignore": [
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method void org.kie.server.controller.api.service.SpecManagementService::updateContainerSpec(java.lang.String, java.lang.String, org.kie.server.controller.api.model.spec.ContainerSpec, java.lang.Boolean)",
+          "package": "org.kie.server.controller.api.service",
+          "classSimpleName": "SpecManagementService",
+          "methodName": "updateContainerSpec",
+          "elementKind": "method",
+          "justification": "AF-1685: Development Lifecycle Streamline"
+        }
+      ]
     }
   }
 }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/events/ServerTemplateUpdated.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/events/ServerTemplateUpdated.java
@@ -15,17 +15,25 @@
 
 package org.kie.server.controller.api.model.events;
 
+import java.util.Objects;
+
 import org.kie.server.controller.api.model.spec.ServerTemplate;
 
 public class ServerTemplateUpdated implements KieServerControllerEvent {
 
     private ServerTemplate serverTemplate;
+    private boolean resetBeforeUpdate;
 
     public ServerTemplateUpdated() {
     }
 
     public ServerTemplateUpdated(ServerTemplate serverTemplate) {
+        this(serverTemplate, false);
+    }
+
+    public ServerTemplateUpdated(ServerTemplate serverTemplate, boolean resetBeforeUpdate) {
         this.serverTemplate = serverTemplate;
+        this.resetBeforeUpdate = resetBeforeUpdate;
     }
 
     public ServerTemplate getServerTemplate() {
@@ -36,10 +44,19 @@ public class ServerTemplateUpdated implements KieServerControllerEvent {
         this.serverTemplate = serverInstance;
     }
 
+    public boolean isResetBeforeUpdate() {
+        return resetBeforeUpdate;
+    }
+
+    public void setResetBeforeUpdate(boolean resetBeforeUpdate) {
+        this.resetBeforeUpdate = resetBeforeUpdate;
+    }
+
     @Override
     public String toString() {
         return "Updated server template{" +
-                 serverTemplate +
+                "serverTemplate=" + serverTemplate +
+                ", resetBeforeUpdate=" + resetBeforeUpdate +
                 '}';
     }
 
@@ -51,18 +68,13 @@ public class ServerTemplateUpdated implements KieServerControllerEvent {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         ServerTemplateUpdated that = (ServerTemplateUpdated) o;
 
-        if (serverTemplate != null ? !serverTemplate.equals(that.serverTemplate) : that.serverTemplate != null) {
-            return false;
-        }
-
-        return true;
+        return resetBeforeUpdate == that.resetBeforeUpdate && Objects.equals(serverTemplate, that.serverTemplate);
     }
 
     @Override
     public int hashCode() {
-        return serverTemplate != null ? serverTemplate.hashCode() : 0;
+        return Objects.hash(serverTemplate, resetBeforeUpdate);
     }
 }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/spec/ServerTemplate.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/spec/ServerTemplate.java
@@ -1,17 +1,18 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.kie.server.controller.api.model.spec;
 
@@ -26,6 +27,7 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
+import org.kie.server.api.model.KieServerMode;
 import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
 
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -40,6 +42,8 @@ public class ServerTemplate extends ServerTemplateKey {
     private Collection<ServerInstanceKey> serverInstances = new ArrayList<ServerInstanceKey>();
     @XmlElement(name="capabilities")
     private List<String> capabilities = new ArrayList<String>();
+    @XmlElement(name="mode")
+    private KieServerMode mode;
 
     public ServerTemplate() {
     }
@@ -196,6 +200,14 @@ public class ServerTemplate extends ServerTemplateKey {
 
     public void setCapabilities(List<String> capabilities) {
         this.capabilities = capabilities;
+    }
+
+    public KieServerMode getMode() {
+        return mode;
+    }
+
+    public void setMode(KieServerMode mode) {
+        this.mode = mode;
     }
 
     public boolean hasMatchingId(ServerTemplateKey serverTemplateKey) {

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/service/SpecManagementService.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/service/SpecManagementService.java
@@ -1,17 +1,18 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.kie.server.controller.api.service;
 
@@ -25,6 +26,8 @@ public interface SpecManagementService {
     void updateContainerSpec(String serverTemplateId, ContainerSpec containerSpec);
 
     void updateContainerSpec(String serverTemplateId, String containerId, ContainerSpec containerSpec);
+
+    void updateContainerSpec(String serverTemplateId, String containerId, ContainerSpec containerSpec, Boolean resetBeforeUpdate);
 
     void saveServerTemplate(ServerTemplate serverTemplate);
 

--- a/kie-server-parent/kie-server-controller/kie-server-controller-client/src/main/java/org/kie/server/controller/client/rest/RestKieServerControllerClient.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-client/src/main/java/org/kie/server/controller/client/rest/RestKieServerControllerClient.java
@@ -314,9 +314,7 @@ public class RestKieServerControllerClient implements KieServerControllerClient 
     private <T> T makePostRequestAndCreateCustomResponse(String uri, Object bodyObject, Class<T> resultType, Map<String, Object> params) {
         WebTarget clientRequest = httpClient.target(uri);
 
-        for(Iterator<Map.Entry<String, Object>> it = params.entrySet().iterator(); it.hasNext(); ){
-            Map.Entry<String, Object> entry = it.next();
-
+        for (Map.Entry<String, Object> entry : params.entrySet()) {
             clientRequest = clientRequest.queryParam(entry.getKey(), entry.getValue());
         }
 

--- a/kie-server-parent/kie-server-controller/kie-server-controller-client/src/main/java/org/kie/server/controller/client/rest/RestKieServerControllerClient.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-client/src/main/java/org/kie/server/controller/client/rest/RestKieServerControllerClient.java
@@ -16,7 +16,6 @@
 
 package org.kie.server.controller.client.rest;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -29,7 +28,6 @@ import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Configuration;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriBuilder;
 
 import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.marshalling.Marshaller;

--- a/kie-server-parent/kie-server-controller/kie-server-controller-client/src/main/java/org/kie/server/controller/client/websocket/WebSocketKieServerControllerClient.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-client/src/main/java/org/kie/server/controller/client/websocket/WebSocketKieServerControllerClient.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -163,11 +163,23 @@ public class WebSocketKieServerControllerClient implements KieServerControllerCl
     public void updateContainerSpec(final String serverTemplateId,
                                     final String containerId,
                                     final ContainerSpec containerSpec) {
+        updateContainerSpec(serverTemplateId,
+                            containerId,
+                            containerSpec,
+                            false);
+    }
+
+    @Override
+    public void updateContainerSpec(final String serverTemplateId,
+                                    final String containerId,
+                                    final ContainerSpec containerSpec,
+                                    final Boolean resetBeforeUpdate) {
         sendCommand(SpecManagementService.class.getName(),
                     "updateContainerSpec",
                     serverTemplateId,
                     containerId,
-                    containerSpec);
+                    containerSpec,
+                    resetBeforeUpdate);
     }
 
     @Override

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerControllerImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerControllerImpl.java
@@ -181,6 +181,8 @@ public abstract class KieServerControllerImpl implements KieServerController {
             }
             serverTemplate.setCapabilities(capabilities);
 
+            serverTemplate.setMode(serverInfo.getMode());
+
             // add newly connected server instance
             serverTemplate.addServerInstance(serverInstanceKey);
 

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/SpecManagementServiceImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/SpecManagementServiceImpl.java
@@ -1,17 +1,18 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.kie.server.controller.impl.service;
 
@@ -82,6 +83,11 @@ public class SpecManagementServiceImpl implements SpecManagementService {
 
     @Override
     public synchronized void updateContainerSpec(final String serverTemplateId, final String containerId, final ContainerSpec containerSpec) {
+        updateContainerSpec(serverTemplateId, containerId, containerSpec, false);
+    }
+
+    @Override
+    public synchronized void updateContainerSpec(String serverTemplateId, String containerId, ContainerSpec containerSpec, Boolean resetBeforeUpdate) {
         ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
 
         if (serverTemplate == null) {
@@ -110,10 +116,10 @@ public class SpecManagementServiceImpl implements SpecManagementService {
 
         templateStorage.update(serverTemplate);
 
-        notificationService.notify(new ServerTemplateUpdated(serverTemplate));
+        notificationService.notify(new ServerTemplateUpdated(serverTemplate, resetBeforeUpdate));
         // in case container was started before it was update or update comes with status started update container in running servers
         if (currentVersion.getStatus().equals(KieContainerStatus.STARTED) || containerSpec.getStatus().equals(KieContainerStatus.STARTED)) {
-            List<Container> containers = kieServerInstanceManager.upgradeAndStartContainer(serverTemplate, containerSpec);
+            List<Container> containers = kieServerInstanceManager.upgradeAndStartContainer(serverTemplate, containerSpec, resetBeforeUpdate);
             notificationService.notify(serverTemplate, containerSpec, containers);
         }
     }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/KieServerInstanceManagerTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/KieServerInstanceManagerTest.java
@@ -48,6 +48,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doNothing;
@@ -246,14 +248,14 @@ public class KieServerInstanceManagerTest {
         doReturn(containerId).when(containerSpec).getId();
         doReturn(releaseId).when(containerSpec).getReleasedId();
         doReturn(containerResource).when(instanceManager).makeContainerResource(container, containerSpec);
-        doReturn(response).when(client).updateReleaseId(containerId, releaseId);
+        doReturn(response).when(client).updateReleaseId(containerId, releaseId, false);
         doReturn(responseType).when(response).getType();
         doNothing().when(instanceManager).collectContainerInfo(containerSpec, client, container);
 
-        instanceManager.makeUpgradeContainerOperation(containerSpec).doOperation(client, container);
+        instanceManager.makeUpgradeContainerOperation(containerSpec, false).doOperation(client, container);
 
         verify(client, never()).createContainer(anyString(), any(KieContainerResource.class));
-        verify(client).updateReleaseId(containerId, releaseId);
+        verify(client).updateReleaseId(containerId, releaseId, false);
         verify(instanceManager).collectContainerInfo(containerSpec, client, container);
         verify(instanceManager, never()).log(any(), any(), any(), any());
     }
@@ -270,16 +272,16 @@ public class KieServerInstanceManagerTest {
         doReturn(containerId).when(containerSpec).getId();
         doReturn(releaseId).when(containerSpec).getReleasedId();
         doReturn(containerResource).when(instanceManager).makeContainerResource(container, containerSpec);
-        doReturn(response).when(client).updateReleaseId(containerId, releaseId);
+        doReturn(response).when(client).updateReleaseId(containerId, releaseId, false);
         doReturn(responseType).when(response).getType();
         doReturn(msg).when(response).getMsg();
         doReturn(url).when(container).getUrl();
         doNothing().when(instanceManager).collectContainerInfo(containerSpec, client, container);
 
-        instanceManager.makeUpgradeContainerOperation(containerSpec).doOperation(client, container);
+        instanceManager.makeUpgradeContainerOperation(containerSpec, false).doOperation(client, container);
 
         verify(client, never()).createContainer(anyString(), any(KieContainerResource.class));
-        verify(client).updateReleaseId(containerId, releaseId);
+        verify(client).updateReleaseId(containerId, releaseId, false);
         verify(instanceManager).collectContainerInfo(containerSpec, client, container);
         verify(instanceManager).log("Container {} failed to upgrade on server instance {} due to {}", containerId, url, msg);
     }
@@ -294,14 +296,14 @@ public class KieServerInstanceManagerTest {
         doReturn(containerId).when(containerSpec).getId();
         doReturn(releaseId).when(containerSpec).getReleasedId();
         doReturn(containerResource).when(instanceManager).makeContainerResource(container, containerSpec);
-        doReturn(response).when(client).updateReleaseId(containerId, releaseId);
+        doReturn(response).when(client).updateReleaseId(containerId, releaseId, false);
         doReturn(responseType).when(response).getType();
         doNothing().when(instanceManager).collectContainerInfo(containerSpec, client, container);
 
-        instanceManager.makeUpgradeAndStartContainerOperation(containerSpec).doOperation(client, container);
+        instanceManager.makeUpgradeAndStartContainerOperation(containerSpec, false).doOperation(client, container);
 
         verify(client).createContainer(containerId, containerResource);
-        verify(client).updateReleaseId(containerId, releaseId);
+        verify(client).updateReleaseId(containerId, releaseId, false);
         verify(instanceManager).collectContainerInfo(containerSpec, client, container);
         verify(instanceManager, never()).log(any(), any(), any(), any());
     }
@@ -318,16 +320,16 @@ public class KieServerInstanceManagerTest {
         doReturn(containerId).when(containerSpec).getId();
         doReturn(releaseId).when(containerSpec).getReleasedId();
         doReturn(containerResource).when(instanceManager).makeContainerResource(container, containerSpec);
-        doReturn(response).when(client).updateReleaseId(containerId, releaseId);
+        doReturn(response).when(client).updateReleaseId(containerId, releaseId, false);
         doReturn(responseType).when(response).getType();
         doReturn(msg).when(response).getMsg();
         doReturn(url).when(container).getUrl();
         doNothing().when(instanceManager).collectContainerInfo(containerSpec, client, container);
 
-        instanceManager.makeUpgradeAndStartContainerOperation(containerSpec).doOperation(client, container);
+        instanceManager.makeUpgradeAndStartContainerOperation(containerSpec, false).doOperation(client, container);
 
         verify(client).createContainer(containerId, containerResource);
-        verify(client).updateReleaseId(containerId, releaseId);
+        verify(client).updateReleaseId(containerId, releaseId, false);
         verify(instanceManager).collectContainerInfo(containerSpec, client, container);
         verify(instanceManager).log("Container {} failed to upgrade on server instance {} due to {}", containerId, url, msg);
     }
@@ -465,7 +467,7 @@ public class KieServerInstanceManagerTest {
     @Test
     public void testUpgradeContainer() {
 
-        doReturn(operation).when(instanceManager).makeUpgradeContainerOperation(containerSpec);
+        doReturn(operation).when(instanceManager).makeUpgradeContainerOperation(containerSpec, false);
 
         instanceManager.upgradeContainer(serverTemplate, containerSpec);
 
@@ -475,7 +477,7 @@ public class KieServerInstanceManagerTest {
     @Test
     public void testUpgradeAndStartContainer() {
 
-        doReturn(operation).when(instanceManager).makeUpgradeAndStartContainerOperation(containerSpec);
+        doReturn(operation).when(instanceManager).makeUpgradeAndStartContainerOperation(containerSpec, false);
 
         instanceManager.upgradeAndStartContainer(serverTemplate, containerSpec);
 

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/SpecManagementServiceImplTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/SpecManagementServiceImplTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import com.sun.org.apache.xpath.internal.Arg;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/SpecManagementServiceImplTest.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/test/java/org/kie/server/controller/impl/service/SpecManagementServiceImplTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import com.sun.org.apache.xpath.internal.Arg;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -39,6 +40,7 @@ import org.kie.server.controller.api.service.NotificationService;
 import org.kie.server.controller.api.storage.KieServerTemplateStorage;
 import org.kie.server.controller.impl.KieServerInstanceManager;
 import org.kie.server.controller.impl.storage.InMemoryKieServerTemplateStorage;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -673,6 +675,73 @@ public class SpecManagementServiceImplTest extends AbstractServiceImplTest {
 
         assertEquals(expectedContainers, actualContainers);
     }
+
+    @Test
+    public void testUpdateAndStartContainerSpecDefault() {
+        testUpdateAndStartContainerSpec(false, true);
+    }
+
+    @Test
+    public void testUpdateContainerSpecDefault() {
+        testUpdateAndStartContainerSpec(false, false);
+    }
+
+    @Test
+    public void testUpdateAndStartContainerSpecResetBeforeUpdate() {
+        testUpdateAndStartContainerSpec(true, true);
+    }
+
+    @Test
+    public void testUpdateContainerSpecResetBeforeUpdate() {
+        testUpdateAndStartContainerSpec(true, false);
+    }
+
+    private void testUpdateAndStartContainerSpec(boolean resetBeforeUpdate, boolean started) {
+        final String serverTemplateId = "serverTemplateId";
+        final String serverTemplateName = "serverTemplateName";
+        final String containerSpecId = "containerSpecId";
+
+        ServerTemplate template = new ServerTemplate(serverTemplateId, serverTemplateName);
+
+        ContainerSpec containerSpec = new ContainerSpec();
+        containerSpec.setId(containerSpecId);
+        containerSpec.setServerTemplateKey(new ServerTemplateKey(template.getId(), template.getName()));
+        containerSpec.setReleasedId(new ReleaseId("org.kie", "kie-server-kjar", "1.0"));
+        containerSpec.setStatus(started ? KieContainerStatus.STARTED : KieContainerStatus.STOPPED);
+
+        template.addContainerSpec(containerSpec);
+
+        when(templateStorage.load(eq(serverTemplateId))).thenReturn(template);
+
+        final SpecManagementServiceImpl specManagementService = (SpecManagementServiceImpl) this.specManagementService;
+
+        specManagementService.setTemplateStorage(templateStorage);
+        specManagementService.setNotificationService(notificationService);
+
+        specManagementService.updateContainerSpec(serverTemplateId, containerSpecId, containerSpec, resetBeforeUpdate);
+
+        verify(templateStorage).update(eq(template));
+
+        ArgumentCaptor<ServerTemplateUpdated> captor = ArgumentCaptor.forClass(ServerTemplateUpdated.class);
+
+        verify(notificationService).notify(captor.capture());
+
+        ServerTemplateUpdated serverTemplateUpdated = captor.getValue();
+
+        assertNotNull(serverTemplateUpdated);
+        assertEquals(template, serverTemplateUpdated.getServerTemplate());
+
+        if(!resetBeforeUpdate) {
+            assertFalse(serverTemplateUpdated.isResetBeforeUpdate());
+        } else {
+            assertTrue(serverTemplateUpdated.isResetBeforeUpdate());
+        }
+
+        verify(kieServerInstanceManager, started ? times(1) : never()).upgradeAndStartContainer(eq(template), eq(containerSpec), eq(resetBeforeUpdate));
+        verify(notificationService, started ? times(1) : never()).notify(eq(template), eq(containerSpec), anyList());
+    }
+
+
 
     @Test
     public void testUpdateContainerRuleConfigWhenKieScannerStatusIsStarted() {

--- a/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/build/revapi-config.json
@@ -2356,6 +2356,47 @@
           "elementKind": "method",
           "justification": "JBPM-7934 - Update Controller REST API endpoint data to Swagger"
         },
+        {
+          "code": "java.annotation.attributeValueChanged",
+          "old": "parameter javax.ws.rs.core.Response org.kie.server.controller.rest.RestSpecManagementServiceImpl::updateContainerSpec(javax.ws.rs.core.HttpHeaders, ===java.lang.String===, java.lang.String, java.lang.String)",
+          "new": "parameter javax.ws.rs.core.Response org.kie.server.controller.rest.RestSpecManagementServiceImpl::updateContainerSpec(javax.ws.rs.core.HttpHeaders, ===java.lang.String===, java.lang.String, java.lang.String, boolean)",
+          "annotationType": "javax.ws.rs.PathParam",
+          "annotation": "@javax.ws.rs.PathParam(\"serverTemplateId\")",
+          "attribute": "value",
+          "oldValue": "\"id\"",
+          "newValue": "\"serverTemplateId\"",
+          "package": "org.kie.server.controller.rest",
+          "classSimpleName": "RestSpecManagementServiceImpl",
+          "methodName": "updateContainerSpec",
+          "parameterIndex": "1",
+          "elementKind": "parameter",
+          "justification": "AF-1685: Development Lifecycle Streamline"
+        },
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method javax.ws.rs.core.Response org.kie.server.controller.rest.RestSpecManagementServiceImpl::updateContainerSpec(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String, java.lang.String)",
+          "new": "method javax.ws.rs.core.Response org.kie.server.controller.rest.RestSpecManagementServiceImpl::updateContainerSpec(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String, java.lang.String, boolean)",
+          "package": "org.kie.server.controller.rest",
+          "classSimpleName": "RestSpecManagementServiceImpl",
+          "methodName": "updateContainerSpec",
+          "elementKind": "method",
+          "justification": "AF-1685: Development Lifecycle Streamline"
+        },
+        {
+          "code": "java.annotation.attributeValueChanged",
+          "old": "method javax.ws.rs.core.Response org.kie.server.controller.rest.RestSpecManagementServiceImpl::updateContainerSpec(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String, java.lang.String)",
+          "new": "method javax.ws.rs.core.Response org.kie.server.controller.rest.RestSpecManagementServiceImpl::updateContainerSpec(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String, java.lang.String, boolean)",
+          "annotationType": "javax.ws.rs.Path",
+          "annotation": "@javax.ws.rs.Path(\"servers\/{serverTemplateId}\/containers\/{containerId}\")",
+          "attribute": "value",
+          "oldValue": "\"servers\/{id}\/containers\/{containerId}\"",
+          "newValue": "\"servers\/{serverTemplateId}\/containers\/{containerId}\"",
+          "package": "org.kie.server.controller.rest",
+          "classSimpleName": "RestSpecManagementServiceImpl",
+          "methodName": "updateContainerSpec",
+          "elementKind": "method",
+          "justification": "AF-1685: Development Lifecycle Streamline"
+        }
       ]
     }
   }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/main/java/org/kie/server/controller/rest/RestSpecManagementServiceImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/main/java/org/kie/server/controller/rest/RestSpecManagementServiceImpl.java
@@ -100,7 +100,8 @@ public class RestSpecManagementServiceImpl {
                                         @Example(value = {
                                                 @ExampleProperty(mediaType = JSON, value = CONTAINER_SPEC_JSON),
                                                 @ExampleProperty(mediaType = XML, value = CONTAINER_SPEC_XML)
-                                        })) String containerSpecPayload) {
+                                        })) String containerSpecPayload,
+                                        @ApiParam(value = "Optional param to reset current environment before updating on dev mode, defaults to false") @QueryParam("resetBeforeUpdate")  @DefaultValue("false") boolean resetBeforeUpdate) {
 
         String contentType = getContentType(headers);
         try {
@@ -108,7 +109,7 @@ public class RestSpecManagementServiceImpl {
             ContainerSpec containerSpec = unmarshal(containerSpecPayload, contentType, ContainerSpec.class);
             logger.debug("Container spec is {}", containerSpec);
 
-            specManagementService.updateContainerSpec(serverTemplateId, containerId, containerSpec);
+            specManagementService.updateContainerSpec(serverTemplateId, containerId, containerSpec, resetBeforeUpdate);
             logger.debug("Returning response for update container spec request for server template with id '{}': CREATED", serverTemplateId);
             return createCorrectVariant("", headers, Response.Status.CREATED);
         } catch (KieServerControllerIllegalArgumentException e) {

--- a/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/main/java/org/kie/server/controller/rest/RestSpecManagementServiceImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/main/java/org/kie/server/controller/rest/RestSpecManagementServiceImpl.java
@@ -101,7 +101,7 @@ public class RestSpecManagementServiceImpl {
                                                 @ExampleProperty(mediaType = JSON, value = CONTAINER_SPEC_JSON),
                                                 @ExampleProperty(mediaType = XML, value = CONTAINER_SPEC_XML)
                                         })) String containerSpecPayload,
-                                        @ApiParam(value = "Optional param to reset current environment before updating on dev mode, defaults to false") @QueryParam("resetBeforeUpdate")  @DefaultValue("false") boolean resetBeforeUpdate) {
+                                        @ApiParam(value = "Allows to reset the current environment aborting active process instances before updating when the server runs on development mode. Optional, defaults to false") @QueryParam("resetBeforeUpdate")  @DefaultValue("false") boolean resetBeforeUpdate) {
 
         String contentType = getContentType(headers);
         try {

--- a/kie-server-parent/kie-server-controller/kie-server-controller-websocket/src/main/java/org/kie/server/controller/websocket/client/WebSocketKieServerClient.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-websocket/src/main/java/org/kie/server/controller/websocket/client/WebSocketKieServerClient.java
@@ -508,13 +508,18 @@ public class WebSocketKieServerClient implements KieServicesClient {
 
     @Override
     public ServiceResponse<ReleaseId> updateReleaseId(String id, ReleaseId releaseId) {
-        CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new UpdateReleaseIdCommand(id, releaseId)));
+        return updateReleaseId(id, releaseId, false);
+    }
+
+    @Override
+    public ServiceResponse<ReleaseId> updateReleaseId(String id, ReleaseId releaseId, boolean resetBeforeUpdate) {
+        CommandScript script = new CommandScript(Collections.singletonList(new UpdateReleaseIdCommand(id, releaseId, resetBeforeUpdate)));
         ServiceResponse<ReleaseId> response = (ServiceResponse<ReleaseId>) sendCommandToAllSessions(script, new WebSocketServiceResponse(true, (message) -> {
             ServiceResponsesList list = WebSocketUtils.unmarshal(message, ServiceResponsesList.class);
             return list.getResponses().get(0);
         })).getResponses().get(0);
-        
-        return response; 
+
+        return response;
     }
 
     @Override

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/build/revapi-config.json
@@ -50,6 +50,15 @@
           "methodName": "close",
           "elementKind": "method",
           "justification": "Added close method of kie services client to allow to release resources"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method org.kie.server.api.model.ServiceResponse<org.kie.server.api.model.ReleaseId> org.kie.server.client.KieServicesClient::updateReleaseId(java.lang.String, org.kie.server.api.model.ReleaseId, boolean)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "KieServicesClient",
+          "methodName": "updateReleaseId",
+          "elementKind": "method",
+          "justification": "AF-1685: Development Lifecycle Streamline"
         }
       ]
     }

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesClient.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesClient.java
@@ -58,6 +58,8 @@ public interface KieServicesClient {
 
     ServiceResponse<ReleaseId> updateReleaseId(String id, ReleaseId releaseId);
 
+    ServiceResponse<ReleaseId> updateReleaseId(String id, ReleaseId releaseId, boolean resetBeforeUpdate);
+
     ServiceResponse<KieServerStateInfo> getServerState();
     
     void close();

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
@@ -252,29 +252,43 @@ public abstract class AbstractKieServicesClientImpl {
         }
     }
 
-    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(
-            String uri, Object bodyObject,
-            Class<T> resultType) {
-        return makeHttpPostRequestAndCreateServiceResponse( uri, serialize( bodyObject ), resultType );
+    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(String uri,
+                                                                                 Object bodyObject,
+                                                                                 Class<T> resultType) {
+        return makeHttpPostRequestAndCreateServiceResponseWithParams(uri, bodyObject, resultType, new HashMap<>());
     }
 
-    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(
-            String uri, Object bodyObject,
-            Class<T> resultType, Map<String, String> headers) {
-        return makeHttpPostRequestAndCreateServiceResponse( uri, serialize( bodyObject ), resultType, headers );
+    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponseWithParams(String uri,
+                                                                                           Object bodyObject,
+                                                                                           Class<T> resultType,
+                                                                                           Map<String, Object> params) {
+        return makeHttpPostRequestAndCreateServiceResponse(uri, serialize( bodyObject ), resultType, new HashMap<>(), params);
     }
 
-    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(String uri, String body, Class<T> resultType) {
-        return  makeHttpPostRequestAndCreateServiceResponse( uri, body, resultType, new HashMap<String, String>() );
+    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(String uri,
+                                                                                 Object bodyObject,
+                                                                                 Class<T> resultType,
+                                                                                 Map<String, String> headers) {
+        return makeHttpPostRequestAndCreateServiceResponse(uri, serialize( bodyObject ), resultType, headers, new HashMap<>());
+    }
+
+    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(String uri,
+                                                                                 String body,
+                                                                                 Class<T> resultType) {
+        return  makeHttpPostRequestAndCreateServiceResponse(uri, body, resultType, new HashMap<>());
     }
 
     @SuppressWarnings("unchecked")
-    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(String uri, String body, Class<T> resultType, Map<String, String> headers) {
+    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(String uri,
+                                                                                 String body,
+                                                                                 Class<T> resultType,
+                                                                                 Map<String, String> headers,
+                                                                                 Map<String, Object> params) {
         logger.debug("About to send POST request to '{}' with payload '{}'", uri, body);
         KieServerHttpRequest request = invoke(uri, new RemoteHttpOperation(){
             @Override
             public KieServerHttpRequest doOperation(String url) {
-                return newRequest( uri ).headers(headers).body(body).post();
+                return newRequest(uri).query(params).headers(headers).body(body).post();
             }
         });
 

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
@@ -252,43 +252,29 @@ public abstract class AbstractKieServicesClientImpl {
         }
     }
 
-    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(String uri,
-                                                                                 Object bodyObject,
-                                                                                 Class<T> resultType) {
-        return makeHttpPostRequestAndCreateServiceResponseWithParams(uri, bodyObject, resultType, new HashMap<>());
+    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(
+            String uri, Object bodyObject,
+            Class<T> resultType) {
+        return makeHttpPostRequestAndCreateServiceResponse( uri, serialize( bodyObject ), resultType );
     }
 
-    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponseWithParams(String uri,
-                                                                                           Object bodyObject,
-                                                                                           Class<T> resultType,
-                                                                                           Map<String, Object> params) {
-        return makeHttpPostRequestAndCreateServiceResponse(uri, serialize( bodyObject ), resultType, new HashMap<>(), params);
+    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(
+            String uri, Object bodyObject,
+            Class<T> resultType, Map<String, String> headers) {
+        return makeHttpPostRequestAndCreateServiceResponse( uri, serialize( bodyObject ), resultType, headers );
     }
 
-    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(String uri,
-                                                                                 Object bodyObject,
-                                                                                 Class<T> resultType,
-                                                                                 Map<String, String> headers) {
-        return makeHttpPostRequestAndCreateServiceResponse(uri, serialize( bodyObject ), resultType, headers, new HashMap<>());
-    }
-
-    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(String uri,
-                                                                                 String body,
-                                                                                 Class<T> resultType) {
-        return  makeHttpPostRequestAndCreateServiceResponse(uri, body, resultType, new HashMap<>());
+    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(String uri, String body, Class<T> resultType) {
+        return  makeHttpPostRequestAndCreateServiceResponse( uri, body, resultType, new HashMap<String, String>() );
     }
 
     @SuppressWarnings("unchecked")
-    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(String uri,
-                                                                                 String body,
-                                                                                 Class<T> resultType,
-                                                                                 Map<String, String> headers,
-                                                                                 Map<String, Object> params) {
+    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(String uri, String body, Class<T> resultType, Map<String, String> headers) {
         logger.debug("About to send POST request to '{}' with payload '{}'", uri, body);
         KieServerHttpRequest request = invoke(uri, new RemoteHttpOperation(){
             @Override
             public KieServerHttpRequest doOperation(String url) {
-                return newRequest(uri).query(params).headers(headers).body(body).post();
+                return newRequest( uri ).headers(headers).body(body).post();
             }
         });
 

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesClientImpl.java
@@ -291,12 +291,17 @@ public class KieServicesClientImpl extends AbstractKieServicesClientImpl impleme
 
     @Override
     public ServiceResponse<ReleaseId> updateReleaseId(String id, ReleaseId releaseId) {
+        return updateReleaseId(id, releaseId, false);
+    }
+
+    @Override
+    public ServiceResponse<ReleaseId> updateReleaseId(String id, ReleaseId releaseId, boolean resetBeforeUpdate) {
         if (config.isRest()) {
             return makeHttpPostRequestAndCreateServiceResponse(
-                    loadBalancer.getUrl() + "/containers/" + id + "/release-id", releaseId,
+                    loadBalancer.getUrl() + "/containers/" + id + "/release-id?resetBeforeUpdate=" + resetBeforeUpdate, releaseId,
                     ReleaseId.class );
         } else {
-            CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new UpdateReleaseIdCommand(id, releaseId)));
+            CommandScript script = new CommandScript(Collections.singletonList(new UpdateReleaseIdCommand(id, releaseId, resetBeforeUpdate)));
             ServiceResponse<ReleaseId> response = (ServiceResponse<ReleaseId>) executeJmsCommand(script, null, null, id).getResponses().get(0);
             return getResponseOrNullIfNoResponse(response);
         }

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesClientImpl.java
@@ -298,10 +298,7 @@ public class KieServicesClientImpl extends AbstractKieServicesClientImpl impleme
     @Override
     public ServiceResponse<ReleaseId> updateReleaseId(String id, ReleaseId releaseId, boolean resetBeforeUpdate) {
         if (config.isRest()) {
-            Map<String, Object> params = new HashMap<>();
-            params.put(KieServerConstants.RESET_CONTAINER_BEFORE_UPDATE, resetBeforeUpdate);
-            return makeHttpPostRequestAndCreateServiceResponseWithParams(
-                    loadBalancer.getUrl() + "/containers/" + id + "/release-id", releaseId, ReleaseId.class, params);
+            return makeHttpPostRequestAndCreateServiceResponse(loadBalancer.getUrl() + "/containers/" + id + "/release-id?" + KieServerConstants.RESET_CONTAINER_BEFORE_UPDATE + "=" + resetBeforeUpdate, releaseId, ReleaseId.class);
         } else {
             CommandScript script = new CommandScript(Collections.singletonList(new UpdateReleaseIdCommand(id, releaseId, resetBeforeUpdate)));
             ServiceResponse<ReleaseId> response = (ServiceResponse<ReleaseId>) executeJmsCommand(script, null, null, id).getResponses().get(0);

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/KieServicesClientImpl.java
@@ -16,6 +16,7 @@
 package org.kie.server.client.impl;
 
 import org.kie.api.command.Command;
+import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.commands.GetReleaseIdCommand;
 import org.kie.server.api.model.KieContainerResourceFilter;
 import org.kie.server.api.commands.ActivateContainerCommand;
@@ -297,9 +298,10 @@ public class KieServicesClientImpl extends AbstractKieServicesClientImpl impleme
     @Override
     public ServiceResponse<ReleaseId> updateReleaseId(String id, ReleaseId releaseId, boolean resetBeforeUpdate) {
         if (config.isRest()) {
-            return makeHttpPostRequestAndCreateServiceResponse(
-                    loadBalancer.getUrl() + "/containers/" + id + "/release-id?resetBeforeUpdate=" + resetBeforeUpdate, releaseId,
-                    ReleaseId.class );
+            Map<String, Object> params = new HashMap<>();
+            params.put(KieServerConstants.RESET_CONTAINER_BEFORE_UPDATE, resetBeforeUpdate);
+            return makeHttpPostRequestAndCreateServiceResponseWithParams(
+                    loadBalancer.getUrl() + "/containers/" + id + "/release-id", releaseId, ReleaseId.class, params);
         } else {
             CommandScript script = new CommandScript(Collections.singletonList(new UpdateReleaseIdCommand(id, releaseId, resetBeforeUpdate)));
             ServiceResponse<ReleaseId> response = (ServiceResponse<ReleaseId>) executeJmsCommand(script, null, null, id).getResponses().get(0);

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/KieServicesClientTest.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/KieServicesClientTest.java
@@ -136,6 +136,28 @@ public class KieServicesClientTest extends BaseKieServicesClientTest {
     }
 
     @Test
+    public void testUpdateContainer() {
+        stubFor(post(urlPathEqualTo("/containers/kie1/release-id"))
+                        .withHeader("Accept", equalTo("application/xml"))
+                        .willReturn(aResponse()
+                                            .withStatus(200)
+                                            .withHeader("Content-Type", "application/xml")
+                                            .withBody("<response type=\"SUCCESS\" msg=\"Container successfully deployed\">\n" +
+                                                              "    <release-id>\n" +
+                                                              "      <group-id>org.kie.server.testing</group-id>\n" +
+                                                              "      <artifact-id>kjar2</artifact-id>\n" +
+                                                              "      <version>1.0</version>\n" +
+                                                              "    </release-id>\n" +
+                                                              "</response>")));
+        KieServicesClient client = KieServicesFactory.newKieServicesClient(config);
+        ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "kjar2", "1.0");
+        ServiceResponse<ReleaseId> response = client.updateReleaseId("kie1", releaseId);
+        assertSuccess(response);
+        ReleaseId result = response.getResult();
+        assertEquals("Release id", releaseId, result);
+    }
+
+    @Test
     public void testGetServerInfoWithSingletonExtraClass() {
         stubFor(get(urlEqualTo("/"))
                 .withHeader("Accept", equalTo("application/json"))

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/build/revapi-config.json
@@ -76,7 +76,32 @@
           "parameterIndex": "2",
           "elementKind": "parameter",
           "justification": "Add Swagger examples for updating scanner."
-        }
+        },
+        {
+           "code": "java.annotation.attributeAdded",
+           "old": "parameter javax.ws.rs.core.Response org.kie.server.remote.rest.common.resource.KieServerRestImpl::updateReleaseId(javax.ws.rs.core.HttpHeaders, java.lang.String, ===java.lang.String===)",
+           "new": "parameter javax.ws.rs.core.Response org.kie.server.remote.rest.common.resource.KieServerRestImpl::updateReleaseId(javax.ws.rs.core.HttpHeaders, java.lang.String, ===java.lang.String===, boolean)",
+           "annotationType": "io.swagger.annotations.ApiParam",
+           "annotation": "@io.swagger.annotations.ApiParam(value = \"Release Id to be upgraded to as ReleaseId type\", required = true, examples = @io.swagger.annotations.Example({@io.swagger.annotations.ExampleProperty(mediaType = \"application\/json\", value = \"{\n    \"group-id\" : \"foo\",\n    \"artifact-id\" : \"bar\",\n    \"version\" : \"1.0\"\n}\"), @io.swagger.annotations.ExampleProperty(mediaType = \"application\/xml\", value = \"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<release-id>\n    <group-id>foo<\/group-id>\n    <artifact-id>bar<\/artifact-id>\n    <version>1.0<\/version>\n<\/release-id>\n\")}))",
+           "attribute": "examples",
+           "value": "@io.swagger.annotations.Example({@io.swagger.annotations.ExampleProperty(mediaType = \"application\/json\", value = \"{\n    \"group-id\" : \"foo\",\n    \"artifact-id\" : \"bar\",\n    \"version\" : \"1.0\"\n}\"), @io.swagger.annotations.ExampleProperty(mediaType = \"application\/xml\", value = \"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<release-id>\n    <group-id>foo<\/group-id>\n    <artifact-id>bar<\/artifact-id>\n    <version>1.0<\/version>\n<\/release-id>\n\")})",
+           "package": "org.kie.server.remote.rest.common.resource",
+           "classSimpleName": "KieServerRestImpl",
+           "methodName": "updateReleaseId",
+           "parameterIndex": "2",
+           "elementKind": "parameter",
+           "justification": "AF-1685: Development Lifecycle Streamline"
+        },
+        {
+           "code": "java.method.numberOfParametersChanged",
+           "old": "method javax.ws.rs.core.Response org.kie.server.remote.rest.common.resource.KieServerRestImpl::updateReleaseId(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String)",
+           "new": "method javax.ws.rs.core.Response org.kie.server.remote.rest.common.resource.KieServerRestImpl::updateReleaseId(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String, boolean)",
+           "package": "org.kie.server.remote.rest.common.resource",
+           "classSimpleName": "KieServerRestImpl",
+           "methodName": "updateReleaseId",
+           "elementKind": "method",
+           "justification": "AF-1685: Development Lifecycle Streamline"
+         }
       ]
     }
   }

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/resource/KieServerRestImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/resource/KieServerRestImpl.java
@@ -295,7 +295,7 @@ public class KieServerRestImpl {
             @ApiParam(value = "Release Id to be upgraded to as ReleaseId type", required = true, examples=@Example(value= {
                                    @ExampleProperty(mediaType=JSON, value=UPDATE_RELEASE_ID_JSON),
                                    @ExampleProperty(mediaType=XML, value=UPDATE_RELEASE_ID_XML)})) String releaseIdPayload,
-            @ApiParam(value = "Optional param to reset current environment before updating on dev mode, defaults to false") @QueryParam("resetBeforeUpdate")  @DefaultValue("false") boolean resetBeforeUpdate) {
+            @ApiParam(value = "Allows to reset the current environment aborting active process instances before updating when the server runs on development mode. Optional, defaults to false") @QueryParam("resetBeforeUpdate")  @DefaultValue("false") boolean resetBeforeUpdate) {
         
         ServiceResponse<?> forbidden = this.server.checkAccessability();
         if (forbidden != null) {                       

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/resource/KieServerRestImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/resource/KieServerRestImpl.java
@@ -1,17 +1,18 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.kie.server.remote.rest.common.resource;
 
@@ -293,7 +294,8 @@ public class KieServerRestImpl {
             @ApiParam(value = "Container id that release id should be upgraded", required = true) @PathParam("id") String id, 
             @ApiParam(value = "Release Id to be upgraded to as ReleaseId type", required = true, examples=@Example(value= {
                                    @ExampleProperty(mediaType=JSON, value=UPDATE_RELEASE_ID_JSON),
-                                   @ExampleProperty(mediaType=XML, value=UPDATE_RELEASE_ID_XML)})) String releaseIdPayload) {
+                                   @ExampleProperty(mediaType=XML, value=UPDATE_RELEASE_ID_XML)})) String releaseIdPayload,
+            @ApiParam(value = "Optional param to reset current environment before updating on dev mode, defaults to false") @QueryParam("resetBeforeUpdate")  @DefaultValue("false") boolean resetBeforeUpdate) {
         
         ServiceResponse<?> forbidden = this.server.checkAccessability();
         if (forbidden != null) {                       
@@ -304,7 +306,7 @@ public class KieServerRestImpl {
 
         ReleaseId releaseId = marshallerHelper.unmarshal(releaseIdPayload, contentType, ReleaseId.class);
         Header conversationIdHeader = buildConversationIdHeader(id, server.getServerRegistry(), headers);
-        return createCorrectVariant(server.updateContainerReleaseId(id, releaseId), headers, conversationIdHeader);
+        return createCorrectVariant(server.updateContainerReleaseId(id, releaseId, resetBeforeUpdate), headers, conversationIdHeader);
     }
 
     @ApiOperation(value="Retrieves server state - configuration that the server is currently running with",

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/resource/KieServerRestImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/resource/KieServerRestImpl.java
@@ -306,6 +306,7 @@ public class KieServerRestImpl {
 
         ReleaseId releaseId = marshallerHelper.unmarshal(releaseIdPayload, contentType, ReleaseId.class);
         Header conversationIdHeader = buildConversationIdHeader(id, server.getServerRegistry(), headers);
+
         return createCorrectVariant(server.updateContainerReleaseId(id, releaseId, resetBeforeUpdate), headers, conversationIdHeader);
     }
 

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/test/java/org/kie/server/remote/rest/common/resource/KieServerRestImplTest.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/test/java/org/kie/server/remote/rest/common/resource/KieServerRestImplTest.java
@@ -106,7 +106,7 @@ public class KieServerRestImplTest {
   
         KieServerRestImpl restServer = new KieServerRestImpl(kieServer);
         
-        Response response = restServer.updateReleaseId(headers, "test", "");        
+        Response response = restServer.updateReleaseId(headers, "test", "", false);
         assertForbiddenResponse(response);
     }
     

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/test/java/org/kie/server/remote/rest/common/resource/KieServerRestImplTest.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/test/java/org/kie/server/remote/rest/common/resource/KieServerRestImplTest.java
@@ -48,12 +48,12 @@ public class KieServerRestImplTest {
 
     private static final File REPOSITORY_DIR = new File("target/repository-dir");
     private static final String KIE_SERVER_ID = "kie-server-impl-test";
-    
+
     private KieServerImpl kieServer;
     private String origServerId = null;
-    
+
     private Marshaller marshaller = MarshallerFactory.getMarshaller(MarshallingFormat.JSON, this.getClass().getClassLoader());
-    
+
     @Mock
     private HttpHeaders headers;
 
@@ -68,7 +68,7 @@ public class KieServerRestImplTest {
         FileUtils.forceMkdir(REPOSITORY_DIR);
         kieServer = new KieServerImpl(new KieServerStateFileRepository(REPOSITORY_DIR));
         kieServer.init();
-        
+
         MultivaluedHashMap<String, String> mockedRequestHeaders = new MultivaluedHashMap<>();
         mockedRequestHeaders.add("Accept", "application/json");
         when(headers.getRequestHeaders()).thenReturn(mockedRequestHeaders);
@@ -82,30 +82,30 @@ public class KieServerRestImplTest {
         KieServerEnvironment.setServerId(origServerId);
         System.clearProperty(KieServerConstants.KIE_SERVER_MGMT_API_DISABLED);
     }
-    
+
     @Test
     public void testCreateContainerWithManagementDisabled() {
-  
+
         KieServerRestImpl restServer = new KieServerRestImpl(kieServer);
-        
-        Response response = restServer.createContainer(headers, "test", "");        
+
+        Response response = restServer.createContainer(headers, "test", "");
         assertForbiddenResponse(response);
     }
-    
+
     @Test
     public void testDisposeContainerWithManagementDisabled() {
-  
+
         KieServerRestImpl restServer = new KieServerRestImpl(kieServer);
-        
-        Response response = restServer.disposeContainer(headers, "test");        
+
+        Response response = restServer.disposeContainer(headers, "test");
         assertForbiddenResponse(response);
     }
-    
+
     @Test
     public void testUpdateReleaseIdWithManagementDisabled() {
-  
+
         KieServerRestImpl restServer = new KieServerRestImpl(kieServer);
-        
+
         Response response = restServer.updateReleaseId(headers, "test", "", false);
         assertForbiddenResponse(response);
     }

--- a/kie-server-parent/kie-server-router/kie-server-router-client/src/test/java/org/kie/server/router/client/KieServerRouterEventListenerRetryTest.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-client/src/test/java/org/kie/server/router/client/KieServerRouterEventListenerRetryTest.java
@@ -205,6 +205,11 @@ public class KieServerRouterEventListenerRetryTest {
             }
 
             @Override
+            public ServiceResponse<ReleaseId> updateContainerReleaseId(String id, ReleaseId releaseId, boolean reset) {
+                return null;
+            }
+
+            @Override
             public ServiceResponse<KieServerStateInfo> getServerState() {
                 return null;
             }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieServer.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieServer.java
@@ -1,17 +1,18 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.kie.server.services.api;
 
@@ -44,6 +45,8 @@ public interface KieServer {
     ServiceResponse<ReleaseId> getContainerReleaseId(String id);
 
     ServiceResponse<ReleaseId> updateContainerReleaseId(String id, ReleaseId releaseId);
+
+    ServiceResponse<ReleaseId> updateContainerReleaseId(String id, ReleaseId releaseId, boolean reset);
 
     ServiceResponse<KieServerStateInfo> getServerState();
 

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieContainerCommandServiceImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieContainerCommandServiceImpl.java
@@ -184,7 +184,7 @@ public class KieContainerCommandServiceImpl implements KieContainerCommandServic
                         responses.add(forbidden);
                         continue;
                     }
-                    responses.add(this.kieServer.updateContainerReleaseId(((UpdateReleaseIdCommand) command).getContainerId(), ((UpdateReleaseIdCommand) command).getReleaseId()));
+                    responses.add(this.kieServer.updateContainerReleaseId(((UpdateReleaseIdCommand) command).getContainerId(), ((UpdateReleaseIdCommand) command).getReleaseId(), ((UpdateReleaseIdCommand) command).isResetBeforeUpdate()));
                 } else if (command instanceof GetServerStateCommand) {
                     responses.add(this.kieServer.getServerState());
                 } else if (command instanceof ActivateContainerCommand) {

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
@@ -1,17 +1,18 @@
 /*
- * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.kie.server.services.impl;
 
@@ -24,6 +25,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -42,6 +44,7 @@ import org.kie.api.builder.Results;
 import org.kie.scanner.KieModuleMetaData;
 import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.KieServerEnvironment;
+import org.kie.server.api.model.KieServerMode;
 import org.kie.server.api.Version;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieContainerResourceFilter;
@@ -70,6 +73,7 @@ import org.kie.server.services.impl.security.JACCIdentityProvider;
 import org.kie.server.services.impl.storage.KieServerState;
 import org.kie.server.services.impl.storage.KieServerStateRepository;
 import org.kie.server.services.impl.storage.file.KieServerStateFileRepository;
+import org.kie.server.services.impl.util.KieServerUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -102,12 +106,22 @@ public class KieServerImpl implements KieServer {
     
     private boolean managementDisabled = Boolean.parseBoolean(System.getProperty(KieServerConstants.KIE_SERVER_MGMT_API_DISABLED, "false"));
 
+    private KieServerMode mode;
+
     public KieServerImpl() {
         this(new KieServerStateFileRepository());
     }
 
     public KieServerImpl(KieServerStateRepository stateRepository) {
-        this.repository = stateRepository;    
+        this.repository = stateRepository;
+
+        String modeParam = System.getProperty(KieServerConstants.KIE_SERVER_MODE, KieServerMode.DEVELOPMENT.toString());
+
+        try {
+            mode = KieServerMode.valueOf(modeParam.toUpperCase());
+        } catch (Exception ex) {
+            mode = KieServerMode.DEVELOPMENT;
+        }
     }
     
     public void init() {
@@ -212,7 +226,7 @@ public class KieServerImpl implements KieServer {
             capabilities.add(extension.getImplementedCapability());
         }
 
-        return new KieServerInfo(serverId, serverName, versionStr, capabilities, kieServerLocation);
+        return new KieServerInfo(serverId, serverName, versionStr, capabilities, kieServerLocation, mode);
     }
 
     public ServiceResponse<KieServerInfo> getInfo() {
@@ -229,10 +243,17 @@ public class KieServerImpl implements KieServer {
     }
 
     public ServiceResponse<KieContainerResource> createContainer(String containerId, KieContainerResource container) {
-        if (container == null || container.getReleaseId() == null) {
-            logger.error("Error creating container. Release Id is null: " + container);
-            return new ServiceResponse<KieContainerResource>(ServiceResponse.ResponseType.FAILURE, "Failed to create container " + containerId + ". Release Id is null: " + container + ".");
+
+        Optional<ServiceResponse> optional = Optional.ofNullable(validateContainerReleaseAndMode("Error creating container.", container));
+
+        if(optional.isPresent()) {
+            ServiceResponse response = optional.get();
+
+            logger.error(response.getMsg());
+
+            return optional.get();
         }
+
         List<Message> messages = new CopyOnWriteArrayList<Message>();
 
         container.setContainerId(containerId);
@@ -258,7 +279,7 @@ public class KieServerImpl implements KieServer {
 
                             Map<String, Object> parameters = getContainerParameters(releaseId, messages);
                             // process server extensions
-                            List<KieServerExtension> extensions = context.getServerExtensions();
+                            List<KieServerExtension> extensions = getServerExtensions();
                             for (KieServerExtension extension : extensions) {
                                 extension.createContainer(containerId, ci, parameters);
                                 logger.debug("Container {} (for release id {}) {} initialization: DONE", containerId, releaseId, extension);
@@ -282,7 +303,7 @@ public class KieServerImpl implements KieServer {
                                 container.setStatus(KieContainerStatus.STARTED);
                                 currentState.getContainers().add(container);
                             });
-                            
+
                             // add successful message only when there are no errors
                             if (!messages.stream().filter(m -> m.getSeverity().equals(Severity.ERROR)).findAny().isPresent()) {
                                 messages.add(new Message(Severity.INFO, "Container " + containerId + " successfully created with module " + releaseId + "."));
@@ -321,7 +342,37 @@ public class KieServerImpl implements KieServer {
             this.containerMessages.put(containerId, messages);
         }
     }
-    
+
+    private ServiceResponse<?> validateContainerReleaseAndMode(String preffix, KieContainerResource container) {
+
+        if(container == null) {
+            return new ServiceResponse<>(ResponseType.FAILURE, preffix, "Release Id is null");
+        }
+
+        return validateReleaseAndMode(preffix, container.getReleaseId());
+    }
+
+    private ServiceResponse<?> validateReleaseAndMode(String preffix, ReleaseId releaseId) {
+
+        if(releaseId == null) {
+            return new ServiceResponse(ResponseType.FAILURE, preffix + "Release Id is null");
+        }
+
+        boolean isSnapshot = KieServerUtils.isSnapshot(releaseId);
+
+        if(isSnapshot) {
+            if(mode.equals(KieServerMode.REGULAR)) {
+                return new ServiceResponse(ResponseType.FAILURE, preffix + "KieServers running on REGULAR mode doesn't support deploying SNAPSHOT modules.");
+            }
+        } else {
+            if(mode.equals(KieServerMode.DEVELOPMENT)) {
+                return new ServiceResponse(ResponseType.FAILURE, preffix + "KieServers running on DEVELOPMENT mode only support deploying SNAPSHOT modules.");
+            }
+        }
+
+        return null;
+    }
+
     public ServiceResponse<KieContainerResource> activateContainer(String containerId) {
      
         List<Message> messages = new CopyOnWriteArrayList<Message>();
@@ -350,7 +401,7 @@ public class KieServerImpl implements KieServer {
                             }
                         });
                     });
-                   
+
                     eventSupport.fireAfterContainerActivated(this, kci);
                     
                     messages.add(new Message(Severity.INFO, "Container " + containerId + " activated successfully."));
@@ -529,7 +580,7 @@ public class KieServerImpl implements KieServer {
                             });
                             currentState.setContainers(new HashSet<KieContainerResource>(containers));
                         });
-                        
+
                         messages.add(new Message(Severity.INFO, "Container " + containerId + " successfully stopped."));
 
                         eventSupport.fireAfterContainerStopped(this, kci);
@@ -642,7 +693,7 @@ public class KieServerImpl implements KieServer {
     }
 
     /**
-     * Persists updated KieServer state. 
+     * Persists updated KieServer state.
      * @param kieServerStateConsumer
      */
     private void storeServerState(Consumer<KieServerState> kieServerStateConsumer) {
@@ -786,11 +837,24 @@ public class KieServerImpl implements KieServer {
         }
     }
 
+    @Override
     public ServiceResponse<ReleaseId> updateContainerReleaseId(String containerId, ReleaseId releaseId) {
-        if (releaseId == null) {
-            logger.error("Error updating releaseId for container '" + containerId + "'. ReleaseId is null.");
-            return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.FAILURE, "Error updating releaseId for container " + containerId + ". ReleaseId is null. ");
+        return updateContainerReleaseId(containerId, releaseId, false);
+    }
+
+    @Override
+    public ServiceResponse<ReleaseId> updateContainerReleaseId(String containerId, ReleaseId releaseId, boolean resetBeforeUpdate) {
+
+        Optional<ServiceResponse> optional = Optional.ofNullable(validateReleaseAndMode("Error updating releaseId for container '" + containerId + "'.", releaseId));
+
+        if(optional.isPresent()) {
+            ServiceResponse response = optional.get();
+
+            logger.error(response.getMsg());
+
+            return optional.get();
         }
+
         List<Message> messages = getMessagesForContainer(containerId);
         messages.clear();
         try {
@@ -800,9 +864,10 @@ public class KieServerImpl implements KieServer {
             // call do dispose() is executed.
             if (kci != null && kci.getKieContainer() != null) {
                 // before upgrade check with all extensions if that is allowed
-                Map<String, Object> parameters = getContainerParameters(releaseId, messages);
+                Map<String, Object> parameters = getReleaseUpdateParameters(releaseId, messages, resetBeforeUpdate);
+
                 // process server extensions
-                List<KieServerExtension> extensions = context.getServerExtensions();
+                List<KieServerExtension> extensions = getServerExtensions();
                 for (KieServerExtension extension : extensions) {
                     boolean allowed = extension.isUpdateContainerAllowed(containerId, kci, parameters);
                     if (!allowed) {
@@ -822,7 +887,7 @@ public class KieServerImpl implements KieServer {
                     messages.add(updateMessage);
                     return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.FAILURE, "Error updating release id on container " + containerId + " to " + releaseId, kci.getResource().getReleaseId());
                 }
-                updateExtensions(kci, releaseId, messages);
+                updateExtensions(kci, releaseId, messages, resetBeforeUpdate);
 
                 // If extension update fails then restore previous container
                 if (messages.stream().anyMatch(m -> m.getSeverity().equals(Severity.ERROR))) {
@@ -833,7 +898,7 @@ public class KieServerImpl implements KieServer {
                         messages.add(updateMessage);
                         return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.FAILURE, "Error reverting release id update on container " + containerId + " to original release id " + originalReleaseId, kci.getResource().getReleaseId());
                     }
-                    updateExtensions(kci, originalReleaseId, messages);
+                    updateExtensions(kci, originalReleaseId, messages, resetBeforeUpdate);
 
                     messages.add(new Message(Severity.WARN, "Error updating release id on container " + containerId + " to " + releaseId + ", release id returned back to " + kci.getResource().getReleaseId()));
                     return new ServiceResponse<ReleaseId>(ServiceResponse.ResponseType.FAILURE, "Error updating release id on container " + containerId + " to " + releaseId + ", release id returned back to " + kci.getResource().getReleaseId(), kci.getResource().getReleaseId());
@@ -851,7 +916,7 @@ public class KieServerImpl implements KieServer {
                     });
                     currentState.setContainers(new HashSet<KieContainerResource>(containers));
                 });
-                
+
                 logger.info("Container {} successfully updated to release id {}", containerId, releaseId);
                 ks.getRepository().removeKieModule(originalReleaseId);
 
@@ -892,10 +957,10 @@ public class KieServerImpl implements KieServer {
         return response;
     }
 
-    private List<Message> updateExtensions(KieContainerInstanceImpl kci, ReleaseId releaseId, List<Message> messages) {
+    private List<Message> updateExtensions(KieContainerInstanceImpl kci, ReleaseId releaseId, List<Message> messages, boolean resetBeforeUpdate) {
         String containerId = kci.getContainerId();
-        List<KieServerExtension> extensions = context.getServerExtensions();
-        Map<String, Object> parameters = getContainerParameters(releaseId, messages);
+        List<KieServerExtension> extensions = getServerExtensions();
+        Map<String, Object> parameters = getReleaseUpdateParameters(releaseId, messages, resetBeforeUpdate);
 
         // once the upgrade was successful, notify all extensions so they can be upgraded (if needed)
         for (KieServerExtension extension : extensions) {
@@ -924,6 +989,18 @@ public class KieServerImpl implements KieServer {
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put(KieServerConstants.KIE_SERVER_PARAM_MODULE_METADATA, metaData);
         parameters.put(KieServerConstants.KIE_SERVER_PARAM_MESSAGES, messages);
+        return parameters;
+    }
+
+    protected Map<String, Object> getReleaseUpdateParameters(final org.kie.api.builder.ReleaseId releaseId, final List<Message> messages, final boolean resetBeforeUpdate) {
+        Map<String, Object> parameters = getContainerParameters(releaseId, messages);
+
+        if(mode.equals(KieServerMode.DEVELOPMENT) && KieServerUtils.isSnapshot(releaseId)) {
+            parameters.put(KieServerConstants.KIE_SERVER_PARAM_RESET_BEFORE_UPDATE, resetBeforeUpdate);
+        } else {
+            parameters.put(KieServerConstants.KIE_SERVER_PARAM_RESET_BEFORE_UPDATE, false);
+        }
+
         return parameters;
     }
 

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/util/KieServerUtils.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/util/KieServerUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.services.impl.util;
+
+import org.kie.server.api.model.ReleaseId;
+
+public class KieServerUtils {
+
+    private static final String SNAPSHOT = "-SNAPSHOT";
+
+    public static boolean isSnapshot(final ReleaseId releaseId) {
+        return isSnapshot(releaseId.getVersion());
+    }
+
+    public static boolean isSnapshot(final org.kie.api.builder.ReleaseId releaseId) {
+        return isSnapshot(releaseId.getVersion());
+    }
+
+    public static boolean isSnapshot(final String version) {
+        return version.toUpperCase().endsWith(SNAPSHOT);
+    }
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/AbstractKieServerImplTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/AbstractKieServerImplTest.java
@@ -1,10 +1,11 @@
 /*
- * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,12 +15,6 @@
  */
 
 package org.kie.server.services.impl;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,7 +51,8 @@ import org.kie.server.api.model.KieScannerResource;
 import org.kie.server.api.model.KieScannerStatus;
 import org.kie.server.api.model.KieServerCommand;
 import org.kie.server.api.model.KieServerInfo;
-import org.kie.server.api.model.KieServiceResponse.ResponseType;
+import org.kie.server.api.model.KieServerMode;
+import org.kie.server.api.model.KieServiceResponse;
 import org.kie.server.api.model.Message;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
@@ -73,28 +69,69 @@ import org.kie.server.services.impl.controller.DefaultRestControllerImpl;
 import org.kie.server.services.impl.storage.KieServerState;
 import org.kie.server.services.impl.storage.KieServerStateRepository;
 import org.kie.server.services.impl.storage.file.KieServerStateFileRepository;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
-public class KieServerImplTest {
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-    private static final File REPOSITORY_DIR = new File("target/repository-dir");
-    private static final String KIE_SERVER_ID = "kie-server-impl-test";
-    private static final String GROUP_ID = "org.kie.server.test";
-    private static final String DEFAULT_VERSION = "1.0.0.Final";
+public abstract class AbstractKieServerImplTest {
 
-    private KieServerImpl kieServer;
-    private org.kie.api.builder.ReleaseId releaseId;
-    private String origServerId = null;
+    static final File REPOSITORY_DIR = new File("target/repository-dir");
+    static final String KIE_SERVER_ID = "kie-server-impl-test";
+    static final String GROUP_ID = "org.kie.server.test";
+    static final String REGULAR_MODE_VERSION = "1.0.0.Final";
+    static final String DEVELOPMENT_MODE_VERSION = "1.0.0-SNAPSHOT";
+
+    protected KieServerMode mode;
+    protected String testVersion;
+
+    protected KieServerImpl kieServer;
+    protected org.kie.api.builder.ReleaseId releaseId;
+    protected String origServerId = null;
+
+    protected List<KieServerExtension> extensions;
+
+    abstract KieServerMode getTestMode();
 
     @Before
     public void setupKieServerImpl() throws Exception {
+        extensions = new ArrayList<>();
+        mode = getTestMode();
+
+        testVersion = getVersion(mode);
+
         origServerId = KieServerEnvironment.getServerId();
+        System.setProperty(KieServerConstants.KIE_SERVER_MODE, mode.name());
         System.setProperty("org.kie.server.id", KIE_SERVER_ID);
         KieServerEnvironment.setServerId(KIE_SERVER_ID);
 
+
         FileUtils.deleteDirectory(REPOSITORY_DIR);
         FileUtils.forceMkdir(REPOSITORY_DIR);
-        kieServer = new KieServerImpl(new KieServerStateFileRepository(REPOSITORY_DIR));
+        kieServer = new KieServerImpl(new KieServerStateFileRepository(REPOSITORY_DIR)) {
+            @Override
+            public List<KieServerExtension> getServerExtensions() {
+                return extensions;
+            }
+        };
         kieServer.init();
+    }
+
+    private String getVersion(KieServerMode mode) {
+        return mode.equals(KieServerMode.DEVELOPMENT) ? DEVELOPMENT_MODE_VERSION : REGULAR_MODE_VERSION;
     }
 
     @After
@@ -104,75 +141,79 @@ public class KieServerImplTest {
         }
         KieServerEnvironment.setServerId(origServerId);
     }
-    
+
+    @Test
+    public void testCheckMode() {
+        assertSame(mode, kieServer.getInfo().getResult().getMode());
+    }
+
     @Test
     public void testReadinessCheck() {
-        
         assertTrue(kieServer.isKieServerReady());
     }
-    
+
     @Test(timeout=10000)
     public void testReadinessCheckDelayedStart() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         CountDownLatch startedlatch = new CountDownLatch(1);
         kieServer.destroy();
         kieServer = delayedKieServer(latch, startedlatch);
-        
+
         assertFalse(kieServer.isKieServerReady());
         latch.countDown();
-        
-        startedlatch.await();        
+
+        startedlatch.await();
         assertTrue(kieServer.isKieServerReady());
     }
-    
+
     @Test
     public void testHealthCheck() {
-        
+
         List<Message> healthMessages = kieServer.healthCheck(false);
-        
+
         assertEquals(healthMessages.size(), 0);
     }
-    
+
     @Test
     public void testHealthCheckWithReport() {
-        
+
         List<Message> healthMessages = kieServer.healthCheck(true);
-        
+
         assertEquals(healthMessages.size(), 2);
         Message header = healthMessages.get(0);
         assertEquals(Severity.INFO, header.getSeverity());
         assertEquals(2, header.getMessages().size());
-        
+
         Message footer = healthMessages.get(1);
         assertEquals(Severity.INFO, footer.getSeverity());
         assertEquals(1, footer.getMessages().size());
     }
-    
+
     @Test(timeout=10000)
     public void testHealthCheckDelayedStart() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         CountDownLatch startedlatch = new CountDownLatch(1);
         kieServer.destroy();
         kieServer = delayedKieServer(latch, startedlatch);
-        
-        assertFalse(kieServer.isKieServerReady());        
-        
+
+        assertFalse(kieServer.isKieServerReady());
+
         List<Message> healthMessages = kieServer.healthCheck(false);
         assertEquals(healthMessages.size(), 1);
-        
+
         Message notReady = healthMessages.get(0);
         assertEquals(Severity.ERROR, notReady.getSeverity());
         assertEquals(1, notReady.getMessages().size());
-        
+
         latch.countDown();
-        startedlatch.await();        
+        startedlatch.await();
         assertTrue(kieServer.isKieServerReady());
-        
+
         healthMessages = kieServer.healthCheck(false);
-        
+
         assertEquals(healthMessages.size(), 0);
     }
-    
+
     @Test
     public void testHealthCheckFailedContainer() {
         kieServer.destroy();
@@ -185,120 +226,111 @@ public class KieServerImplTest {
                 containers.add(container);
                 return containers;
             }
-            
+
         };
         kieServer.init();
         List<Message> healthMessages = kieServer.healthCheck(false);
-        
+
         assertEquals(healthMessages.size(), 1);
         Message failedContainer = healthMessages.get(0);
         assertEquals(Severity.ERROR, failedContainer.getSeverity());
         assertEquals(1, failedContainer.getMessages().size());
         assertEquals("KIE Container 'test' is in FAILED state", failedContainer.getMessages().iterator().next());
     }
-    
+
     @Test
     public void testHealthCheckFailedExtension() {
-        kieServer.destroy();
-        kieServer = new KieServerImpl(new KieServerStateFileRepository(REPOSITORY_DIR)) {
+        extensions.add(new KieServerExtension() {
 
             @Override
-            public List<KieServerExtension> getServerExtensions() {
-                List<KieServerExtension> extensions = new ArrayList<>();
-                extensions.add(new KieServerExtension() {
-                    
-                    @Override
-                    public List<Message> healthCheck(boolean report) {
-                        List<Message> messages = KieServerExtension.super.healthCheck(report);
-                        messages.add(new Message(Severity.ERROR, "TEST extension is unhealthy"));
-                        return messages;
-                    }
-
-                    @Override
-                    public void updateContainer(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {                        
-                    }
-                    
-                    @Override
-                    public boolean isUpdateContainerAllowed(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {
-                        return false;
-                    }
-                    
-                    @Override
-                    public boolean isInitialized() {
-                        return true;
-                    }
-                    
-                    @Override
-                    public boolean isActive() {
-                        return true;
-                    }
-                    
-                    @Override
-                    public void init(KieServerImpl kieServer, KieServerRegistry registry) {                        
-                    }
-                    
-                    @Override
-                    public Integer getStartOrder() {
-                        return 10;
-                    }
-                    
-                    @Override
-                    public List<Object> getServices() {
-                        return null;
-                    }
-                    
-                    @Override
-                    public String getImplementedCapability() {
-                        return "TEST";
-                    }
-                    
-                    @Override
-                    public String getExtensionName() {
-                        return "TEST";
-                    }
-                    
-                    @Override
-                    public <T> T getAppComponents(Class<T> serviceType) {
-                        return null;
-                    }
-                    
-                    @Override
-                    public List<Object> getAppComponents(SupportedTransports type) {
-                        return null;
-                    }
-                    
-                    @Override
-                    public void disposeContainer(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {
-                    }
-                    
-                    @Override
-                    public void destroy(KieServerImpl kieServer, KieServerRegistry registry) {
-                    }
-                    
-                    @Override
-                    public void createContainer(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {
-                    }
-                });
-                return extensions;
+            public List<Message> healthCheck(boolean report) {
+                List<Message> messages = KieServerExtension.super.healthCheck(report);
+                messages.add(new Message(Severity.ERROR, "TEST extension is unhealthy"));
+                return messages;
             }
-            
-        };
+
+            @Override
+            public void updateContainer(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {
+            }
+
+            @Override
+            public boolean isUpdateContainerAllowed(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {
+                return false;
+            }
+
+            @Override
+            public boolean isInitialized() {
+                return true;
+            }
+
+            @Override
+            public boolean isActive() {
+                return true;
+            }
+
+            @Override
+            public void init(KieServerImpl kieServer, KieServerRegistry registry) {
+            }
+
+            @Override
+            public Integer getStartOrder() {
+                return 10;
+            }
+
+            @Override
+            public List<Object> getServices() {
+                return null;
+            }
+
+            @Override
+            public String getImplementedCapability() {
+                return "TEST";
+            }
+
+            @Override
+            public String getExtensionName() {
+                return "TEST";
+            }
+
+            @Override
+            public <T> T getAppComponents(Class<T> serviceType) {
+                return null;
+            }
+
+            @Override
+            public List<Object> getAppComponents(SupportedTransports type) {
+                return null;
+            }
+
+            @Override
+            public void disposeContainer(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {
+            }
+
+            @Override
+            public void destroy(KieServerImpl kieServer, KieServerRegistry registry) {
+            }
+
+            @Override
+            public void createContainer(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {
+            }
+        });
+
         kieServer.init();
         List<Message> healthMessages = kieServer.healthCheck(false);
-        
+
         assertEquals(healthMessages.size(), 1);
         Message failedContainer = healthMessages.get(0);
         assertEquals(Severity.ERROR, failedContainer.getSeverity());
         assertEquals(1, failedContainer.getMessages().size());
         assertEquals("TEST extension is unhealthy", failedContainer.getMessages().iterator().next());
     }
-    
+
     @Test
     public void testManagementDisabledDefault() {
-        
+
         assertNull(kieServer.checkAccessability());
     }
-    
+
     @Test
     public void testManagementDisabledConfigured() {
         System.setProperty(KieServerConstants.KIE_SERVER_MGMT_API_DISABLED, "true");
@@ -312,7 +344,7 @@ public class KieServerImplTest {
             System.clearProperty(KieServerConstants.KIE_SERVER_MGMT_API_DISABLED);
         }
     }
-    
+
     @Test
     public void testManagementDisabledConfiguredViaCommandService() {
         System.setProperty(KieServerConstants.KIE_SERVER_MGMT_API_DISABLED, "true");
@@ -320,27 +352,27 @@ public class KieServerImplTest {
             kieServer.destroy();
             kieServer = new KieServerImpl(new KieServerStateFileRepository(REPOSITORY_DIR));
             kieServer.init();
-            
+
             KieContainerCommandServiceImpl commandService = new KieContainerCommandServiceImpl(kieServer, kieServer.getServerRegistry());
             List<KieServerCommand> commands = new ArrayList<>();
-            
+
             commands.add(new CreateContainerCommand());
             commands.add(new DisposeContainerCommand());
             commands.add(new UpdateScannerCommand());
             commands.add(new UpdateReleaseIdCommand());
-            
+
             CommandScript commandScript = new CommandScript(commands);
             ServiceResponsesList responseList = commandService.executeScript(commandScript, MarshallingFormat.JAXB, null);
             assertNotNull(responseList);
-            
+
             List<ServiceResponse<?>> responses = responseList.getResponses();
             assertEquals(4, responses.size());
-            
+
             for (ServiceResponse<?> forbidden : responses) {
-            
+
                 assertForbiddenResponse(forbidden);
             }
-            
+
         } finally {
             System.clearProperty(KieServerConstants.KIE_SERVER_MGMT_API_DISABLED);
         }
@@ -375,6 +407,7 @@ public class KieServerImplTest {
         Assertions.assertThat(containers).hasSize(1);
         container = containers.iterator().next();
         Assertions.assertThat(container.getScanner()).isEqualTo(updatedKieScannerResource);
+        kieServer.disposeContainer(containerId);
     }
 
     @Test
@@ -385,6 +418,143 @@ public class KieServerImplTest {
 
         // create the container (provide scanner info as well)
         KieContainerResource kieContainerResource = new KieContainerResource(containerId, new ReleaseId(releaseId));
+        KieScannerResource kieScannerResource = new KieScannerResource(KieScannerStatus.STARTED, 20000L);
+        kieContainerResource.setScanner(kieScannerResource);
+        ServiceResponse<KieContainerResource> createResponse = kieServer.createContainer(containerId, kieContainerResource);
+        Assertions.assertThat(createResponse.getType()).isEqualTo(ServiceResponse.ResponseType.SUCCESS);
+        Assertions.assertThat(createResponse.getResult().getScanner()).isEqualTo(kieScannerResource);
+
+        ServiceResponse<KieContainerResource> getResponse = kieServer.getContainerInfo(containerId);
+        Assertions.assertThat(getResponse.getType()).isEqualTo(ServiceResponse.ResponseType.SUCCESS);
+        Assertions.assertThat(getResponse.getResult().getScanner()).isEqualTo(kieScannerResource);
+        kieServer.disposeContainer(containerId);
+    }
+
+    @Test
+    public void testCreateContainerValidationNullContainer() {
+        String containerId = "container-to-create";
+
+        createEmptyKjar(containerId);
+
+        ServiceResponse<KieContainerResource> createResponse = kieServer.createContainer(containerId, null);
+        Assertions.assertThat(createResponse.getType()).isEqualTo(ServiceResponse.ResponseType.FAILURE);
+    }
+
+    @Test
+    public void testCreateContainerValidationNullRelease() {
+        String containerId = "container-to-create";
+
+        createEmptyKjar(containerId);
+
+        // create the container (provide scanner info as well)
+        KieContainerResource kieContainerResource = new KieContainerResource(containerId, null);
+        KieScannerResource kieScannerResource = new KieScannerResource(KieScannerStatus.STARTED, 20000L);
+        kieContainerResource.setScanner(kieScannerResource);
+        ServiceResponse<KieContainerResource> createResponse = kieServer.createContainer(containerId, kieContainerResource);
+        Assertions.assertThat(createResponse.getType()).isEqualTo(ServiceResponse.ResponseType.FAILURE);
+    }
+
+    @Test
+    public void testCreateContainerValidationModeConflict() {
+        String containerId = "container-to-create";
+
+        createEmptyKjar(containerId);
+
+        ReleaseId testReleaseId = new ReleaseId(GROUP_ID, containerId, getVersion(mode.equals(KieServerMode.DEVELOPMENT) ? KieServerMode.REGULAR : KieServerMode.DEVELOPMENT));
+
+        // create the container (provide scanner info as well)
+        KieContainerResource kieContainerResource = new KieContainerResource(containerId, testReleaseId);
+        KieScannerResource kieScannerResource = new KieScannerResource(KieScannerStatus.STARTED, 20000L);
+        kieContainerResource.setScanner(kieScannerResource);
+        ServiceResponse<KieContainerResource> createResponse = kieServer.createContainer(containerId, kieContainerResource);
+        Assertions.assertThat(createResponse.getType()).isEqualTo(ServiceResponse.ResponseType.FAILURE);
+    }
+
+    @Test
+    public void testUpdateContainer() {
+        KieServerExtension extension = mock(KieServerExtension.class);
+        when(extension.isUpdateContainerAllowed(any(), any(), any())).thenReturn(true);
+        extensions.add(extension);
+
+        String containerId = "container-to-update";
+
+        startContainerToUpdate(containerId);
+
+        ServiceResponse<ReleaseId> updateResponse = kieServer.updateContainerReleaseId(containerId, new ReleaseId(releaseId), true);
+        Assertions.assertThat(updateResponse.getType()).isEqualTo(ServiceResponse.ResponseType.SUCCESS);
+
+        verify(extension).isUpdateContainerAllowed(anyString(), any(), any());
+        verify(extension).updateContainer(any(), any(), any());
+
+        kieServer.disposeContainer(containerId);
+    }
+
+    @Test
+    public void testUpdateContainerWithExtensionNotAllowing() {
+        KieServerExtension extension = mock(KieServerExtension.class);
+        when(extension.isUpdateContainerAllowed(any(), any(), any())).thenReturn(false);
+        extensions.add(extension);
+
+        String containerId = "container-to-update";
+
+        startContainerToUpdate(containerId);
+
+        ServiceResponse<ReleaseId> updateResponse = kieServer.updateContainerReleaseId(containerId, new ReleaseId(this.releaseId), true);
+        Assertions.assertThat(updateResponse.getType()).isEqualTo(ServiceResponse.ResponseType.FAILURE);
+
+        verify(extension).isUpdateContainerAllowed(anyString(), any(), any());
+        verify(extension, never()).updateContainer(any(), any(), any());
+
+        kieServer.disposeContainer(containerId);
+    }
+
+    @Test
+    public void testUpdateContainerWithModeConflict() {
+        KieServerExtension extension = mock(KieServerExtension.class);
+        when(extension.isUpdateContainerAllowed(any(), any(), any())).thenReturn(false);
+        extensions.add(extension);
+
+        String containerId = "container-to-update";
+
+        startContainerToUpdate(containerId);
+
+        ReleaseId updateReleaseId = new ReleaseId(GROUP_ID, containerId, getVersion(mode.equals(KieServerMode.DEVELOPMENT) ? KieServerMode.REGULAR : KieServerMode.DEVELOPMENT));
+
+        ServiceResponse<ReleaseId> updateResponse = kieServer.updateContainerReleaseId(containerId, updateReleaseId, true);
+        Assertions.assertThat(updateResponse.getType()).isEqualTo(ServiceResponse.ResponseType.FAILURE);
+
+        verify(extension, never()).isUpdateContainerAllowed(anyString(), any(), any());
+        verify(extension, never()).updateContainer(any(), any(), any());
+
+        kieServer.disposeContainer(containerId);
+    }
+
+    @Test
+    public void testUpdateContainerWithNullReleaseID() {
+        KieServerExtension extension = mock(KieServerExtension.class);
+        when(extension.isUpdateContainerAllowed(any(), any(), any())).thenReturn(false);
+        extensions.add(extension);
+
+        String containerId = "container-to-update";
+
+        startContainerToUpdate(containerId);
+
+        ServiceResponse<ReleaseId> updateResponse = kieServer.updateContainerReleaseId(containerId, null, true);
+        Assertions.assertThat(updateResponse.getType()).isEqualTo(ServiceResponse.ResponseType.FAILURE);
+
+        verify(extension, never()).isUpdateContainerAllowed(anyString(), any(), any());
+        verify(extension, never()).updateContainer(any(), any(), any());
+
+        kieServer.disposeContainer(containerId);
+    }
+
+    private void startContainerToUpdate(String containerId) {
+        createEmptyKjar(containerId);
+
+        ReleaseId releaseId = new ReleaseId(this.releaseId);
+
+        // create the container (provide scanner info as well)
+        KieContainerResource kieContainerResource = new KieContainerResource(containerId, releaseId);
         KieScannerResource kieScannerResource = new KieScannerResource(KieScannerStatus.STARTED, 20000L);
         kieContainerResource.setScanner(kieScannerResource);
         ServiceResponse<KieContainerResource> createResponse = kieServer.createContainer(containerId, kieContainerResource);
@@ -456,7 +626,46 @@ public class KieServerImplTest {
         }
     }
 
-    private void assertReleaseIds(String containerId, ReleaseId configuredReleaseId, ReleaseId resolvedReleaseId, long timeoutMillis) throws InterruptedException {
+    protected KieServerImpl delayedKieServer(CountDownLatch latch, CountDownLatch startedlatch) {
+        KieServerImpl server = new KieServerImpl(new KieServerStateFileRepository(REPOSITORY_DIR)) {
+
+            @Override
+            public void markAsReady() {
+                super.markAsReady();
+                startedlatch.countDown();
+            }
+
+            @Override
+            protected KieServerController getController() {
+                return new DefaultRestControllerImpl(getServerRegistry()) {
+                    @Override
+                    public KieServerSetup connect(KieServerInfo serverInfo) {
+                        try {
+                            if (latch.await(10, TimeUnit.MILLISECONDS)) {
+                                return new KieServerSetup();
+                            }
+                            throw new KieControllerNotConnectedException("Unable to connect to any controller");
+                        } catch (InterruptedException e) {
+                            throw new KieControllerNotConnectedException("Unable to connect to any controller");
+                        }
+                    }
+
+                };
+            }
+
+        };
+        server.init();
+        return server;
+    }
+
+    protected void assertForbiddenResponse(ServiceResponse<?> forbidden) {
+        assertNotNull(forbidden);
+
+        assertEquals(KieServiceResponse.ResponseType.FAILURE, forbidden.getType());
+        assertEquals("KIE Server management api is disabled", forbidden.getMsg());
+    }
+
+    protected void assertReleaseIds(String containerId, ReleaseId configuredReleaseId, ReleaseId resolvedReleaseId, long timeoutMillis) throws InterruptedException {
         long timeSpentWaiting = 0;
         while (timeSpentWaiting < timeoutMillis) {
             ServiceResponse<KieContainerResourceList> listResponse = kieServer.listContainers(KieContainerResourceFilter.ACCEPT_ALL);
@@ -472,24 +681,25 @@ public class KieServerImplTest {
             timeSpentWaiting += 200L;
         }
         Assertions.fail("Waiting too long for container " + containerId + " to have expected releaseIds updated! " +
-                "expected: releaseId=" + configuredReleaseId + ", resolvedReleaseId=" + resolvedReleaseId);
+                                "expected: releaseId=" + configuredReleaseId + ", resolvedReleaseId=" + resolvedReleaseId);
     }
 
 
-    private void createEmptyKjar(String artifactId) {
-        createEmptyKjar(artifactId, DEFAULT_VERSION);
+    protected void createEmptyKjar(String artifactId) {
+        createEmptyKjar(artifactId, testVersion);
     }
-    private void createEmptyKjar(String artifactId, String version) {
+
+    protected void createEmptyKjar(String artifactId, String version) {
         // create empty kjar; content does not matter
         KieServices kieServices = KieServices.Factory.get();
         KieFileSystem kfs = kieServices.newKieFileSystem();
         releaseId = kieServices.newReleaseId(GROUP_ID, artifactId, version);
-        KieModule kieModule = kieServices.newKieBuilder( kfs ).buildAll().getKieModule();
-        KieMavenRepository.getKieMavenRepository().installArtifact( releaseId, (InternalKieModule)kieModule, createPomFile( artifactId, version ) );
+        KieModule kieModule = kieServices.newKieBuilder(kfs ).buildAll().getKieModule();
+        KieMavenRepository.getKieMavenRepository().installArtifact(releaseId, (InternalKieModule)kieModule, createPomFile(artifactId, version ) );
         kieServices.getRepository().addKieModule(kieModule);
     }
 
-    private File createPomFile(String artifactId, String version) {
+    protected File createPomFile(String artifactId, String version) {
         String pomContent = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
                 "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
                 "         xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd\">\n" +
@@ -507,45 +717,6 @@ public class KieServerImplTest {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-    }
-    
-    private KieServerImpl delayedKieServer(CountDownLatch latch, CountDownLatch startedlatch) {
-        KieServerImpl server = new KieServerImpl(new KieServerStateFileRepository(REPOSITORY_DIR)) {
-
-            @Override
-            public void markAsReady() {
-                super.markAsReady();
-                startedlatch.countDown();
-            }
-
-            @Override
-            protected KieServerController getController() {
-                return new DefaultRestControllerImpl(getServerRegistry()) {                    
-                    @Override
-                    public KieServerSetup connect(KieServerInfo serverInfo) {
-                        try {
-                            if (latch.await(10, TimeUnit.MILLISECONDS)) {
-                                return new KieServerSetup();
-                            }
-                            throw new KieControllerNotConnectedException("Unable to connect to any controller");
-                        } catch (InterruptedException e) {
-                            throw new KieControllerNotConnectedException("Unable to connect to any controller");
-                        }
-                    }
-                    
-                };
-            }
-            
-        };
-        server.init();
-        return server;
-    }
-    
-    private void assertForbiddenResponse(ServiceResponse<?> forbidden) {        
-        assertNotNull(forbidden);
-        
-        assertEquals(ResponseType.FAILURE, forbidden.getType());
-        assertEquals("KIE Server management api is disabled", forbidden.getMsg());
     }
 
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/AbstractKieServerImplTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/AbstractKieServerImplTest.java
@@ -115,7 +115,7 @@ public abstract class AbstractKieServerImplTest {
 
         origServerId = KieServerEnvironment.getServerId();
         System.setProperty(KieServerConstants.KIE_SERVER_MODE, mode.name());
-        System.setProperty("org.kie.server.id", KIE_SERVER_ID);
+        System.setProperty(KieServerConstants.KIE_SERVER_ID, KIE_SERVER_ID);
         KieServerEnvironment.setServerId(KIE_SERVER_ID);
 
 

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerImplDevelopmentModeTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerImplDevelopmentModeTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.services.impl;
+
+import org.junit.runner.RunWith;
+import org.kie.server.api.model.KieServerMode;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KieServerImplDevelopmentModeTest extends AbstractKieServerImplTest {
+
+    @Override
+    KieServerMode getTestMode() {
+        return KieServerMode.DEVELOPMENT;
+    }
+
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerImplRegularModeTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerImplRegularModeTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.services.impl;
+
+import org.junit.runner.RunWith;
+import org.kie.server.api.model.KieServerMode;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KieServerImplRegularModeTest extends AbstractKieServerImplTest {
+
+    @Override
+    KieServerMode getTestMode() {
+        return KieServerMode.REGULAR;
+    }
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
@@ -366,7 +366,6 @@ public class JbpmKieServerExtension implements KieServerExtension {
                 return;
             }
 
-            
             boolean hasStatefulSession = false;
             boolean hasDefaultSession = false;
             // let validate if they are any stateful sessions defined and in case there are not, skip this container
@@ -521,10 +520,11 @@ public class JbpmKieServerExtension implements KieServerExtension {
         }
 
         // Checking if we need to abort the existing process instances before disposing container, by default it should be false
+        Boolean isSnapshot = KieServerUtils.isSnapshot(kieContainerInstance.getKieContainer().getReleaseId());
         Boolean abortInstances = (Boolean) parameters.getOrDefault(KieServerConstants.KIE_SERVER_PARAM_RESET_BEFORE_UPDATE, Boolean.FALSE);
 
         KModuleDeploymentUnit unit = (KModuleDeploymentUnit) deploymentService.getDeployedUnit(id).getDeploymentUnit();
-        deploymentService.undeploy(new CustomIdKmoduleDeploymentUnit(id, unit.getGroupId(), unit.getArtifactId(), unit.getVersion()), abortInstances);
+        deploymentService.undeploy(new CustomIdKmoduleDeploymentUnit(id, unit.getGroupId(), unit.getArtifactId(), unit.getVersion()), isSnapshot && abortInstances);
 
         // remove any query result mappers for container
         List<String> addedMappers = containerMappers.get(id);

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/test/java/org/kie/server/services/jbpm/JbpmKieServerExtensionTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/test/java/org/kie/server/services/jbpm/JbpmKieServerExtensionTest.java
@@ -1,49 +1,285 @@
 /*
- * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.kie.server.services.jbpm;
 
-import org.jbpm.services.api.query.QueryService;
-import org.junit.Test;
-import org.kie.server.api.KieServerEnvironment;
-import org.kie.server.services.api.KieServerRegistry;
-import org.kie.server.services.impl.KieServerRegistryImpl;
-import org.kie.server.services.impl.storage.file.KieServerStateFileRepository;
-import org.mockito.Mockito;
-
-import static org.mockito.Mockito.*;
-
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
+import org.apache.commons.io.IOUtils;
+import org.appformer.maven.support.DependencyFilter;
+import org.drools.compiler.kie.builder.impl.InternalKieModule;
+import org.drools.compiler.kie.builder.impl.KieServicesImpl;
+import org.drools.core.impl.InternalKieContainer;
+import org.jbpm.kie.services.impl.DeployedUnitImpl;
+import org.jbpm.services.api.DeploymentService;
+import org.jbpm.services.api.RuntimeDataService;
+import org.jbpm.services.api.model.DeployedUnit;
+import org.jbpm.services.api.model.DeploymentUnit;
+import org.jbpm.services.api.model.ProcessInstanceDesc;
+import org.jbpm.services.api.query.QueryService;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.KieModule;
+import org.kie.scanner.KieMavenRepository;
+import org.kie.scanner.KieModuleMetaData;
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.KieServerEnvironment;
+import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.api.model.Message;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.services.api.KieServerRegistry;
+import org.kie.server.services.impl.KieContainerInstanceImpl;
+import org.kie.server.services.impl.KieServerImpl;
+import org.kie.server.services.impl.KieServerRegistryImpl;
+import org.kie.server.services.impl.storage.file.KieServerStateFileRepository;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
 public class JbpmKieServerExtensionTest {
+
+    private static final String RESOURCES = "src/main/resources/";
+
+    private static final String CONTAINER_ID = "my-container";
+
+    private static final String GROUP_ID = "org.kie.server.test";
+    private static final String ARTIFACT_ID = "my-test-artifact";
+    private static final String VERSION = "1.0.0.Final";
+    private static final String VERSION_SNAPSHOT = "1.0.0-SNAPSHOT";
+
+    private boolean deployed = false;
+
+    @Mock
+    private DeploymentService deploymentService;
+
+    @Mock
+    private RuntimeDataService runtimeDataService;
+
+    @Mock
+    private QueryService queryService;
+
+    @Mock
+    private KieServerImpl kieServer;
+
+    private KieServicesImpl kieServices;
+
+    private KieServerRegistry context;
+
+    private JbpmKieServerExtension extension;
+
+    private InternalKieContainer kieContainer;
+
+    private DeploymentUnit deploymentUnit;
+
+    private DeployedUnit deployedUnit;
+
+    @Before
+    public void init() {
+        KieServerEnvironment.setServerId(UUID.randomUUID().toString());
+
+        context = new KieServerRegistryImpl();
+        context.registerStateRepository(new KieServerStateFileRepository(new File("target")));
+
+        kieServices = (KieServicesImpl) KieServices.Factory.get();
+
+        extension = new JbpmKieServerExtension() {
+            {
+                this.deploymentService = JbpmKieServerExtensionTest.this.deploymentService;
+                this.runtimeDataService = JbpmKieServerExtensionTest.this.runtimeDataService;
+            }
+        };
+
+        when(deploymentService.isDeployed(anyString())).thenAnswer((Answer<Boolean>) invocation -> deployed);
+        doAnswer(invocation -> {
+            deployed = false;
+            return null;
+        }).when(deploymentService).undeploy(any(), anyBoolean());
+        doAnswer(invocation -> {
+            deployed = false;
+            return null;
+        }).when(deploymentService).undeploy(any());
+        doAnswer((Answer<Void>) invocation -> {
+            deploymentUnit = (DeploymentUnit) invocation.getArguments()[0];
+            deployed = true;
+            return null;
+        }).when(deploymentService).deploy(any());
+
+        when(deploymentService.getDeployedUnit(anyString())).thenAnswer((Answer<DeployedUnit>) invocation -> {
+            deployedUnit = new DeployedUnitImpl(deploymentUnit);
+            return deployedUnit;
+        });
+        extension.setQueryService(queryService);
+        extension.setContext(context);
+    }
+
+    @After
+    public void clear() {
+        kieServices.nullAllContainerIds();
+    }
+
+    @Test
+    public void testCreateContainer() throws IOException {
+        testDeployContainer(VERSION);
+    }
+
+    @Test
+    public void testCreateSNAPSHOTContainer() throws IOException {
+        testDeployContainer(VERSION_SNAPSHOT);
+    }
+
+    @Test
+    public void testIsUpdateAllowedSNAPSHOT() throws IOException {
+        testDeployContainer(VERSION_SNAPSHOT);
+
+        assertTrue(extension.isUpdateContainerAllowed(CONTAINER_ID, new KieContainerInstanceImpl(CONTAINER_ID, KieContainerStatus.STARTED, kieContainer), new HashMap<>()));
+    }
+
+    @Test
+    public void testIsUpdateAllowedWithoutProcessInstances() throws IOException {
+        testIsUpdateAllowed(false);
+    }
+
+    @Test
+    public void testIsUpdateAllowedWithProcessInstances() throws IOException {
+        testIsUpdateAllowed(true);
+    }
 
     @Test
     public void testLoadDefaultQueryDefinitions() {
-        KieServerEnvironment.setServerId(UUID.randomUUID().toString());
-        QueryService queryService = Mockito.mock(QueryService.class);
-        
-        KieServerRegistry context = new KieServerRegistryImpl();
-        context.registerStateRepository(new KieServerStateFileRepository(new File("target")));
-        
-        JbpmKieServerExtension extension = new JbpmKieServerExtension();
-        extension.setQueryService(queryService);
-        extension.setContext(context);
-        
         extension.registerDefaultQueryDefinitions();
-        
+
         verify(queryService, times(10)).replaceQuery(any());
+    }
+
+    @Test
+    public void testUpdateContainer() throws IOException {
+        testUpdateContainer(VERSION, false, false);
+    }
+
+    @Test
+    public void testUpdateContainerWithForcedCleanup() throws IOException {
+        testUpdateContainer(VERSION, true, false);
+    }
+
+    @Test
+    public void testUpdateSNAPSHOTContainer() throws IOException {
+        testUpdateContainer(VERSION_SNAPSHOT, false, false);
+    }
+
+    @Test
+    public void testUpdateSNAPSHOTContainerWithForcedCeanup() throws IOException {
+        testUpdateContainer(VERSION_SNAPSHOT, true, true);
+    }
+
+    private void testUpdateContainer(String version, boolean cleanup, boolean expectedCleanup) throws IOException {
+        testDeployContainer(version);
+
+        KieModuleMetaData metaData = KieModuleMetaData.Factory.newKieModuleMetaData(new ReleaseId(GROUP_ID, ARTIFACT_ID, version), DependencyFilter.COMPILE_FILTER);
+        List<Message> messages = new ArrayList<>();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put(KieServerConstants.KIE_SERVER_PARAM_MODULE_METADATA, metaData);
+        params.put(KieServerConstants.KIE_SERVER_PARAM_MESSAGES, messages);
+        params.put(KieServerConstants.KIE_SERVER_PARAM_RESET_BEFORE_UPDATE, cleanup);
+
+        extension.updateContainer(CONTAINER_ID, new KieContainerInstanceImpl(CONTAINER_ID, KieContainerStatus.STARTED, kieContainer), params);
+
+        verify(deploymentService).undeploy(any(), eq(expectedCleanup));
+        verify(deploymentService, times(2)).deploy(any());
+    }
+
+    private void testDeployContainer(String version) throws IOException {
+        createEmptyKjar(GROUP_ID, ARTIFACT_ID, version);
+
+        ReleaseId releaseId = new ReleaseId(GROUP_ID, ARTIFACT_ID, version);
+
+        kieContainer = (InternalKieContainer) kieServices.newKieContainer(CONTAINER_ID, releaseId);
+        KieContainerInstanceImpl containerInstance = new KieContainerInstanceImpl(CONTAINER_ID, KieContainerStatus.STARTED, kieContainer);
+
+        KieModuleMetaData metaData = KieModuleMetaData.Factory.newKieModuleMetaData(releaseId, DependencyFilter.COMPILE_FILTER);
+
+        List<Message> messages = new ArrayList<>();
+
+        Map<String, Object> params = new HashMap<>();
+        params.put(KieServerConstants.KIE_SERVER_PARAM_MODULE_METADATA, metaData);
+        params.put(KieServerConstants.KIE_SERVER_PARAM_MESSAGES, messages);
+
+        extension.createContainer(CONTAINER_ID, containerInstance, params);
+
+        verify(deploymentService).deploy(any());
+    }
+
+    private void testIsUpdateAllowed(boolean existingInstances) throws IOException {
+        List<ProcessInstanceDesc> activeProcesses = new ArrayList<>();
+        if (existingInstances) {
+            activeProcesses.add(mock(ProcessInstanceDesc.class));
+            activeProcesses.add(mock(ProcessInstanceDesc.class));
+        }
+
+        when(runtimeDataService.getProcessInstancesByDeploymentId(anyString(), anyList(), any())).thenReturn(activeProcesses);
+
+        testDeployContainer(VERSION);
+
+        if (existingInstances) {
+            assertFalse(extension.isUpdateContainerAllowed(CONTAINER_ID, new KieContainerInstanceImpl(CONTAINER_ID, KieContainerStatus.STARTED, kieContainer), new HashMap<>()));
+        } else {
+            assertTrue(extension.isUpdateContainerAllowed(CONTAINER_ID, new KieContainerInstanceImpl(CONTAINER_ID, KieContainerStatus.STARTED, kieContainer), new HashMap<>()));
+        }
+    }
+
+    private void createEmptyKjar(String groupId, String artifactId, String version) throws IOException {
+        // create empty kjar; content does not matter
+        KieServices kieServices = KieServices.Factory.get();
+        KieFileSystem kfs = kieServices.newKieFileSystem();
+        org.kie.api.builder.ReleaseId releaseId = kieServices.newReleaseId(groupId, artifactId, version);
+
+        kfs.generateAndWritePomXML(releaseId);
+
+        String processContent = IOUtils.toString(this.getClass().getResourceAsStream("/processes/hiring.bpmn2"), Charset.defaultCharset());
+
+        kfs.write(RESOURCES + "hiring.bpmn2", processContent);
+
+        KieModule kieModule = kieServices.newKieBuilder(kfs).buildAll().getKieModule();
+        byte[] pom = kfs.read("pom.xml");
+        byte[] jar = ((InternalKieModule) kieModule).getBytes();
+        KieMavenRepository.getKieMavenRepository().installArtifact(releaseId, jar, pom);
     }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/test/resources/processes/hiring.bpmn2
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/test/resources/processes/hiring.bpmn2
@@ -1,0 +1,565 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_k9I54LzKEeKT6qCaqCIbfQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_nameItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_ageItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="_twitterItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_offeringItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="_skillsItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_mailItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="_tech_scoreItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="_hr_scoreItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="_signedItem" structureRef="Boolean"/>
+  <bpmn2:itemDefinition id="__6998ACD3-21DC-421D-AC04-BA7D375B0B21_GroupIdInputItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__6998ACD3-21DC-421D-AC04-BA7D375B0B21_CommentInputItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__6998ACD3-21DC-421D-AC04-BA7D375B0B21_in_nameInputItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_nameOutputItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_ageOutputItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_mailOutputItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_scoreOutputItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__FADFBC55-C369-4F58-B04B-3AD20337F215_in_nameInputItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__FADFBC55-C369-4F58-B04B-3AD20337F215_in_ageInputItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__FADFBC55-C369-4F58-B04B-3AD20337F215_in_mailInputItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__FADFBC55-C369-4F58-B04B-3AD20337F215_GroupIdInputItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__FADFBC55-C369-4F58-B04B-3AD20337F215_CommentInputItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__FADFBC55-C369-4F58-B04B-3AD20337F215_out_skillsOutputItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__FADFBC55-C369-4F58-B04B-3AD20337F215_out_scoreOutputItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__FADFBC55-C369-4F58-B04B-3AD20337F215_out_twitterOutputItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__12435ADA-3C57-414C-8DDD-5D236E462BD8_in_tech_scoreInputItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__12435ADA-3C57-414C-8DDD-5D236E462BD8_in_hr_scoreInputItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__12435ADA-3C57-414C-8DDD-5D236E462BD8_GroupIdInputItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__12435ADA-3C57-414C-8DDD-5D236E462BD8_CommentInputItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__12435ADA-3C57-414C-8DDD-5D236E462BD8_out_offeringOutputItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__D9B752FE-4900-4172-B8C9-31CC838E18A5_in_offeringInputItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__D9B752FE-4900-4172-B8C9-31CC838E18A5_in_nameInputItem" structureRef="String"/>
+  <bpmn2:itemDefinition id="__D9B752FE-4900-4172-B8C9-31CC838E18A5_GroupIdInputItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__D9B752FE-4900-4172-B8C9-31CC838E18A5_CommentInputItem" structureRef="Object"/>
+  <bpmn2:itemDefinition id="__D9B752FE-4900-4172-B8C9-31CC838E18A5_out_signedOutputItem" structureRef="Boolean"/>
+  <bpmn2:process id="hiring" drools:packageName="HR.src.main.resources.kbase" drools:version="1" name="Hiring a Developer" isExecutable="true">
+    <bpmn2:property id="name" itemSubjectRef="_nameItem"/>
+    <bpmn2:property id="age" itemSubjectRef="_ageItem"/>
+    <bpmn2:property id="twitter" itemSubjectRef="_twitterItem"/>
+    <bpmn2:property id="offering" itemSubjectRef="_offeringItem"/>
+    <bpmn2:property id="skills" itemSubjectRef="_skillsItem"/>
+    <bpmn2:property id="mail" itemSubjectRef="_mailItem"/>
+    <bpmn2:property id="tech_score" itemSubjectRef="_tech_scoreItem"/>
+    <bpmn2:property id="hr_score" itemSubjectRef="_hr_scoreItem"/>
+    <bpmn2:property id="signed" itemSubjectRef="_signedItem"/>
+    <bpmn2:startEvent id="_76910DD0-5F45-421F-B1AC-E6507CC1C26C" drools:bgcolor="#9acd32" drools:selectable="true" name="">
+      <bpmn2:outgoing>_416C6A67-B7EC-400B-9F2B-0F53B3FEDEB4</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:userTask id="_6998ACD3-21DC-421D-AC04-BA7D375B0B21" drools:selectable="true" drools:taskName="HRInterview" drools:scriptFormat="http://www.java.com/java" name="Updated HR Interview">
+      <bpmn2:incoming>_416C6A67-B7EC-400B-9F2B-0F53B3FEDEB4</bpmn2:incoming>
+      <bpmn2:outgoing>_202CE0F7-63B3-4A5D-B5A9-9C9C5EB87468</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_k9LWILzKEeKT6qCaqCIbfQ">
+        <bpmn2:dataInput id="_6998ACD3-21DC-421D-AC04-BA7D375B0B21_TaskNameInput" name="TaskName"/>
+        <bpmn2:dataInput id="_6998ACD3-21DC-421D-AC04-BA7D375B0B21_GroupIdInput" drools:dtype="Object" itemSubjectRef="__6998ACD3-21DC-421D-AC04-BA7D375B0B21_GroupIdInputItem" name="GroupId"/>
+        <bpmn2:dataInput id="_6998ACD3-21DC-421D-AC04-BA7D375B0B21_CommentInput" drools:dtype="Object" itemSubjectRef="__6998ACD3-21DC-421D-AC04-BA7D375B0B21_CommentInputItem" name="Comment"/>
+        <bpmn2:dataInput id="_6998ACD3-21DC-421D-AC04-BA7D375B0B21_in_nameInput" drools:dtype="String" itemSubjectRef="__6998ACD3-21DC-421D-AC04-BA7D375B0B21_in_nameInputItem" name="in_name"/>
+        <bpmn2:dataOutput id="_6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_nameOutput" drools:dtype="String" itemSubjectRef="__6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_nameOutputItem" name="out_name"/>
+        <bpmn2:dataOutput id="_6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_ageOutput" drools:dtype="Integer" itemSubjectRef="__6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_ageOutputItem" name="out_age"/>
+        <bpmn2:dataOutput id="_6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_mailOutput" drools:dtype="String" itemSubjectRef="__6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_mailOutputItem" name="out_mail"/>
+        <bpmn2:dataOutput id="_6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_scoreOutput" drools:dtype="Integer" itemSubjectRef="__6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_scoreOutputItem" name="out_score"/>
+        <bpmn2:inputSet id="_k9LWIbzKEeKT6qCaqCIbfQ">
+          <bpmn2:dataInputRefs>_6998ACD3-21DC-421D-AC04-BA7D375B0B21_GroupIdInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_6998ACD3-21DC-421D-AC04-BA7D375B0B21_CommentInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_6998ACD3-21DC-421D-AC04-BA7D375B0B21_in_nameInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_6998ACD3-21DC-421D-AC04-BA7D375B0B21_TaskNameInput</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_k9LWIrzKEeKT6qCaqCIbfQ">
+          <bpmn2:dataOutputRefs>_6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_nameOutput</bpmn2:dataOutputRefs>
+          <bpmn2:dataOutputRefs>_6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_ageOutput</bpmn2:dataOutputRefs>
+          <bpmn2:dataOutputRefs>_6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_mailOutput</bpmn2:dataOutputRefs>
+          <bpmn2:dataOutputRefs>_6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_scoreOutput</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_k9L9MLzKEeKT6qCaqCIbfQ">
+        <bpmn2:targetRef>_6998ACD3-21DC-421D-AC04-BA7D375B0B21_TaskNameInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_k9L9MbzKEeKT6qCaqCIbfQ">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_k9L9MrzKEeKT6qCaqCIbfQ">HRInterview</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_k9L9M7zKEeKT6qCaqCIbfQ">_6998ACD3-21DC-421D-AC04-BA7D375B0B21_TaskNameInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_k9L9NLzKEeKT6qCaqCIbfQ">
+        <bpmn2:sourceRef>name</bpmn2:sourceRef>
+        <bpmn2:targetRef>_6998ACD3-21DC-421D-AC04-BA7D375B0B21_in_nameInput</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_k9L9NbzKEeKT6qCaqCIbfQ">
+        <bpmn2:targetRef>_6998ACD3-21DC-421D-AC04-BA7D375B0B21_GroupIdInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_k9L9NrzKEeKT6qCaqCIbfQ">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_k9L9N7zKEeKT6qCaqCIbfQ">HR</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_k9L9OLzKEeKT6qCaqCIbfQ">_6998ACD3-21DC-421D-AC04-BA7D375B0B21_GroupIdInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_k9L9ObzKEeKT6qCaqCIbfQ">
+        <bpmn2:targetRef>_6998ACD3-21DC-421D-AC04-BA7D375B0B21_CommentInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_k9L9OrzKEeKT6qCaqCIbfQ">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_k9L9O7zKEeKT6qCaqCIbfQ"><![CDATA[Candidate: #{name}]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_k9L9PLzKEeKT6qCaqCIbfQ">_6998ACD3-21DC-421D-AC04-BA7D375B0B21_CommentInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation id="_k9L9PbzKEeKT6qCaqCIbfQ">
+        <bpmn2:sourceRef>_6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_ageOutput</bpmn2:sourceRef>
+        <bpmn2:targetRef>age</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+      <bpmn2:dataOutputAssociation id="_k9L9PrzKEeKT6qCaqCIbfQ">
+        <bpmn2:sourceRef>_6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_mailOutput</bpmn2:sourceRef>
+        <bpmn2:targetRef>mail</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+      <bpmn2:dataOutputAssociation id="_k9L9P7zKEeKT6qCaqCIbfQ">
+        <bpmn2:sourceRef>_6998ACD3-21DC-421D-AC04-BA7D375B0B21_out_scoreOutput</bpmn2:sourceRef>
+        <bpmn2:targetRef>hr_score</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="_416C6A67-B7EC-400B-9F2B-0F53B3FEDEB4" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_76910DD0-5F45-421F-B1AC-E6507CC1C26C" targetRef="_6998ACD3-21DC-421D-AC04-BA7D375B0B21"/>
+    <bpmn2:userTask id="_FADFBC55-C369-4F58-B04B-3AD20337F215" drools:selectable="true" drools:taskName="TechInterview" drools:scriptFormat="http://www.java.com/java" name="Tech Interview">
+      <bpmn2:incoming>_202CE0F7-63B3-4A5D-B5A9-9C9C5EB87468</bpmn2:incoming>
+      <bpmn2:outgoing>_4976D9C3-B97A-48F7-B794-32307FF855D6</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_k9L9QLzKEeKT6qCaqCIbfQ">
+        <bpmn2:dataInput id="_FADFBC55-C369-4F58-B04B-3AD20337F215_TaskNameInput" name="TaskName"/>
+        <bpmn2:dataInput id="_FADFBC55-C369-4F58-B04B-3AD20337F215_in_nameInput" drools:dtype="String" itemSubjectRef="__FADFBC55-C369-4F58-B04B-3AD20337F215_in_nameInputItem" name="in_name"/>
+        <bpmn2:dataInput id="_FADFBC55-C369-4F58-B04B-3AD20337F215_in_ageInput" drools:dtype="Integer" itemSubjectRef="__FADFBC55-C369-4F58-B04B-3AD20337F215_in_ageInputItem" name="in_age"/>
+        <bpmn2:dataInput id="_FADFBC55-C369-4F58-B04B-3AD20337F215_in_mailInput" drools:dtype="String" itemSubjectRef="__FADFBC55-C369-4F58-B04B-3AD20337F215_in_mailInputItem" name="in_mail"/>
+        <bpmn2:dataInput id="_FADFBC55-C369-4F58-B04B-3AD20337F215_GroupIdInput" drools:dtype="Object" itemSubjectRef="__FADFBC55-C369-4F58-B04B-3AD20337F215_GroupIdInputItem" name="GroupId"/>
+        <bpmn2:dataInput id="_FADFBC55-C369-4F58-B04B-3AD20337F215_CommentInput" drools:dtype="Object" itemSubjectRef="__FADFBC55-C369-4F58-B04B-3AD20337F215_CommentInputItem" name="Comment"/>
+        <bpmn2:dataOutput id="_FADFBC55-C369-4F58-B04B-3AD20337F215_out_skillsOutput" drools:dtype="String" itemSubjectRef="__FADFBC55-C369-4F58-B04B-3AD20337F215_out_skillsOutputItem" name="out_skills"/>
+        <bpmn2:dataOutput id="_FADFBC55-C369-4F58-B04B-3AD20337F215_out_scoreOutput" drools:dtype="Integer" itemSubjectRef="__FADFBC55-C369-4F58-B04B-3AD20337F215_out_scoreOutputItem" name="out_score"/>
+        <bpmn2:dataOutput id="_FADFBC55-C369-4F58-B04B-3AD20337F215_out_twitterOutput" drools:dtype="String" itemSubjectRef="__FADFBC55-C369-4F58-B04B-3AD20337F215_out_twitterOutputItem" name="out_twitter"/>
+        <bpmn2:inputSet id="_k9L9QbzKEeKT6qCaqCIbfQ">
+          <bpmn2:dataInputRefs>_FADFBC55-C369-4F58-B04B-3AD20337F215_in_nameInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_FADFBC55-C369-4F58-B04B-3AD20337F215_in_ageInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_FADFBC55-C369-4F58-B04B-3AD20337F215_in_mailInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_FADFBC55-C369-4F58-B04B-3AD20337F215_GroupIdInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_FADFBC55-C369-4F58-B04B-3AD20337F215_CommentInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_FADFBC55-C369-4F58-B04B-3AD20337F215_TaskNameInput</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_k9L9QrzKEeKT6qCaqCIbfQ">
+          <bpmn2:dataOutputRefs>_FADFBC55-C369-4F58-B04B-3AD20337F215_out_skillsOutput</bpmn2:dataOutputRefs>
+          <bpmn2:dataOutputRefs>_FADFBC55-C369-4F58-B04B-3AD20337F215_out_scoreOutput</bpmn2:dataOutputRefs>
+          <bpmn2:dataOutputRefs>_FADFBC55-C369-4F58-B04B-3AD20337F215_out_twitterOutput</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_k9L9Q7zKEeKT6qCaqCIbfQ">
+        <bpmn2:targetRef>_FADFBC55-C369-4F58-B04B-3AD20337F215_TaskNameInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_k9L9RLzKEeKT6qCaqCIbfQ">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_k9L9RbzKEeKT6qCaqCIbfQ">TechInterview</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_k9L9RrzKEeKT6qCaqCIbfQ">_FADFBC55-C369-4F58-B04B-3AD20337F215_TaskNameInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_k9L9R7zKEeKT6qCaqCIbfQ">
+        <bpmn2:sourceRef>name</bpmn2:sourceRef>
+        <bpmn2:targetRef>_FADFBC55-C369-4F58-B04B-3AD20337F215_in_nameInput</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_k9L9SLzKEeKT6qCaqCIbfQ">
+        <bpmn2:sourceRef>age</bpmn2:sourceRef>
+        <bpmn2:targetRef>_FADFBC55-C369-4F58-B04B-3AD20337F215_in_ageInput</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_k9L9SbzKEeKT6qCaqCIbfQ">
+        <bpmn2:sourceRef>mail</bpmn2:sourceRef>
+        <bpmn2:targetRef>_FADFBC55-C369-4F58-B04B-3AD20337F215_in_mailInput</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_k9L9SrzKEeKT6qCaqCIbfQ">
+        <bpmn2:targetRef>_FADFBC55-C369-4F58-B04B-3AD20337F215_GroupIdInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_k9L9S7zKEeKT6qCaqCIbfQ">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_k9L9TLzKEeKT6qCaqCIbfQ">IT</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_k9L9TbzKEeKT6qCaqCIbfQ">_FADFBC55-C369-4F58-B04B-3AD20337F215_GroupIdInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_k9L9TrzKEeKT6qCaqCIbfQ">
+        <bpmn2:targetRef>_FADFBC55-C369-4F58-B04B-3AD20337F215_CommentInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_k9L9T7zKEeKT6qCaqCIbfQ">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_k9L9ULzKEeKT6qCaqCIbfQ"><![CDATA[Candidate: #{name}]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_k9L9UbzKEeKT6qCaqCIbfQ">_FADFBC55-C369-4F58-B04B-3AD20337F215_CommentInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation id="_k9L9UrzKEeKT6qCaqCIbfQ">
+        <bpmn2:sourceRef>_FADFBC55-C369-4F58-B04B-3AD20337F215_out_skillsOutput</bpmn2:sourceRef>
+        <bpmn2:targetRef>skills</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+      <bpmn2:dataOutputAssociation id="_k9L9U7zKEeKT6qCaqCIbfQ">
+        <bpmn2:sourceRef>_FADFBC55-C369-4F58-B04B-3AD20337F215_out_scoreOutput</bpmn2:sourceRef>
+        <bpmn2:targetRef>tech_score</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+      <bpmn2:dataOutputAssociation id="_k9L9VLzKEeKT6qCaqCIbfQ">
+        <bpmn2:sourceRef>_FADFBC55-C369-4F58-B04B-3AD20337F215_out_twitterOutput</bpmn2:sourceRef>
+        <bpmn2:targetRef>twitter</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="_202CE0F7-63B3-4A5D-B5A9-9C9C5EB87468" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_6998ACD3-21DC-421D-AC04-BA7D375B0B21" targetRef="_FADFBC55-C369-4F58-B04B-3AD20337F215"/>
+    <bpmn2:userTask id="_12435ADA-3C57-414C-8DDD-5D236E462BD8" drools:selectable="true" drools:taskName="CreateProposal" drools:scriptFormat="http://www.java.com/java" name="Create Proposal">
+      <bpmn2:incoming>_4976D9C3-B97A-48F7-B794-32307FF855D6</bpmn2:incoming>
+      <bpmn2:outgoing>_7C032B11-46FC-4599-94B7-8FCA9AA05437</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_k9L9VbzKEeKT6qCaqCIbfQ">
+        <bpmn2:dataInput id="_12435ADA-3C57-414C-8DDD-5D236E462BD8_TaskNameInput" name="TaskName"/>
+        <bpmn2:dataInput id="_12435ADA-3C57-414C-8DDD-5D236E462BD8_in_tech_scoreInput" drools:dtype="Integer" itemSubjectRef="__12435ADA-3C57-414C-8DDD-5D236E462BD8_in_tech_scoreInputItem" name="in_tech_score"/>
+        <bpmn2:dataInput id="_12435ADA-3C57-414C-8DDD-5D236E462BD8_in_hr_scoreInput" drools:dtype="Integer" itemSubjectRef="__12435ADA-3C57-414C-8DDD-5D236E462BD8_in_hr_scoreInputItem" name="in_hr_score"/>
+        <bpmn2:dataInput id="_12435ADA-3C57-414C-8DDD-5D236E462BD8_GroupIdInput" drools:dtype="Object" itemSubjectRef="__12435ADA-3C57-414C-8DDD-5D236E462BD8_GroupIdInputItem" name="GroupId"/>
+        <bpmn2:dataInput id="_12435ADA-3C57-414C-8DDD-5D236E462BD8_CommentInput" drools:dtype="Object" itemSubjectRef="__12435ADA-3C57-414C-8DDD-5D236E462BD8_CommentInputItem" name="Comment"/>
+        <bpmn2:dataOutput id="_12435ADA-3C57-414C-8DDD-5D236E462BD8_out_offeringOutput" drools:dtype="Integer" itemSubjectRef="__12435ADA-3C57-414C-8DDD-5D236E462BD8_out_offeringOutputItem" name="out_offering"/>
+        <bpmn2:inputSet id="_k9L9VrzKEeKT6qCaqCIbfQ">
+          <bpmn2:dataInputRefs>_12435ADA-3C57-414C-8DDD-5D236E462BD8_in_tech_scoreInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_12435ADA-3C57-414C-8DDD-5D236E462BD8_in_hr_scoreInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_12435ADA-3C57-414C-8DDD-5D236E462BD8_GroupIdInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_12435ADA-3C57-414C-8DDD-5D236E462BD8_CommentInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_12435ADA-3C57-414C-8DDD-5D236E462BD8_TaskNameInput</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_k9MkQLzKEeKT6qCaqCIbfQ">
+          <bpmn2:dataOutputRefs>_12435ADA-3C57-414C-8DDD-5D236E462BD8_out_offeringOutput</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_k9MkQbzKEeKT6qCaqCIbfQ">
+        <bpmn2:targetRef>_12435ADA-3C57-414C-8DDD-5D236E462BD8_TaskNameInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_k9MkQrzKEeKT6qCaqCIbfQ">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_k9MkQ7zKEeKT6qCaqCIbfQ">CreateProposal</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_k9MkRLzKEeKT6qCaqCIbfQ">_12435ADA-3C57-414C-8DDD-5D236E462BD8_TaskNameInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_k9MkRbzKEeKT6qCaqCIbfQ">
+        <bpmn2:sourceRef>tech_score</bpmn2:sourceRef>
+        <bpmn2:targetRef>_12435ADA-3C57-414C-8DDD-5D236E462BD8_in_tech_scoreInput</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_k9MkRrzKEeKT6qCaqCIbfQ">
+        <bpmn2:sourceRef>hr_score</bpmn2:sourceRef>
+        <bpmn2:targetRef>_12435ADA-3C57-414C-8DDD-5D236E462BD8_in_hr_scoreInput</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_k9MkR7zKEeKT6qCaqCIbfQ">
+        <bpmn2:targetRef>_12435ADA-3C57-414C-8DDD-5D236E462BD8_GroupIdInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_k9MkSLzKEeKT6qCaqCIbfQ">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_k9MkSbzKEeKT6qCaqCIbfQ">Accounting</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_k9MkSrzKEeKT6qCaqCIbfQ">_12435ADA-3C57-414C-8DDD-5D236E462BD8_GroupIdInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_k9MkS7zKEeKT6qCaqCIbfQ">
+        <bpmn2:targetRef>_12435ADA-3C57-414C-8DDD-5D236E462BD8_CommentInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_k9MkTLzKEeKT6qCaqCIbfQ">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_k9MkTbzKEeKT6qCaqCIbfQ"><![CDATA[Proposal for: #{name}]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_k9MkTrzKEeKT6qCaqCIbfQ">_12435ADA-3C57-414C-8DDD-5D236E462BD8_CommentInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation id="_k9MkT7zKEeKT6qCaqCIbfQ">
+        <bpmn2:sourceRef>_12435ADA-3C57-414C-8DDD-5D236E462BD8_out_offeringOutput</bpmn2:sourceRef>
+        <bpmn2:targetRef>offering</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="_4976D9C3-B97A-48F7-B794-32307FF855D6" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_FADFBC55-C369-4F58-B04B-3AD20337F215" targetRef="_12435ADA-3C57-414C-8DDD-5D236E462BD8"/>
+    <bpmn2:scriptTask id="_3D70555E-A579-4431-A465-21B085906EEF" drools:selectable="true" name="Send Proposal" scriptFormat="http://www.java.com/java">
+      <bpmn2:incoming>_7C032B11-46FC-4599-94B7-8FCA9AA05437</bpmn2:incoming>
+      <bpmn2:outgoing>_3357BAA4-262A-41BA-9C29-7845432CCB8A</bpmn2:outgoing>
+      <bpmn2:script><![CDATA[System.out.println("Sending Proposal to: "+mail);\nSystem.out.println(" \t Acme Inc. offers you:  "+offering);\nSystem.out.println(" \t For the Software Developer Position");]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="_7C032B11-46FC-4599-94B7-8FCA9AA05437" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_12435ADA-3C57-414C-8DDD-5D236E462BD8" targetRef="_3D70555E-A579-4431-A465-21B085906EEF"/>
+    <bpmn2:userTask id="_D9B752FE-4900-4172-B8C9-31CC838E18A5" drools:selectable="true" drools:taskName="SignContract" drools:scriptFormat="http://www.java.com/java" name="Sign Contract">
+      <bpmn2:incoming>_3357BAA4-262A-41BA-9C29-7845432CCB8A</bpmn2:incoming>
+      <bpmn2:outgoing>_B7EF3CD8-7D33-4464-81B4-69522F1799D5</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_k9MkULzKEeKT6qCaqCIbfQ">
+        <bpmn2:dataInput id="_D9B752FE-4900-4172-B8C9-31CC838E18A5_TaskNameInput" name="TaskName"/>
+        <bpmn2:dataInput id="_D9B752FE-4900-4172-B8C9-31CC838E18A5_in_offeringInput" drools:dtype="Integer" itemSubjectRef="__D9B752FE-4900-4172-B8C9-31CC838E18A5_in_offeringInputItem" name="in_offering"/>
+        <bpmn2:dataInput id="_D9B752FE-4900-4172-B8C9-31CC838E18A5_in_nameInput" drools:dtype="String" itemSubjectRef="__D9B752FE-4900-4172-B8C9-31CC838E18A5_in_nameInputItem" name="in_name"/>
+        <bpmn2:dataInput id="_D9B752FE-4900-4172-B8C9-31CC838E18A5_GroupIdInput" drools:dtype="Object" itemSubjectRef="__D9B752FE-4900-4172-B8C9-31CC838E18A5_GroupIdInputItem" name="GroupId"/>
+        <bpmn2:dataInput id="_D9B752FE-4900-4172-B8C9-31CC838E18A5_CommentInput" drools:dtype="Object" itemSubjectRef="__D9B752FE-4900-4172-B8C9-31CC838E18A5_CommentInputItem" name="Comment"/>
+        <bpmn2:dataOutput id="_D9B752FE-4900-4172-B8C9-31CC838E18A5_out_signedOutput" drools:dtype="Boolean" itemSubjectRef="__D9B752FE-4900-4172-B8C9-31CC838E18A5_out_signedOutputItem" name="out_signed"/>
+        <bpmn2:inputSet id="_k9MkUbzKEeKT6qCaqCIbfQ">
+          <bpmn2:dataInputRefs>_D9B752FE-4900-4172-B8C9-31CC838E18A5_in_offeringInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_D9B752FE-4900-4172-B8C9-31CC838E18A5_in_nameInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_D9B752FE-4900-4172-B8C9-31CC838E18A5_GroupIdInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_D9B752FE-4900-4172-B8C9-31CC838E18A5_CommentInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_D9B752FE-4900-4172-B8C9-31CC838E18A5_TaskNameInput</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_k9MkUrzKEeKT6qCaqCIbfQ">
+          <bpmn2:dataOutputRefs>_D9B752FE-4900-4172-B8C9-31CC838E18A5_out_signedOutput</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_k9MkU7zKEeKT6qCaqCIbfQ">
+        <bpmn2:targetRef>_D9B752FE-4900-4172-B8C9-31CC838E18A5_TaskNameInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_k9MkVLzKEeKT6qCaqCIbfQ">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_k9MkVbzKEeKT6qCaqCIbfQ">SignContract</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_k9MkVrzKEeKT6qCaqCIbfQ">_D9B752FE-4900-4172-B8C9-31CC838E18A5_TaskNameInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_k9MkV7zKEeKT6qCaqCIbfQ">
+        <bpmn2:sourceRef>offering</bpmn2:sourceRef>
+        <bpmn2:targetRef>_D9B752FE-4900-4172-B8C9-31CC838E18A5_in_offeringInput</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_k9MkWLzKEeKT6qCaqCIbfQ">
+        <bpmn2:sourceRef>name</bpmn2:sourceRef>
+        <bpmn2:targetRef>_D9B752FE-4900-4172-B8C9-31CC838E18A5_in_nameInput</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_k9MkWbzKEeKT6qCaqCIbfQ">
+        <bpmn2:targetRef>_D9B752FE-4900-4172-B8C9-31CC838E18A5_GroupIdInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_k9MkWrzKEeKT6qCaqCIbfQ">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_k9MkW7zKEeKT6qCaqCIbfQ">HR</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_k9MkXLzKEeKT6qCaqCIbfQ">_D9B752FE-4900-4172-B8C9-31CC838E18A5_GroupIdInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_k9MkXbzKEeKT6qCaqCIbfQ">
+        <bpmn2:targetRef>_D9B752FE-4900-4172-B8C9-31CC838E18A5_CommentInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_k9MkXrzKEeKT6qCaqCIbfQ">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_k9MkX7zKEeKT6qCaqCIbfQ"><![CDATA[with #{name}]]></bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_k9MkYLzKEeKT6qCaqCIbfQ">_D9B752FE-4900-4172-B8C9-31CC838E18A5_CommentInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation id="_k9MkYbzKEeKT6qCaqCIbfQ">
+        <bpmn2:sourceRef>_D9B752FE-4900-4172-B8C9-31CC838E18A5_out_signedOutput</bpmn2:sourceRef>
+        <bpmn2:targetRef>signed</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="_3357BAA4-262A-41BA-9C29-7845432CCB8A" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_3D70555E-A579-4431-A465-21B085906EEF" targetRef="_D9B752FE-4900-4172-B8C9-31CC838E18A5"/>
+    <bpmn2:scriptTask id="_BB384E33-D98D-4809-9063-53675BC5D27E" drools:selectable="true" drools:taskName="Twitter" name="Tweet New Hire" scriptFormat="http://www.java.com/java">
+      <bpmn2:incoming>_B7EF3CD8-7D33-4464-81B4-69522F1799D5</bpmn2:incoming>
+      <bpmn2:outgoing>_AABB6FDC-F7B4-40FB-A691-969E83285E16</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_k9MkYrzKEeKT6qCaqCIbfQ">
+        <bpmn2:dataInput id="_BB384E33-D98D-4809-9063-53675BC5D27E_TaskNameInput" name="TaskName"/>
+        <bpmn2:inputSet id="_k9MkY7zKEeKT6qCaqCIbfQ"/>
+        <bpmn2:outputSet id="_k9MkZLzKEeKT6qCaqCIbfQ"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_k9MkZbzKEeKT6qCaqCIbfQ">
+        <bpmn2:targetRef>_BB384E33-D98D-4809-9063-53675BC5D27E_TaskNameInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_k9MkZrzKEeKT6qCaqCIbfQ">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_k9MkZ7zKEeKT6qCaqCIbfQ">Twitter</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_k9MkaLzKEeKT6qCaqCIbfQ">_BB384E33-D98D-4809-9063-53675BC5D27E_TaskNameInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:script><![CDATA[System.out.println("New Hire: "+twitter);]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="_B7EF3CD8-7D33-4464-81B4-69522F1799D5" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_D9B752FE-4900-4172-B8C9-31CC838E18A5" targetRef="_BB384E33-D98D-4809-9063-53675BC5D27E"/>
+    <bpmn2:endEvent id="_F059CD07-FBF7-4D08-82D0-439414BAE553" drools:bgcolor="#ff6347" drools:selectable="true" name="">
+      <bpmn2:incoming>_AABB6FDC-F7B4-40FB-A691-969E83285E16</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_AABB6FDC-F7B4-40FB-A691-969E83285E16" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_BB384E33-D98D-4809-9063-53675BC5D27E" targetRef="_F059CD07-FBF7-4D08-82D0-439414BAE553"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_k9NLULzKEeKT6qCaqCIbfQ">
+    <bpmndi:BPMNPlane id="_k9NLUbzKEeKT6qCaqCIbfQ" bpmnElement="hiring">
+      <bpmndi:BPMNShape id="_k9NLUrzKEeKT6qCaqCIbfQ" bpmnElement="_76910DD0-5F45-421F-B1AC-E6507CC1C26C">
+        <dc:Bounds height="30.0" width="30.0" x="161.0" y="188.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_k9NLU7zKEeKT6qCaqCIbfQ" bpmnElement="_6998ACD3-21DC-421D-AC04-BA7D375B0B21">
+        <dc:Bounds height="80.0" width="100.0" x="236.0" y="163.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_k9NLVLzKEeKT6qCaqCIbfQ" bpmnElement="_416C6A67-B7EC-400B-9F2B-0F53B3FEDEB4">
+        <di:waypoint xsi:type="dc:Point" x="176.0" y="203.0"/>
+        <di:waypoint xsi:type="dc:Point" x="286.0" y="203.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_k9NLVbzKEeKT6qCaqCIbfQ" bpmnElement="_FADFBC55-C369-4F58-B04B-3AD20337F215">
+        <dc:Bounds height="80.0" width="100.0" x="375.0" y="163.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_k9NLVrzKEeKT6qCaqCIbfQ" bpmnElement="_202CE0F7-63B3-4A5D-B5A9-9C9C5EB87468">
+        <di:waypoint xsi:type="dc:Point" x="286.0" y="203.0"/>
+        <di:waypoint xsi:type="dc:Point" x="425.0" y="203.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_k9NLV7zKEeKT6qCaqCIbfQ" bpmnElement="_12435ADA-3C57-414C-8DDD-5D236E462BD8">
+        <dc:Bounds height="80.0" width="100.0" x="526.0" y="163.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_k9NLWLzKEeKT6qCaqCIbfQ" bpmnElement="_4976D9C3-B97A-48F7-B794-32307FF855D6">
+        <di:waypoint xsi:type="dc:Point" x="425.0" y="203.0"/>
+        <di:waypoint xsi:type="dc:Point" x="576.0" y="203.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_k9NLWbzKEeKT6qCaqCIbfQ" bpmnElement="_3D70555E-A579-4431-A465-21B085906EEF">
+        <dc:Bounds height="80.0" width="100.0" x="671.0" y="163.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_k9NLWrzKEeKT6qCaqCIbfQ" bpmnElement="_7C032B11-46FC-4599-94B7-8FCA9AA05437">
+        <di:waypoint xsi:type="dc:Point" x="576.0" y="203.0"/>
+        <di:waypoint xsi:type="dc:Point" x="721.0" y="203.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_k9NLW7zKEeKT6qCaqCIbfQ" bpmnElement="_D9B752FE-4900-4172-B8C9-31CC838E18A5">
+        <dc:Bounds height="80.0" width="100.0" x="810.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_k9NLXLzKEeKT6qCaqCIbfQ" bpmnElement="_3357BAA4-262A-41BA-9C29-7845432CCB8A">
+        <di:waypoint xsi:type="dc:Point" x="721.0" y="203.0"/>
+        <di:waypoint xsi:type="dc:Point" x="860.0" y="205.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_k9NLXbzKEeKT6qCaqCIbfQ" bpmnElement="_BB384E33-D98D-4809-9063-53675BC5D27E">
+        <dc:Bounds height="80.0" width="100.0" x="961.0" y="163.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_k9NLXrzKEeKT6qCaqCIbfQ" bpmnElement="_B7EF3CD8-7D33-4464-81B4-69522F1799D5">
+        <di:waypoint xsi:type="dc:Point" x="860.0" y="205.0"/>
+        <di:waypoint xsi:type="dc:Point" x="935.0" y="205.0"/>
+        <di:waypoint xsi:type="dc:Point" x="935.0" y="203.0"/>
+        <di:waypoint xsi:type="dc:Point" x="1011.0" y="203.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_k9NLX7zKEeKT6qCaqCIbfQ" bpmnElement="_F059CD07-FBF7-4D08-82D0-439414BAE553">
+        <dc:Bounds height="28.0" width="28.0" x="1093.0" y="189.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_k9NLYLzKEeKT6qCaqCIbfQ" bpmnElement="_AABB6FDC-F7B4-40FB-A691-969E83285E16">
+        <di:waypoint xsi:type="dc:Point" x="1011.0" y="203.0"/>
+        <di:waypoint xsi:type="dc:Point" x="1107.0" y="203.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_k9NLYbzKEeKT6qCaqCIbfQ" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="s"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_416C6A67-B7EC-400B-9F2B-0F53B3FEDEB4" id="_k9NLYrzKEeKT6qCaqCIbfQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_202CE0F7-63B3-4A5D-B5A9-9C9C5EB87468" id="_k9NyYLzKEeKT6qCaqCIbfQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_3D70555E-A579-4431-A465-21B085906EEF" id="_k9NyYbzKEeKT6qCaqCIbfQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_6998ACD3-21DC-421D-AC04-BA7D375B0B21" id="_k9NyYrzKEeKT6qCaqCIbfQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_FADFBC55-C369-4F58-B04B-3AD20337F215" id="_k9NyY7zKEeKT6qCaqCIbfQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_4976D9C3-B97A-48F7-B794-32307FF855D6" id="_k9NyZLzKEeKT6qCaqCIbfQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_76910DD0-5F45-421F-B1AC-E6507CC1C26C" id="_k9NyZbzKEeKT6qCaqCIbfQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:WaitTime xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:WaitTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_7C032B11-46FC-4599-94B7-8FCA9AA05437" id="_k9NyZrzKEeKT6qCaqCIbfQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_D9B752FE-4900-4172-B8C9-31CC838E18A5" id="_k9NyZ7zKEeKT6qCaqCIbfQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_12435ADA-3C57-414C-8DDD-5D236E462BD8" id="_k9NyaLzKEeKT6qCaqCIbfQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_BB384E33-D98D-4809-9063-53675BC5D27E" id="_k9NyabzKEeKT6qCaqCIbfQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_B7EF3CD8-7D33-4464-81B4-69522F1799D5" id="_k9NyarzKEeKT6qCaqCIbfQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_F059CD07-FBF7-4D08-82D0-439414BAE553" id="_k9Nya7zKEeKT6qCaqCIbfQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:NormalDistribution mean="0.0" standardDeviation="0.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_AABB6FDC-F7B4-40FB-A691-969E83285E16" id="_k9NybLzKEeKT6qCaqCIbfQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_3357BAA4-262A-41BA-9C29-7845432CCB8A" id="_k9NybbzKEeKT6qCaqCIbfQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_k9I54LzKEeKT6qCaqCIbfQ</bpmn2:source>
+    <bpmn2:target>_k9I54LzKEeKT6qCaqCIbfQ</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerExecutor.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerExecutor.java
@@ -15,6 +15,7 @@
  */
 package org.kie.server.integrationtests.shared;
 
+import org.kie.server.api.model.KieServerMode;
 import org.kie.server.integrationtests.shared.basetests.KieServerBaseIntegrationTest;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -72,6 +73,7 @@ public class KieServerExecutor {
         System.setProperty(KieServerConstants.KIE_SERVER_LOCATION, TestConfig.getEmbeddedKieServerHttpUrl());
         System.setProperty(KieServerConstants.KIE_SERVER_STATE_REPO, "./target");
         System.setProperty(KieServerConstants.CFG_SYNC_DEPLOYMENT, Boolean.toString(syncWithController));
+        System.setProperty(KieServerConstants.KIE_SERVER_MODE, KieServerMode.REGULAR.name());
 
         // kie server policy settings
         System.setProperty(KieServerConstants.KIE_SERVER_ACTIVATE_POLICIES, "KeepLatestOnly");

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -57,6 +57,7 @@
     <org.kie.server.datasource.username>sa</org.kie.server.datasource.username>
     <org.kie.server.datasource.password>sa</org.kie.server.datasource.password>
     <org.kie.server.datasource.driver.class>org.h2.jdbcx.JdbcDataSource</org.kie.server.datasource.driver.class>
+    <org.kie.server.mode.regular>REGULAR</org.kie.server.mode.regular>
 
     <!-- Springboot specific property which is overridden by production DBs profile -->
     <!-- By default we use bundled H2 database jar -->
@@ -229,6 +230,7 @@
                 <!-- Persistence configuration -->
                 <org.kie.server.persistence.ds>${org.kie.server.persistence.ds}</org.kie.server.persistence.ds>
                 <org.kie.server.persistence.dialect>${org.kie.server.persistence.dialect}</org.kie.server.persistence.dialect>
+                <org.kie.server.mode>${org.kie.server.mode.regular}</org.kie.server.mode>
               </systemProperties>
             </container>
             <deployables>

--- a/kie-spring-boot/kie-spring-boot-samples/keycloak-kie-server-spring-boot-sample/src/test/java/org/kie/server/springboot/samples/KieServerTest.java
+++ b/kie-spring-boot/kie-spring-boot-samples/keycloak-kie-server-spring-boot-sample/src/test/java/org/kie/server/springboot/samples/KieServerTest.java
@@ -26,14 +26,17 @@ import java.util.Map;
 
 import org.appformer.maven.integration.MavenRepository;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.api.KieServices;
+import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieServerMode;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.definition.ProcessDefinition;
 import org.kie.server.api.model.instance.ProcessInstance;
@@ -73,15 +76,20 @@ public class KieServerTest {
     
     @BeforeClass
     public static void generalSetup() {
+        System.setProperty(KieServerConstants.KIE_SERVER_MODE, KieServerMode.REGULAR.name());
         KieServices ks = KieServices.Factory.get();
         org.kie.api.builder.ReleaseId releaseId = ks.newReleaseId(GROUP_ID, ARTIFACT_ID, VERSION);
         File kjar = new File("../kjars/evaluation/jbpm-module.jar");
         File pom = new File("../kjars/evaluation/pom.xml");
         MavenRepository repository = getMavenRepository();
         repository.installArtifact(releaseId, kjar, pom);
-
     }
-    
+
+    @AfterClass
+    public static void generalCleanup() {
+        System.setProperty(KieServerConstants.KIE_SERVER_MODE, KieServerMode.REGULAR.name());
+    }
+
     @Before
     public void setup() {
         ReleaseId releaseId = new ReleaseId(GROUP_ID, ARTIFACT_ID, VERSION);

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/java/org/kie/server/springboot/samples/KieServerMigrationTest.java
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/java/org/kie/server/springboot/samples/KieServerMigrationTest.java
@@ -27,14 +27,17 @@ import java.util.Map;
 
 import org.appformer.maven.integration.MavenRepository;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.api.KieServices;
+import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieServerConfigItem;
+import org.kie.server.api.model.KieServerMode;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.admin.MigrationReportInstance;
 import org.kie.server.api.model.instance.ProcessInstance;
@@ -74,13 +77,18 @@ public class KieServerMigrationTest {
    
     @BeforeClass
     public static void generalSetup() {
+        System.setProperty(KieServerConstants.KIE_SERVER_MODE, KieServerMode.REGULAR.name());
         KieServices ks = KieServices.Factory.get();
         org.kie.api.builder.ReleaseId releaseId = ks.newReleaseId(GROUP_ID, ARTIFACT_ID, VERSION);
         File kjar = new File("../kjars/evaluation/jbpm-module.jar");
         File pom = new File("../kjars/evaluation/pom.xml");
         MavenRepository repository = getMavenRepository();
         repository.installArtifact(releaseId, kjar, pom);
+    }
 
+    @AfterClass
+    public static void generalCleanup() {
+        System.clearProperty(KieServerConstants.KIE_SERVER_MODE);
     }
     
     @Before

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/java/org/kie/server/springboot/samples/KieServerTest.java
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/java/org/kie/server/springboot/samples/KieServerTest.java
@@ -27,13 +27,16 @@ import java.util.Map;
 
 import org.appformer.maven.integration.MavenRepository;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.api.KieServices;
+import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieServerMode;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.definition.ProcessDefinition;
 import org.kie.server.api.model.instance.ProcessInstance;
@@ -85,13 +88,18 @@ public class KieServerTest {
     
     @BeforeClass
     public static void generalSetup() {
+        System.setProperty(KieServerConstants.KIE_SERVER_MODE, KieServerMode.REGULAR.name());
         KieServices ks = KieServices.Factory.get();
         org.kie.api.builder.ReleaseId releaseId = ks.newReleaseId(GROUP_ID, ARTIFACT_ID, VERSION);
         File kjar = new File("../kjars/evaluation/jbpm-module.jar");
         File pom = new File("../kjars/evaluation/pom.xml");
         MavenRepository repository = getMavenRepository();
         repository.installArtifact(releaseId, kjar, pom);
+    }
 
+    @AfterClass
+    public static void generalCleanup() {
+        System.clearProperty(KieServerConstants.KIE_SERVER_MODE);
     }
     
     @Before

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/java/org/kie/server/springboot/samples/RulesOnlyKieServerTest.java
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/java/org/kie/server/springboot/samples/RulesOnlyKieServerTest.java
@@ -27,6 +27,7 @@ import org.appformer.maven.integration.MavenRepository;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.core.io.impl.ClassPathResource;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -39,8 +40,10 @@ import org.kie.api.builder.ReleaseId;
 import org.kie.api.command.Command;
 import org.kie.api.command.KieCommands;
 import org.kie.api.runtime.ExecutionResults;
+import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieServerMode;
 import org.kie.server.api.model.KieServiceResponse;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.client.KieServicesClient;
@@ -79,7 +82,13 @@ public class RulesOnlyKieServerTest {
     
     @BeforeClass
     public static void generalSetup() {
+        System.setProperty(KieServerConstants.KIE_SERVER_MODE, KieServerMode.REGULAR.name());
         createKJar();
+    }
+
+    @AfterClass
+    public static void generalCleanup() {
+        System.clearProperty(KieServerConstants.KIE_SERVER_MODE);
     }
 
     @Before


### PR DESCRIPTION
AF-1687: Align with 'kie-server' with development mode

Added mode to kie-server (development & regular). Development mode allows deploying snapshot modules from the workbench and provides a more flexible policy on update (allows updating containers even if they have running process instances and also allows update and abort existing process instances).

Regular mode only allows deploying non snapshot modules and the update policy is the same as we used to have.

The mode can be configured by adding an extra system property _org.kie.server.mode=[development|regular]_. Being the development mode the default if the option is not present.

@mswiderski @tomasdavidorg could you please take a look? (Tests are not finished yet, but you can start reviewing the code while I keep working)

This is part of an ensemble, please merge with:
https://github.com/kiegroup/appformer/pull/614
https://github.com/kiegroup/jbpm/pull/1424
https://github.com/kiegroup/droolsjbpm-integration/pull/1698
https://github.com/kiegroup/kie-wb-common/pull/2422