### PR TITLE
KieServerInfo has KieServerMode.REGULAR as a default KIE Server mode

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/KieServerInfo.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/KieServerInfo.java
@@ -36,7 +36,7 @@ public class KieServerInfo {
 
     private List<Message> messages;
 
-    private KieServerMode mode = KieServerMode.REGULAR;
+    private KieServerMode mode = KieServerMode.DEVELOPMENT;
     
     public KieServerInfo() {
         super();
@@ -49,7 +49,7 @@ public class KieServerInfo {
     }
 
     public KieServerInfo(String serverId, String name, String version, List<String> capabilities, String location) {
-        this(serverId, name, version, capabilities, location, KieServerMode.REGULAR);
+        this(serverId, name, version, capabilities, location, KieServerMode.DEVELOPMENT);
     }
 
     public KieServerInfo(String serverId, String name, String version, List<String> capabilities, String location, KieServerMode mode) {


### PR DESCRIPTION
Default KIE Server mode is KieServerMode.DEVELOPMENT, so we should reflect it in KieServerInfo entity as well.

@mswiderski I have also noticed that although by default DEVELOPMENT mode is activated, which will allow undeployment while there are still active process instances present, it won't abort them by default. Thus leaving the developer in a possibly inconsistent situation. Shouldn't we make this aborting default in DEVELOPMENT mode? Currently it is not very safe. Perhaps explicitly allowing to undeploy without aborting of processes would be better?
