### PR TITLE
PLANNER-1356: Add out-of-the-box support for java.time.* (un)marshalling to JSON

### DIFF
--- a/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features-fuse.xml
+++ b/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features-fuse.xml
@@ -111,6 +111,7 @@
     <bundle>mvn:org.kie.server/kie-server-client/${version.org.drools.droolsjbpm-integration}</bundle>
     <bundle>mvn:org.kie/kie-dmn-model/${version.org.kie}</bundle> <!-- needed as the kie-server contains DMN client, which uses the kie-dmn-api, which needs kie-dmn-model -->
     <bundle>mvn:org.kie/kie-dmn-api/${version.org.kie}</bundle>   <!-- needed as the kie-server contains DMN client, which uses the kie-dmn-api -->
+    <bundle>mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/${version.com.fasterxml.jackson}</bundle>
   </feature>
 
   <feature name="servlet-api-kie" version="${project.version}">

--- a/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features.xml
+++ b/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features.xml
@@ -163,6 +163,7 @@
     <bundle>mvn:com.fasterxml.jackson.core/jackson-core/${version.com.fasterxml.jackson}</bundle>
     <bundle>mvn:com.fasterxml.jackson.core/jackson-databind/${version.com.fasterxml.jackson}</bundle>
     <bundle>mvn:com.fasterxml.jackson.module/jackson-module-jaxb-annotations/${version.com.fasterxml.jackson}</bundle>
+    <bundle>mvn:com.fasterxml.jackson.datatype/jackson-datatype-jsr310/${version.com.fasterxml.jackson}</bundle>
     <bundle>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/${karaf.version.org.apache.geronimo.specs.jta}</bundle>
     <bundle>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/${karaf.version.org.apache.geronimo.specs.jms}</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/${karaf.servicemix.version.com.thoughtworks.xmlpull}</bundle>

--- a/kie-server-parent/kie-server-api/pom.xml
+++ b/kie-server-parent/kie-server-api/pom.xml
@@ -77,6 +77,10 @@
       <groupId>com.fasterxml.jackson.module</groupId>
       <artifactId>jackson-module-jaxb-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
 
     <!-- xstream -->
     <dependency>

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
@@ -69,6 +69,7 @@ import com.fasterxml.jackson.databind.jsontype.TypeResolverBuilder;
 import com.fasterxml.jackson.databind.jsontype.impl.AsWrapperTypeDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.util.ClassUtil;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
 import org.drools.core.xml.jaxb.util.JaxbListAdapter;
 import org.drools.core.xml.jaxb.util.JaxbListWrapper;
@@ -245,6 +246,10 @@ public class JSONMarshaller implements Marshaller {
             objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
             customSerializationMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         }
