### PR TITLE
[JBPM-7974] kie-server not removed from the controller view if server  is killed or crashes

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerHealthCheckControllerImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerHealthCheckControllerImpl.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.server.controller.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.kie.server.api.model.KieServerInfo;
+import org.kie.server.controller.api.ModelFactory;
+import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
+import org.kie.server.controller.api.model.spec.ServerTemplate;
+import org.kie.server.controller.api.model.spec.ServerTemplateKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KieServerHealthCheckControllerImpl extends KieServerControllerImpl {
+
+    private static final String PING_ALIVE_TIMEOUT = "org.kie.controller.ping.alive.timeout";
+
+    private static final String PING_ALIVE_DISABLED = "org.kie.controller.ping.alive.disable";
+
+    private static long PING_INTERVAL;
+
+    private static boolean PING_DISABLED;
+
+    private static final Logger logger = LoggerFactory.getLogger(KieServerHealthCheckControllerImpl.class);
+
+    private Ping ping;
+
+    private ExecutorService executorService;
+
+    static {
+        try {
+            PING_INTERVAL = Long.parseLong(System.getProperty(PING_ALIVE_TIMEOUT, "5000"));
+        } catch (NumberFormatException e) {
+            logger.warn("The property " + PING_ALIVE_TIMEOUT + " is not a number; Fallback to 5000 ms ping");
+            PING_INTERVAL = 5000L;
+        }
+        try {
+            PING_DISABLED = Boolean.parseBoolean(System.getProperty(PING_ALIVE_DISABLED, "false"));
+        } catch (NumberFormatException e) {
+            logger.warn("The property " + PING_ALIVE_DISABLED + " is not true/false value; Fallback to false");
+            PING_DISABLED = false;
+        }
+    }
+
+    public void setExecutorService(ExecutorService executorService) {
+        this.executorService = executorService;
+    }
+
+    class Ping implements Runnable {
+
+        private AtomicBoolean stop = new AtomicBoolean(false);
+
+        @Override
+        public void run() {
+            try {
+                while (!stop.get()) {
+                    for (KieServerInfo kieServerInfo : getServerInfoList()) {
+                        ServerInstanceKey serverInstanceKey = ModelFactory.newServerInstanceKey(kieServerInfo.getServerId(), kieServerInfo.getLocation());
+                        if (!KieServerInstanceManager.getInstance().isAlive(serverInstanceKey)) {
+                            logger.debug("ping isAlive " + kieServerInfo.getLocation() + ": KO. disconnected.");
+                            disconnect(kieServerInfo);
+                        } else {
+                            logger.debug("ping isAlive " + kieServerInfo.getLocation() + ": OK");
+                        }
+                    }
+                    Thread.sleep(PING_INTERVAL);
+                }
+            } catch (InterruptedException e) {
+                logger.warn("Rest Kie health check was interrupted");
+            }
+
+        }
+
+        public void stop() {
+            stop.set(true);
+        }
+
+    }
+
+    public synchronized void start() {
+        if (PING_DISABLED) {
+            return;
+        }
+        logger.info("Starting is alive ping");
+        ping = new Ping();
+        executorService.execute(ping);
+
+    }
+
+    public synchronized void stop() {
+        if (PING_DISABLED) {
+            return;
+        }
+        logger.info("Stopping is alive ping");
+        ping.stop();
+        ping = null;
+    }
+
+    private List<KieServerInfo> getServerInfoList() {
+        List<KieServerInfo> serversInfo = new ArrayList<>();
+        List<ServerTemplateKey> templateKeys = getTemplateStorage().loadKeys();
+        for (ServerTemplateKey templateKey : templateKeys) {
+            ServerTemplate template = getTemplateStorage().load(templateKey.getId());
+            for (ServerInstanceKey serverInstanceKey : template.getServerInstanceKeys()) {
+                KieServerInfo serverInfo = new KieServerInfo(template.getId(), template.getName());
+                serverInfo.setLocation(serverInstanceKey.getUrl());
+                serversInfo.add(serverInfo);
+            }
+        }
+        return serversInfo;
+    }
+
+
+
+}

