### PR TITLE
JBPM-8177: Use correct namespace for servlet 3.1

### DIFF
--- a/kie-server-parent/kie-server-wars/kie-server/src/main/ee-resources/WEB-INF/web.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/ee-resources/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          version="3.1"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_1.xsd">
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
   <display-name>KieServer</display-name>
   <servlet>
     <servlet-name>org.kie.server.remote.rest.common.KieServerApplication</servlet-name>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/webc-resources/WEB-INF/web.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/webc-resources/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          version="3.1"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_1.xsd">
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
   <display-name>KieServer</display-name>
   <listener>
     <listener-class>org.jboss.narayana.tomcat.jta.NarayanaJtaServletContextListener</listener-class>


### PR DESCRIPTION
For JEE7 and newer the namespace has changed to http://xmlns.jcp.org/xml/ns/javaee [1] , old one was causing crashes on WebLogic.
Checked on all supported application servers.
@elguardian FYI


[1] https://www.oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/index.html