+
+        JavaTimeModule javaTimeModule = new JavaTimeModule();
+        objectMapper.registerModule(javaTimeModule);
+        deserializeObjectMapper.registerModule(javaTimeModule);
 
         this.classesSet = classes;
 

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
@@ -250,6 +250,7 @@ public class JSONMarshaller implements Marshaller {
         JavaTimeModule javaTimeModule = new JavaTimeModule();
         objectMapper.registerModule(javaTimeModule);
         deserializeObjectMapper.registerModule(javaTimeModule);
+        customSerializationMapper.registerModule(javaTimeModule);
 
         this.classesSet = classes;
 

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/JSONMarshallerTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/JSONMarshallerTest.java
@@ -77,7 +77,6 @@ public class JSONMarshallerTest {
 
     @Test
     public void testMarshallDateObjectUnannotated() {
-        System.setProperty("org.kie.server.json.format.date", "true");
         String expectedString = String.format("{%n" +
                 "  \"localDate\" : \"2017-01-01\",%n" +
                 "  \"localDateTime\" : \"2017-01-01T10:10:10\",%n" +
@@ -101,7 +100,6 @@ public class JSONMarshallerTest {
 
     @Test
     public void testUnmarshallDateObjectUnannotated() {
-        System.setProperty("org.kie.server.json.format.date", "true");
         String expectedString = "{\n" +
                 "  \"localDate\" : \"2017-01-01\",\n" +
                 "  \"localDateTime\" : \"2017-01-01T10:10:10\",\n" +

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/SolutionMarshallingTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/SolutionMarshallingTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.api.marshalling;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.kie.server.api.marshalling.objects.DateObjectUnannotated;
+import org.kie.server.api.model.instance.SolverInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests (un)marshalling of {@link SolverInstance} with best solution that has fields from {@link java.time} package
+ * without using custom adapters/converters.
+ */
+@RunWith(Parameterized.class)
+public class SolutionMarshallingTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(SolutionMarshallingTest.class);
+
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Collection<Object[]> data() {
+        return new ArrayList<>(Arrays.asList(new Object[][]{
+                // JAXB doesn't seem to handle java.time.* without using custom adapters
+                /*{MarshallingFormat.JAXB},*/
+                {MarshallingFormat.JSON},
+                {MarshallingFormat.XSTREAM}
+        }));
+    }
+
+    @Parameterized.Parameter
+    public MarshallingFormat marshallingFormat;
+
+    @Test
+    public void testMarshallHardSoftScore() {
+        SolverInstance solverInstance = new SolverInstance();
+
+        DateObjectUnannotated dateObject = new DateObjectUnannotated();
+        dateObject.setLocalDate(LocalDate.of(2018, 8, 18));
+        dateObject.setLocalDateTime(LocalDateTime.of(2017, 7, 17, 17, 17, 17));
+        dateObject.setLocalTime(LocalTime.of(12, 34, 56));
+        dateObject.setOffsetDateTime(OffsetDateTime.of(2019, 2, 4, 20, 57, 11, 0, ZoneOffset.ofHours(1)));
+
+        solverInstance.setBestSolution(dateObject);
+
+        Marshaller marshaller = MarshallerFactory.getMarshaller(
+                marshallingFormat,
+                Thread.currentThread().getContextClassLoader()
+        );
+
+        String marshalledSolverInstance = marshaller.marshall(solverInstance);
+        logger.info("Marshalled SolverInstance ({}): {}", marshallingFormat, marshalledSolverInstance);
+        assertThat(marshalledSolverInstance)
+                .as("Dates should be formatted")
+                .contains(
+                        "2018-08-18",
+                        "2017-07-17T17:17:17",
+                        "12:34:56",
+                        "2019-02-04T20:57:11+01");
+
+        SolverInstance unmarshalledSolverInstance = marshaller.unmarshall(marshalledSolverInstance, SolverInstance.class);
+        DateObjectUnannotated bestSolution = (DateObjectUnannotated) unmarshalledSolverInstance.getBestSolution();
+        assertThat(bestSolution.getLocalDate()).isEqualTo(dateObject.getLocalDate());
+        assertThat(bestSolution.getLocalDateTime()).isEqualTo(dateObject.getLocalDateTime());
+        assertThat(bestSolution.getLocalTime()).isEqualTo(dateObject.getLocalTime());
+        assertThat(bestSolution.getOffsetDateTime()).isEqualTo(dateObject.getOffsetDateTime());
+    }
+}

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/DateObject.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/DateObject.java
@@ -23,6 +23,8 @@ import org.kie.soup.commons.xstream.OffsetDateTimeXStreamConverter;
 
 /**
  * TODO Remove @XStreamConverter for java.time attributes once converters are provided by XStream out of the box.
+ * Maybe keep this for backward compatibility (KIE Soup converters should keep working even if they're no longer needed)
+ * and use {@link DateObjectUnannotated} when testing out-of-the-box time (un)marshalling.
  *
  * @see <a href="https://github.com/x-stream/xstream/issues/75">XStream#75</a>
  */

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/DateObjectUnannotated.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/DateObjectUnannotated.java
@@ -1,0 +1,59 @@
+package org.kie.server.api.marshalling.objects;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+/**
+ * Unannotated means without KIE Soup custom/temporary converters (see {@link DateObject}).
+ * {@code JsonFormat} is OK since it's part of Jackson library and it's needed to enforce keeping of time zone offset.
+ */
+public class DateObjectUnannotated {
+
+    private LocalDate localDate;
+
+    private LocalDateTime localDateTime;
+
+    private LocalTime localTime;
+
+    @JsonFormat(
+            shape = JsonFormat.Shape.STRING,
+            pattern = "yyyy-MM-dd'T'HH:mm:ssZ",
+            without = JsonFormat.Feature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+    private OffsetDateTime offsetDateTime;
+
+    public LocalDate getLocalDate() {
+        return localDate;
+    }
+
+    public void setLocalDate(LocalDate localDate) {
+        this.localDate = localDate;
+    }
+
+    public LocalDateTime getLocalDateTime() {
+        return localDateTime;
+    }
+
+    public void setLocalDateTime(LocalDateTime localDateTime) {
+        this.localDateTime = localDateTime;
+    }
+
+    public LocalTime getLocalTime() {
+        return localTime;
+    }
+
+    public void setLocalTime(LocalTime localTime) {
+        this.localTime = localTime;
+    }
+
+    public OffsetDateTime getOffsetDateTime() {
+        return offsetDateTime;
+    }
+
+    public void setOffsetDateTime(OffsetDateTime offsetDateTime) {
+        this.offsetDateTime = offsetDateTime;
+    }
+}

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/DateObjectUnannotated.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/DateObjectUnannotated.java
@@ -13,10 +13,17 @@ import com.fasterxml.jackson.annotation.JsonFormat;
  */
 public class DateObjectUnannotated {
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     private LocalDate localDate;
 
+    // Without this, Jackson will serialize the date as a timestamp (e.g. "localDateTime" : [ 2017, 7, 17, 17, 17, 17 ]).
+    // The string shape will instruct Jackson (JavaTime module) to format the date in ISO-8601 (default).
+    // Option B is to set org.kie.server.json.format.date=true, this will make JSONMarshaller (KIE Server) disable
+    // Jackson's feature that serializes dates as timestamps.
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     private LocalDateTime localDateTime;
 
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     private LocalTime localTime;
 
     @JsonFormat(


### PR DESCRIPTION
https://issues.jboss.org/browse/PLANNER-1356

@mswiderski Please take a look. The real change is only those 4 lines in `JSONMarshaller`. The rest are tests proving that all of the changes are necessary and that it has the expected outcome.

CC @ge0ffrey, @sterobin (Doc), @rsynek or @sutaakar (QE).