--- a/kie-server-parent/kie-server-controller/kie-server-controller-standalone/src/main/java/org/kie/server/controller/common/StandaloneControllerApplication.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-standalone/src/main/java/org/kie/server/controller/common/StandaloneControllerApplication.java
@@ -22,9 +22,6 @@ import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
 import io.swagger.jaxrs.listing.SwaggerSerializers;
-import org.kie.server.api.KieServerConstants;
-import org.kie.server.controller.api.KieServerController;
-import org.kie.server.controller.api.KieServerControllerConstants;
 import org.kie.server.controller.service.StandaloneKieServerControllerImpl;
 import org.kie.server.controller.service.StandaloneRuntimeManagementServiceImpl;
 import org.kie.server.controller.service.StandaloneSpecManagementServiceImpl;

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerCrashIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerCrashIntegrationTest.java
@@ -1,0 +1,181 @@
+/*
+* Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.integrationtests.controller;
+
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.KieServerEnvironment;
+import org.kie.server.api.model.KieServerConfig;
+import org.kie.server.api.model.KieServerConfigItem;
+import org.kie.server.api.model.KieServerInfo;
+import org.kie.server.api.model.KieServerMode;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.controller.api.KieServerController;
+import org.kie.server.controller.api.model.events.ContainerSpecUpdated;
+import org.kie.server.controller.api.model.events.ServerInstanceConnected;
+import org.kie.server.controller.api.model.events.ServerInstanceDeleted;
+import org.kie.server.controller.api.model.events.ServerInstanceDisconnected;
+import org.kie.server.controller.api.model.events.ServerInstanceUpdated;
+import org.kie.server.controller.api.model.events.ServerTemplateDeleted;
+import org.kie.server.controller.api.model.events.ServerTemplateUpdated;
+import org.kie.server.controller.api.model.runtime.ServerInstanceKeyList;
+import org.kie.server.controller.api.model.spec.ServerTemplate;
+import org.kie.server.controller.api.model.spec.ServerTemplateList;
+import org.kie.server.controller.client.KieServerControllerClientFactory;
+import org.kie.server.controller.client.event.EventHandler;
+import org.kie.server.integrationtests.config.TestConfig;
+import org.kie.server.services.api.KieServerRegistry;
+import org.kie.server.services.impl.KieServerRegistryImpl;
+import org.kie.server.services.impl.controller.DefaultRestControllerImpl;
+import org.kie.server.services.impl.storage.KieServerState;
+import org.kie.server.services.impl.storage.KieServerStateRepository;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class KieControllerCrashIntegrationTest extends KieControllerManagementBaseTest {
+
+    private CountDownLatch serverUp;
+
+    private CountDownLatch serverDown;
+    @Override
+    protected KieServicesClient createDefaultClient() {
+        // we don't need this
+        return null;
+    }
+
+    @Before
+    @Override
+    public void createControllerClient() {
+        EventHandler eventHandler = new EventHandler () {
+            @Override
+            public void onServerInstanceConnected(ServerInstanceConnected serverInstanceConnected) {
+                serverUp.countDown();
+            }
+
+            @Override
+            public void onServerInstanceDeleted(ServerInstanceDeleted serverInstanceDeleted) {}
+
+            @Override
+            public void onServerInstanceDisconnected(ServerInstanceDisconnected serverInstanceDisconnected) {
+                serverDown.countDown();
+            }
+
+            @Override
+            public void onServerTemplateDeleted(ServerTemplateDeleted serverTemplateDeleted) {}
+
+            @Override
+            public void onServerTemplateUpdated(ServerTemplateUpdated serverTemplateUpdated) {}
+
+            @Override
+            public void onServerInstanceUpdated(ServerInstanceUpdated serverInstanceUpdated) {}
+
+            @Override
+            public void onContainerSpecUpdated(ContainerSpecUpdated containerSpecUpdated) {}
+
+        };
+        if (TestConfig.isLocalServer()) {
+            controllerClient = KieServerControllerClientFactory.newWebSocketClient(TestConfig.getControllerWebSocketManagementUrl(),
+                                                                              (String) null,
+                                                                              (String) null, 
+                                                                              eventHandler);
+        } else {
+            controllerClient = KieServerControllerClientFactory.newWebSocketClient(TestConfig.getControllerWebSocketManagementUrl(),
+                                                                              TestConfig.getUsername(),
+                                                                              TestConfig.getPassword(), 
+                                                                              eventHandler);
+        }
+    }
+    
+    @Before
+    @Override
+    public void setup() throws Exception {
+        // simulated kie server
+        super.setup();
+        serverUp = new CountDownLatch(1);
+        serverDown = new CountDownLatch(1);
+    }
+
+    @After
+    public void cleanupEmbeddedKieServer() {
+        // simulated test kie-server
+    }
+
+    @Test
+    public void testCrashAfterRegistered() throws Exception {
+        final String SERVER_TEMPLATE_ID = "template-id";
+        final String SERVER_NAME = "server-name";
+        KieServerEnvironment.setServerId(SERVER_TEMPLATE_ID);
+
+        ServerTemplate serverTemplate = new ServerTemplate(SERVER_TEMPLATE_ID, SERVER_NAME);
+        controllerClient.saveServerTemplate(serverTemplate);
+
+        ServerTemplateList instanceList = controllerClient.listServerTemplates();
+        assertEquals(1, instanceList.getServerTemplates().length);
+
+        // Register kie server in controller.
+        KieServerInfo kieServerInfo = new KieServerInfo(SERVER_TEMPLATE_ID, "1.0.0");
+        kieServerInfo.setLocation("http://127.0.0.1:20000");
+        kieServerInfo.setMode(KieServerMode.PRODUCTION);
+        kieServerInfo.setName(SERVER_NAME);
+
+        KieServerRegistry registry = new KieServerRegistryImpl();
+        KieServerStateRepository dummyKieServerStateRepository = new KieServerStateRepository() {
+
+            @Override
+            public void store(String serverId, KieServerState kieServerState) {}
+
+            @Override
+            public KieServerState load(String serverId) {
+                KieServerState kieServerState = new KieServerState();
+                kieServerState.setControllers(Collections.singleton(TestConfig.getControllerHttpUrl()));
+                kieServerState.setConfiguration(new KieServerConfig());
+
+                if(TestConfig.isLocalServer()) {
+                    kieServerState.getConfiguration().addConfigItem(new KieServerConfigItem(KieServerConstants.CFG_KIE_CONTROLLER_USER, "", null));
+                    kieServerState.getConfiguration().addConfigItem(new KieServerConfigItem(KieServerConstants.CFG_KIE_CONTROLLER_PASSWORD, "", null));
+                } else {
+                    kieServerState.getConfiguration().addConfigItem(new KieServerConfigItem(KieServerConstants.CFG_KIE_CONTROLLER_USER, TestConfig.getUsername(), null));
+                    kieServerState.getConfiguration().addConfigItem(new KieServerConfigItem(KieServerConstants.CFG_KIE_CONTROLLER_PASSWORD, TestConfig.getPassword(), null));
+                }
+                return kieServerState;
+            }
+
+        };
+        registry.registerStateRepository(dummyKieServerStateRepository);
+        KieServerController controller =  new DefaultRestControllerImpl(registry);
+        controller.connect(kieServerInfo);
+        // Check that kie server is registered.
+        serverUp.await(5, TimeUnit.SECONDS);
+        ServerInstanceKeyList list = controllerClient.getServerInstances(instanceList.getServerTemplates()[0].getId());
+        assertNotNull(list.getServerInstanceKeys());
+        assertEquals(1, list.getServerInstanceKeys().length);
+
+        // Check that kie server is deregistered automatically.
+        serverDown.await(5, TimeUnit.SECONDS);
+        list = controllerClient.getServerInstances(instanceList.getServerTemplates()[0].getId());
+        assertNotNull(list.getServerInstanceKeys());
+        assertEquals(0, list.getServerInstanceKeys().length);
+
+    }
+
+}


### PR DESCRIPTION
added logic to the standalone controller to remove servers that were killed or crashed