### PR TITLE
[DROOLS-3654] Add org.kie:kie-gwthelper-maven-plugin

### DIFF
--- a/kie-gwthelper-maven-plugin/Readme.md
+++ b/kie-gwthelper-maven-plugin/Readme.md
@@ -1,0 +1,46 @@
+KIE GWT Helper Maven Plugin
+=======================
+
+Scope of this plugin is to include arbitrary directories (in whatever location of local filesystem) to the runtime sources of a GWT project,
+so that GWT' Super Dev Mode will listen for changes also in those sources, eventually recompiling them when they change.
+
+The main difference with the maven-dependency addSources goal is that this plugin recursively scan a given directory to find
+GWT modules, eventually filtering them based on  **includes/excludes** patterns (optional).
+
+GWT modules are individuated if the directory contains a **src/main/resources/()/().gwt.xml** file.
+
+**includes/excludes** patterns are simple **contains** evaluation on the (full) **gwt.xml** file name; i.e. they are matched if that name **contains** those pattern, **case-sensitive**.
+
+**includes/excludes are mutually exclusive!** If provide both, the plugin will throw an exception.
+
+Moreover, it requires a single parameter to define the folder to scan, so that these parameter may be included as **property** in private user settings,
+to allow different configuration on different machine.
+
+There are three configuration parameters:
+
+1. rootDirectories (required): comma-separated list of absolute/relative paths of directory to scan
+2. includes (optional): comma-separated list of pattern to **include** the module
+3. excludes (optional): comma-separated list of pattern to **exclude** the module
+
+
+Here's an example of a valid configuration:
+
+    <plugin>
+          <groupId>org.kie</groupId>
+          <artifactId>kie-gwthelper-maven-plugin</artifactId>
+          <version>1.1</version>
+          <executions>
+            <execution>
+                <id>add-source</id>
+                <phase>generate-sources</phase>
+                <goals>
+                    <goal>add-source</goal>
+                </goals>
+                <configuration>
+                    <excludes>API,Mock</excludes> <!-- will exclude all GWT module whose configuration file name contains API or Mock -->
+                    <rootDirectories>../common-screens,/home/user/Developing/git/parent-big/external-widgets</rootDirectories> <!-- will search inside those two directories -->
+                </configuration>
+             </execution>
+          </executions>
+    </plugin>
+

--- a/kie-gwthelper-maven-plugin/pom.xml
+++ b/kie-gwthelper-maven-plugin/pom.xml
@@ -16,16 +16,15 @@
   <name>KIE :: Gwt Helper Maven Plugin</name>
 
   <prerequisites>
-    <maven>${maven.required.version}</maven>
+    <maven>${version.maven.required}</maven>
   </prerequisites>
 
   <properties>
-    <maven.required.version>3.0</maven.required.version>
-    <plexus.component.annotations>1.7.1</plexus.component.annotations>
-    <plexus.utils.version>3.1.0</plexus.utils.version>
-    <maven.artifact.version>3.6.0</maven.artifact.version>
-    <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
-    <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
+    <version.maven.required>3.0</version.maven.required>
+    <version.plexus.component.annotations>1.7.1</version.plexus.component.annotations>
+    <version.maven.artifact>3.6.0</version.maven.artifact>
+    <version.maven.source.plugin>3.0.1</version.maven.source.plugin>
+    <version.maven.javadoc.plugin>3.0.1</version.maven.javadoc.plugin>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -54,16 +53,12 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-component-annotations</artifactId>
-        <version>${plexus.component.annotations}</version>
+        <version>${version.plexus.component.annotations}</version>
       </dependency>
-      <!--<dependency>-->
-        <!--<groupId>org.codehaus.plexus</groupId>-->
-        <!--<artifactId>plexus-utils</artifactId>-->
-      <!--</dependency>-->
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-artifact</artifactId>
-        <version>${maven.artifact.version}</version>
+        <version>${version.maven.artifact}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -87,7 +82,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>${maven.source.plugin.version}</version>
+            <version>${version.maven.source.plugin}</version>
             <executions>
               <execution>
                 <id>attach-sources</id>
@@ -100,7 +95,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>${maven.javadoc.plugin.version}</version>
+            <version>${version.maven.javadoc.plugin}</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>

--- a/kie-gwthelper-maven-plugin/pom.xml
+++ b/kie-gwthelper-maven-plugin/pom.xml
@@ -11,7 +11,6 @@
 
   <groupId>org.kie</groupId>
   <artifactId>kie-gwthelper-maven-plugin</artifactId>
-  <version>1.0</version>
   <packaging>maven-plugin</packaging>
 
   <name>KIE :: Gwt Helper Maven Plugin</name>

