### PR TITLE
DROOLS-3543 Raise timeout for BlueprintContainer initialization

### DIFF
--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieSpringjBPMPersistenceKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieSpringjBPMPersistenceKarafIntegrationTest.java
@@ -82,7 +82,7 @@ public class KieSpringjBPMPersistenceKarafIntegrationTest extends AbstractKieSpr
 
     // this is the way to get actual Spring Application Context through "bridging" Blueprint Container
     @Inject
-    @Filter(value = "(osgi.blueprint.container.symbolicname=Test-Kie-Spring-Bundle)", timeout = 60000)
+    @Filter(value = "(osgi.blueprint.container.symbolicname=Test-Kie-Spring-Bundle)", timeout = 120000)
     private BlueprintContainer container;
 
     @Before


### PR DESCRIPTION
Timeout raised because when running with specific databases, it takes a long time to initialize the container. 

@jiripetrlik @mariofusco could you please review? 