### PR TITLE
[7.18.x] Add missing big math library to DMN Fuse feature

### DIFF
--- a/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features-fuse.xml
+++ b/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features-fuse.xml
@@ -38,6 +38,7 @@
 
   <feature name="kie-dmn" description="Kie DMN" version="${project.version}">
     <feature version="${project.version}">drools-module</feature>
+    <bundle>mvn:ch.obermuhlner/big-math/${version.ch.obermuhlner}</bundle>
     <bundle>mvn:org.drools/drlx-parser/${version.org.kie}</bundle>
     <bundle>mvn:org.kie/kie-dmn-model/${version.org.kie}</bundle>
     <bundle>mvn:org.kie/kie-dmn-api/${version.org.kie}</bundle>


### PR DESCRIPTION
This library was added to features.xml but was missing in features for Fuse