--- a/kie-gwthelper-maven-plugin/pom.xml
+++ b/kie-gwthelper-maven-plugin/pom.xml
@@ -12,6 +12,7 @@
   <groupId>org.kie</groupId>
   <artifactId>kie-gwthelper-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
+  <version>${version.org.kie.gwthelper.maven}</version>
 
   <name>KIE :: Gwt Helper Maven Plugin</name>
 

--- a/kie-gwthelper-maven-plugin/pom.xml
+++ b/kie-gwthelper-maven-plugin/pom.xml
@@ -22,14 +22,11 @@
 
   <properties>
     <maven.required.version>3.0</maven.required.version>
-    <maven.version>3.6.0</maven.version>
     <plexus.component.annotations>1.7.1</plexus.component.annotations>
     <plexus.utils.version>3.1.0</plexus.utils.version>
     <maven.artifact.version>3.6.0</maven.artifact.version>
     <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
     <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
-    <maven.compiler.source>8</maven.compiler.source>
-    <maven.compiler.target>8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -37,17 +34,18 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>${maven.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>${maven.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>${maven.version}</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -59,11 +57,10 @@
         <artifactId>plexus-component-annotations</artifactId>
         <version>${plexus.component.annotations}</version>
       </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-utils</artifactId>
-        <version>${plexus.utils.version}</version>
-      </dependency>
+      <!--<dependency>-->
+        <!--<groupId>org.codehaus.plexus</groupId>-->
+        <!--<artifactId>plexus-utils</artifactId>-->
+      <!--</dependency>-->
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-artifact</artifactId>
@@ -77,7 +74,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>${maven.version}</version>
         <configuration>
           <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
         </configuration>

--- a/kie-gwthelper-maven-plugin/pom.xml
+++ b/kie-gwthelper-maven-plugin/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.drools</groupId>
+    <artifactId>droolsjbpm-integration</artifactId>
+    <version>7.19.0-SNAPSHOT</version>
+  </parent>
+
+  <groupId>org.kie</groupId>
+  <artifactId>kie-gwthelper-maven-plugin</artifactId>
+  <version>1.0</version>
+  <packaging>maven-plugin</packaging>
+
+  <name>KIE :: Gwt Helper Maven Plugin</name>
+
+  <prerequisites>
+    <maven>${maven.required.version}</maven>
+  </prerequisites>
+
+  <properties>
+    <maven.required.version>3.0</maven.required.version>
+    <maven.version>3.6.0</maven.version>
+    <plexus.component.annotations>1.7.1</plexus.component.annotations>
+    <plexus.utils.version>3.1.0</plexus.utils.version>
+    <maven.artifact.version>3.6.0</maven.artifact.version>
+    <maven.source.plugin.version>3.0.1</maven.source.plugin.version>
+    <maven.javadoc.plugin.version>3.0.1</maven.javadoc.plugin.version>
+    <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${maven.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-plugin-api</artifactId>
+      <version>${maven.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.plugin-tools</groupId>
+      <artifactId>maven-plugin-annotations</artifactId>
+      <version>${maven.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-component-annotations</artifactId>
+        <version>${plexus.component.annotations}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>${plexus.utils.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-artifact</artifactId>
+        <version>${maven.artifact.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-plugin-plugin</artifactId>
+        <version>${maven.version}</version>
+        <configuration>
+          <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>${maven.source.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${maven.javadoc.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
+
+</project>

--- a/kie-gwthelper-maven-plugin/src/main/java/org/kie/maven/gwthelper/plugin/AddSourceMojo.java
+++ b/kie-gwthelper-maven-plugin/src/main/java/org/kie/maven/gwthelper/plugin/AddSourceMojo.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.maven.gwthelper.plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.StringUtils;
+
+/**
+ * Add more source directories to the POM.
+ */
+@Mojo(name = "add-source", defaultPhase = LifecyclePhase.GENERATE_SOURCES, threadSafe = true)
+public class AddSourceMojo  extends AbstractMojo {
+
+    private final static String SRC_MAIN_JAVA = "/src/main/java".replace("/", System.getProperty("file.separator"));
+    private final static String SRC_MAIN_RESOURCES = "/src/main/resources".replace("/", System.getProperty("file.separator"));
+
+    /**
+     * Comma-separated additional source directories.
+     * @since 0.1
+     */
+    @Parameter(required = true)
+    private String rootDirectories;
+
+    /**
+     * Comma-separated pattern to match for including modules.
+     * Does not use regex, but simple string
+     * @since 0.1
+     */
+    @Parameter(required = false)
+    private String includes;
+
+    /**
+     * Comma-separated pattern to match for excluding modules.
+     * Does not use regex, but simple string
+     * @since 0.1
+     */
+    @Parameter(required = false)
+    private String excludes;
+
+    /**
+     * @since 0.1
+     */
+    @Parameter(readonly = true, defaultValue = "${project}")
+    private MavenProject project;
+
+    public void execute() throws MojoExecutionException {
+        if (StringUtils.isNotEmpty(includes) && StringUtils.isNotEmpty(excludes)) {
+            throw new MojoExecutionException("Only one of 'includes' or 'excludes' can be provided");
+        }
+        String[] rootDirectoryPaths = rootDirectories.split(",");
+        for (String rootDirectoryPath : rootDirectoryPaths) {
+            File rootDirectory = new File(rootDirectoryPath);
+            loopForMavenModules(rootDirectory);
+        }
+    }
+
+    /**
+     * Method to recursively <i>filter</i> only <b>maven</b> directories, i.e. directories containing a <b>pom.xml</b> file
+     * @param source
+     * @throws MojoExecutionException
+     */
+    private void loopForMavenModules(File source) throws MojoExecutionException {
+        checkReadableDirectory(source);
+        if (isMavenModule(source)) {
+            getLog().debug("mavenModule " + source.getAbsolutePath());
+            loopForGwtModule(source);
+            List<File> sources = Arrays.asList(source.listFiles());
+            for (File file : sources) {
+                if (file.isDirectory()) {
+                    loopForMavenModules(file);
+                }
+            }
+        }
+    }
+
+    /**
+     * Method to recursively <i>filter</i> only <b>gwt</b> directories, i.e. directories containing a <b>/src/main/resources/(..)/(..).gwt.xml</b> file
+     * @param source
+     * @throws MojoExecutionException
+     */
+    private void loopForGwtModule(File source) throws MojoExecutionException {
+        getLog().debug("loopForGwtModule " + source.getAbsolutePath());
+        if (isValidGwtModule(source)) {
+            File sources = new File(source.getAbsolutePath() + SRC_MAIN_JAVA);
+            checkReadableDirectory(sources);
+            this.project.addCompileSourceRoot(sources.getAbsolutePath());
+            if (getLog().isInfoEnabled()) {
+                getLog().info("Source directory: " + sources + " added.");
+            }
+            File resources = new File(source.getAbsolutePath() + SRC_MAIN_RESOURCES);
+            this.project.addCompileSourceRoot(resources.getAbsolutePath());
+            if (getLog().isInfoEnabled()) {
+                getLog().info("Source directory: " + resources + " added.");
+            }
+        }
+    }
+
+    /**
+     * Method to check if in the given directory is a <i>valid</i> <b>Gwt</b> module, i.e. it contains a "src/main/resources/./.gwt.xml" file
+     * eventually matching the <b>includes/excludes</b> patterns
+     * @param toCheck
+     * @return
+     * @throws MojoExecutionException
+     */
+    private boolean isValidGwtModule(File toCheck) throws MojoExecutionException {
+        getLog().debug("isValidGwtModule " + toCheck.getAbsolutePath());
+        File resources = new File(toCheck.getAbsolutePath() + SRC_MAIN_RESOURCES);
+        if (!resources.exists()) {
+            return false;
+        }
+        boolean toReturn = false;
+        try {
+            final Optional<Path> first = Files.walk(Paths.get(resources.getAbsolutePath()))
+                    .filter(Files::isRegularFile)
+                    .filter(path -> path.toString().endsWith(".gwt.xml")).findFirst();
+            if (first.isPresent()) {
+                String fileName = first.get().getFileName().toString();
+                if (StringUtils.isNotEmpty(includes)) {
+                    toReturn = matchPattern(fileName, includes);
+                } else if (StringUtils.isNotEmpty(excludes)) {
+                    toReturn = !matchPattern(fileName, excludes);
+                } else {
+                    toReturn = true;
+                }
+            }
+        } catch (IOException e) {
+            String errorMessage = StringUtils.isEmpty(e.getMessage()) ? e.getClass().getName() : e.getMessage();
+            errorMessage += " while analyzing " + toCheck.getAbsolutePath();
+            throw new MojoExecutionException(errorMessage);
+        }
+        return toReturn;
+    }
+
+    /**
+     * Method to check if the given directory is a <b>Maven</b> module (it contains <b>pom.xml</b>)
+     * @param toCheck
+     * @return
+     */
+    private boolean isMavenModule(File toCheck) {
+        return toCheck.isDirectory() && toCheck.list() != null && Arrays.asList(toCheck.list()).contains("pom.xml");
+    }
+
+    /**
+     * Method to check if the given String contains one of the comma-separated pattern.
+     * Matching is done with String.contains()
+     * @param toCheck
+     * @param pattern
+     * @return
+     */
+    private boolean matchPattern(String toCheck, String pattern) {
+        return Arrays.stream(pattern.split(",")).anyMatch(toCheck::contains);
+    }
+
+    /**
+     * Method to check if the given file is an <b>existing, readable, directory</b>
+     * @param toCheck
+     * @throws MojoExecutionException if check fails
+     */
+    private void checkReadableDirectory(File toCheck) throws MojoExecutionException {
+        if (!toCheck.exists() || !toCheck.canRead() || !toCheck.isDirectory()) {
+            throw new MojoExecutionException("Directory " + toCheck.getAbsolutePath() + " is not a readable directory");
+        }
+    }
+}

--- a/kie-gwthelper-maven-plugin/src/main/java/org/kie/maven/gwthelper/plugin/AddSourceMojo.java
+++ b/kie-gwthelper-maven-plugin/src/main/java/org/kie/maven/gwthelper/plugin/AddSourceMojo.java
@@ -39,11 +39,10 @@ import org.codehaus.plexus.util.StringUtils;
 public class AddSourceMojo  extends AbstractMojo {
 
     private final static String SRC_MAIN_JAVA = "/src/main/java".replace("/", System.getProperty("file.separator"));
-    private final static String SRC_MAIN_RESOURCES = "/src/main/resources".replace("/", System.getProperty("file.separator"));
+    private final static String SRC_MAIN_RESOURCES = "/src/main/resources".replace("/", File.separator);
 
     /**
      * Comma-separated additional source directories.
-     * @since 0.1
      */
     @Parameter(required = true)
     private String rootDirectories;
@@ -51,7 +50,6 @@ public class AddSourceMojo  extends AbstractMojo {
     /**
      * Comma-separated pattern to match for including modules.
      * Does not use regex, but simple string
-     * @since 0.1
      */
     @Parameter(required = false)
     private String includes;
@@ -59,14 +57,11 @@ public class AddSourceMojo  extends AbstractMojo {
     /**
      * Comma-separated pattern to match for excluding modules.
      * Does not use regex, but simple string
-     * @since 0.1
+     *
      */
     @Parameter(required = false)
     private String excludes;
 
-    /**
-     * @since 0.1
-     */
     @Parameter(readonly = true, defaultValue = "${project}")
     private MavenProject project;
 
@@ -126,7 +121,7 @@ public class AddSourceMojo  extends AbstractMojo {
      * Method to check if in the given directory is a <i>valid</i> <b>Gwt</b> module, i.e. it contains a "src/main/resources/./.gwt.xml" file
      * eventually matching the <b>includes/excludes</b> patterns
      * @param toCheck
-     * @return
+     * @return <code>true</code> if the given directory contains a <b>Gwt</b> module, <code>false</code> otherwise
      * @throws MojoExecutionException
      */
     private boolean isValidGwtModule(File toCheck) throws MojoExecutionException {
@@ -161,7 +156,7 @@ public class AddSourceMojo  extends AbstractMojo {
     /**
      * Method to check if the given directory is a <b>Maven</b> module (it contains <b>pom.xml</b>)
      * @param toCheck
-     * @return
+     * @return <code>true</code> if the given directory contains a <b>Maven</b> module, <code>false</code> otherwise
      */
     private boolean isMavenModule(File toCheck) {
         return toCheck.isDirectory() && toCheck.list() != null && Arrays.asList(toCheck.list()).contains("pom.xml");
@@ -172,7 +167,7 @@ public class AddSourceMojo  extends AbstractMojo {
      * Matching is done with String.contains()
      * @param toCheck
      * @param pattern
-     * @return
+     * @return <code>true</code> if the <b>toCheck</b> String contains the <b>pattern</b> one, <code>false</code> otherwise
      */
     private boolean matchPattern(String toCheck, String pattern) {
         return Arrays.stream(pattern.split(",")).anyMatch(toCheck::contains);

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
     <module>kie-swagger-ui</module>
     <module>kie-identity-session-provider</module>
     <module>kie-maven-plugin</module>
+    <module>kie-gwthelper-maven-plugin</module>
     <module>kie-takari-plugin</module>
     <!-- The example can not be in the build because of the chicken-egg problem with depending on the plugin,
          that is about to be build in the same Maven reactor build -->


### PR DESCRIPTION
@ederign @porcelli @manstis @danielezonca

Scope of this PR is to add the org.kie:kie-gwthelper-maven-plugin to droolsjbpm-integration.

For some reason, I have to disable enforcer check to build the plugin, since it fails on java version.
I see the enforcer is configured to have "8" as version, and in my machine I have JDK 1.8. Other modules correctly build, but I could not figure out what is the issue.