### PR TITLE
Fix springboot on JDK 11 (jax-ws-api)

### DIFF
--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/src/main/resources/application.properties
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/src/main/resources/application.properties
@@ -14,7 +14,7 @@ jbpm.executor.enabled=false
 #jbpm.executor.threadPoolSize=1
 #jbpm.executor.timeUnit=SECONDS
 
-kieserver.swagger.enabled=true
+kieserver.swagger.enabled=false
 kieserver.location=http://${server.address}:${server.port}${cxf.path}/server
 #kieserver.controllers=
 

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/pom.xml
@@ -105,13 +105,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-
-    <!--Java 11 test dependencies-->
-    <dependency>
-      <groupId>org.jboss.spec.javax.xml.ws</groupId>
-      <artifactId>jboss-jaxws-api_2.3_spec</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
depends on https://github.com/kiegroup/jbpm/pull/1443

2 changes:
* default application.properties of integ-tests-sample shouldn't use swagger, since it is not configured (dismisses the warning)
* kie-server-spring-boot-sample will get JAX-WS API from jbpm-workitems-bpmn2 (previously it wasn't the root module who needed that dependency)