### PR TITLE
AF-1865: [Streamline Development Lifcycle] Fix backguard compatibilities and improve 'dev mode' deployment policy

### DIFF
--- a/camel-container-tests/camel-container-integration-tests/pom.xml
+++ b/camel-container-tests/camel-container-integration-tests/pom.xml
@@ -177,7 +177,6 @@
                 <type>installed</type>
                 <systemProperties>
                   <kie.maven.settings.custom>${kie.maven.settings.custom}</kie.maven.settings.custom>
-                  <org.kie.server.mode>regular</org.kie.server.mode>
                 </systemProperties>
               </container>
               <deployables>
@@ -284,7 +283,6 @@
                 <type>installed</type>
                 <systemProperties>
                   <kie.maven.settings.custom>${kie.maven.settings.custom}</kie.maven.settings.custom>
-                  <org.kie.server.mode>regular</org.kie.server.mode>
                 </systemProperties>
               </container>
               <deployables>

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/KieServerInfo.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/KieServerInfo.java
@@ -36,7 +36,7 @@ public class KieServerInfo {
 
     private List<Message> messages;
 
-    private KieServerMode mode = KieServerMode.DEVELOPMENT;
+    private KieServerMode mode = KieServerMode.REGULAR;
     
     public KieServerInfo() {
         super();
@@ -49,7 +49,7 @@ public class KieServerInfo {
     }
 
     public KieServerInfo(String serverId, String name, String version, List<String> capabilities, String location) {
-        this(serverId, name, version, capabilities, location, KieServerMode.DEVELOPMENT);
+        this(serverId, name, version, capabilities, location, KieServerMode.REGULAR);
     }
 
     public KieServerInfo(String serverId, String name, String version, List<String> capabilities, String location, KieServerMode mode) {

--- a/kie-server-parent/kie-server-controller/kie-server-controller-openshift/src/main/java/org/kie/server/controller/openshift/storage/ServerTemplateConverter.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-openshift/src/main/java/org/kie/server/controller/openshift/storage/ServerTemplateConverter.java
@@ -65,7 +65,7 @@ public class ServerTemplateConverter {
         ServerTemplate template = new ServerTemplate();
         String id = state.getConfiguration().getConfigItemValue(KieServerConstants.KIE_SERVER_ID);
         String url = resolveServerUrl(state);
-        String mode = state.getConfiguration().getConfigItemValue(KieServerConstants.KIE_SERVER_MODE, KieServerMode.DEVELOPMENT.name());
+        String mode = state.getConfiguration().getConfigItemValue(KieServerConstants.KIE_SERVER_MODE, KieServerMode.REGULAR.name());
 
         template.setId(id);
         template.setName(id);

--- a/kie-server-parent/kie-server-controller/kie-server-controller-openshift/src/test/resources/test-kieserver-state-config-map.yml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-openshift/src/test/resources/test-kieserver-state-config-map.yml
@@ -34,7 +34,7 @@ data:
         <configItems>
           <config-item>
             <name>org.kie.server.mode</name>
-            <value>DEVELOPMENT</value>
+            <value>REGULAR</value>
             <type>java.lang.String</type>
           </config-item>
           <config-item>

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/AbstractKieServerImplTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/AbstractKieServerImplTest.java
@@ -69,8 +69,6 @@ import org.kie.server.services.impl.controller.DefaultRestControllerImpl;
 import org.kie.server.services.impl.storage.KieServerState;
 import org.kie.server.services.impl.storage.KieServerStateRepository;
 import org.kie.server.services.impl.storage.file.KieServerStateFileRepository;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -79,9 +77,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -118,7 +114,6 @@ public abstract class AbstractKieServerImplTest {
         System.setProperty(KieServerConstants.KIE_SERVER_ID, KIE_SERVER_ID);
         KieServerEnvironment.setServerId(KIE_SERVER_ID);
 
-
         FileUtils.deleteDirectory(REPOSITORY_DIR);
         FileUtils.forceMkdir(REPOSITORY_DIR);
         kieServer = new KieServerImpl(new KieServerStateFileRepository(REPOSITORY_DIR)) {
@@ -130,7 +125,7 @@ public abstract class AbstractKieServerImplTest {
         kieServer.init();
     }
 
-    private String getVersion(KieServerMode mode) {
+    protected String getVersion(KieServerMode mode) {
         return mode.equals(KieServerMode.DEVELOPMENT) ? DEVELOPMENT_MODE_VERSION : REGULAR_MODE_VERSION;
     }
 
@@ -152,7 +147,7 @@ public abstract class AbstractKieServerImplTest {
         assertTrue(kieServer.isKieServerReady());
     }
 
-    @Test(timeout=10000)
+    @Test(timeout = 10000)
     public void testReadinessCheckDelayedStart() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         CountDownLatch startedlatch = new CountDownLatch(1);
@@ -189,7 +184,7 @@ public abstract class AbstractKieServerImplTest {
         assertEquals(1, footer.getMessages().size());
     }
 
-    @Test(timeout=10000)
+    @Test(timeout = 10000)
     public void testHealthCheckDelayedStart() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         CountDownLatch startedlatch = new CountDownLatch(1);
@@ -226,7 +221,6 @@ public abstract class AbstractKieServerImplTest {
                 containers.add(container);
                 return containers;
             }
-
         };
         kieServer.init();
         List<Message> healthMessages = kieServer.healthCheck(false);
@@ -372,7 +366,6 @@ public abstract class AbstractKieServerImplTest {
 
                 assertForbiddenResponse(forbidden);
             }
-
         } finally {
             System.clearProperty(KieServerConstants.KIE_SERVER_MGMT_API_DISABLED);
         }
@@ -455,22 +448,6 @@ public abstract class AbstractKieServerImplTest {
     }
 
     @Test
-    public void testCreateContainerValidationModeConflict() {
-        String containerId = "container-to-create";
-
-        createEmptyKjar(containerId);
-
-        ReleaseId testReleaseId = new ReleaseId(GROUP_ID, containerId, getVersion(mode.equals(KieServerMode.DEVELOPMENT) ? KieServerMode.REGULAR : KieServerMode.DEVELOPMENT));
-
-        // create the container (provide scanner info as well)
-        KieContainerResource kieContainerResource = new KieContainerResource(containerId, testReleaseId);
-        KieScannerResource kieScannerResource = new KieScannerResource(KieScannerStatus.STARTED, 20000L);
-        kieContainerResource.setScanner(kieScannerResource);
-        ServiceResponse<KieContainerResource> createResponse = kieServer.createContainer(containerId, kieContainerResource);
-        Assertions.assertThat(createResponse.getType()).isEqualTo(ServiceResponse.ResponseType.FAILURE);
-    }
-
-    @Test
     public void testUpdateContainer() {
         KieServerExtension extension = mock(KieServerExtension.class);
         when(extension.isUpdateContainerAllowed(any(), any(), any())).thenReturn(true);
@@ -509,27 +486,6 @@ public abstract class AbstractKieServerImplTest {
     }
 
     @Test
-    public void testUpdateContainerWithModeConflict() {
-        KieServerExtension extension = mock(KieServerExtension.class);
-        when(extension.isUpdateContainerAllowed(any(), any(), any())).thenReturn(false);
-        extensions.add(extension);
-
-        String containerId = "container-to-update";
-
-        startContainerToUpdate(containerId);
-
-        ReleaseId updateReleaseId = new ReleaseId(GROUP_ID, containerId, getVersion(mode.equals(KieServerMode.DEVELOPMENT) ? KieServerMode.REGULAR : KieServerMode.DEVELOPMENT));
-
-        ServiceResponse<ReleaseId> updateResponse = kieServer.updateContainerReleaseId(containerId, updateReleaseId, true);
-        Assertions.assertThat(updateResponse.getType()).isEqualTo(ServiceResponse.ResponseType.FAILURE);
-
-        verify(extension, never()).isUpdateContainerAllowed(anyString(), any(), any());
-        verify(extension, never()).updateContainer(any(), any(), any());
-
-        kieServer.disposeContainer(containerId);
-    }
-
-    @Test
     public void testUpdateContainerWithNullReleaseID() {
         KieServerExtension extension = mock(KieServerExtension.class);
         when(extension.isUpdateContainerAllowed(any(), any(), any())).thenReturn(false);
@@ -548,7 +504,7 @@ public abstract class AbstractKieServerImplTest {
         kieServer.disposeContainer(containerId);
     }
 
-    private void startContainerToUpdate(String containerId) {
+    protected void startContainerToUpdate(String containerId) {
         createEmptyKjar(containerId);
 
         ReleaseId releaseId = new ReleaseId(this.releaseId);
@@ -649,10 +605,8 @@ public abstract class AbstractKieServerImplTest {
                             throw new KieControllerNotConnectedException("Unable to connect to any controller");
                         }
                     }
-
                 };
             }
-
         };
         server.init();
         return server;
@@ -684,7 +638,6 @@ public abstract class AbstractKieServerImplTest {
                                 "expected: releaseId=" + configuredReleaseId + ", resolvedReleaseId=" + resolvedReleaseId);
     }
 
-
     protected void createEmptyKjar(String artifactId) {
         createEmptyKjar(artifactId, testVersion);
     }
@@ -694,8 +647,8 @@ public abstract class AbstractKieServerImplTest {
         KieServices kieServices = KieServices.Factory.get();
         KieFileSystem kfs = kieServices.newKieFileSystem();
         releaseId = kieServices.newReleaseId(GROUP_ID, artifactId, version);
-        KieModule kieModule = kieServices.newKieBuilder(kfs ).buildAll().getKieModule();
-        KieMavenRepository.getKieMavenRepository().installArtifact(releaseId, (InternalKieModule)kieModule, createPomFile(artifactId, version ) );
+        KieModule kieModule = kieServices.newKieBuilder(kfs).buildAll().getKieModule();
+        KieMavenRepository.getKieMavenRepository().installArtifact(releaseId, (InternalKieModule) kieModule, createPomFile(artifactId, version));
         kieServices.getRepository().addKieModule(kieModule);
     }
 
@@ -718,5 +671,4 @@ public abstract class AbstractKieServerImplTest {
             throw new RuntimeException(e);
         }
     }
-
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerImplRegularModeTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerImplRegularModeTest.java
@@ -15,9 +15,24 @@
 
 package org.kie.server.services.impl;
 
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.server.api.model.KieContainerResource;
+import org.kie.server.api.model.KieScannerResource;
+import org.kie.server.api.model.KieScannerStatus;
 import org.kie.server.api.model.KieServerMode;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.services.api.KieServerExtension;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class KieServerImplRegularModeTest extends AbstractKieServerImplTest {
@@ -25,5 +40,42 @@ public class KieServerImplRegularModeTest extends AbstractKieServerImplTest {
     @Override
     KieServerMode getTestMode() {
         return KieServerMode.REGULAR;
+    }
+
+    @Test
+    public void testCreateContainerValidationGAVConflict() {
+        String containerId = "container-to-create";
+
+        createEmptyKjar(containerId);
+
+        ReleaseId testReleaseId = new ReleaseId(GROUP_ID, containerId, getVersion(KieServerMode.DEVELOPMENT));
+
+        // create the container (provide scanner info as well)
+        KieContainerResource kieContainerResource = new KieContainerResource(containerId, testReleaseId);
+        KieScannerResource kieScannerResource = new KieScannerResource(KieScannerStatus.STARTED, 20000L);
+        kieContainerResource.setScanner(kieScannerResource);
+        ServiceResponse<KieContainerResource> createResponse = kieServer.createContainer(containerId, kieContainerResource);
+        Assertions.assertThat(createResponse.getType()).isEqualTo(ServiceResponse.ResponseType.FAILURE);
+    }
+
+    @Test
+    public void testUpdateContainerWithGAVConflict() {
+        KieServerExtension extension = mock(KieServerExtension.class);
+        when(extension.isUpdateContainerAllowed(any(), any(), any())).thenReturn(false);
+        extensions.add(extension);
+
+        String containerId = "container-to-update";
+
+        startContainerToUpdate(containerId);
+
+        ReleaseId updateReleaseId = new ReleaseId(GROUP_ID, containerId, getVersion(KieServerMode.DEVELOPMENT));
+
+        ServiceResponse<ReleaseId> updateResponse = kieServer.updateContainerReleaseId(containerId, updateReleaseId, true);
+        Assertions.assertThat(updateResponse.getType()).isEqualTo(ServiceResponse.ResponseType.FAILURE);
+
+        verify(extension, never()).isUpdateContainerAllowed(anyString(), any(), any());
+        verify(extension, never()).updateContainer(any(), any(), any());
+
+        kieServer.disposeContainer(containerId);
     }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
@@ -11,7 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
 
 package org.kie.server.services.jbpm;
 
@@ -118,7 +118,6 @@ import org.kie.server.services.api.KieServerExtension;
 import org.kie.server.services.api.KieServerRegistry;
 import org.kie.server.services.api.SupportedTransports;
 import org.kie.server.services.impl.KieServerImpl;
-import org.kie.server.services.impl.util.KieServerUtils;
 import org.kie.server.services.jbpm.admin.ProcessAdminServiceBase;
 import org.kie.server.services.jbpm.admin.UserTaskAdminServiceBase;
 import org.kie.server.services.jbpm.jpa.PersistenceUnitInfoImpl;
@@ -137,7 +136,7 @@ public class JbpmKieServerExtension implements KieServerExtension {
     private static final Boolean disabled = Boolean.parseBoolean(System.getProperty(KieServerConstants.KIE_JBPM_SERVER_EXT_DISABLED, "false"));
 
     protected static final Pattern PARAMETER_MATCHER = Pattern.compile("\\$\\{([\\S&&[^\\}]]+)\\}", Pattern.DOTALL);
-   
+
     protected boolean isExecutorAvailable = false;
 
     protected String persistenceUnitName = KieServerConstants.KIE_SERVER_PERSISTENCE_UNIT_NAME;
@@ -187,7 +186,6 @@ public class JbpmKieServerExtension implements KieServerExtension {
         this.kieServer = kieServer;
         this.context = registry;
         configureServices(kieServer, registry);
-        
 
         if (registry.getKieSessionLookupManager() != null) {
             registry.getKieSessionLookupManager().addHandler(new JBPMKieSessionLookupHandler());
@@ -204,7 +202,7 @@ public class JbpmKieServerExtension implements KieServerExtension {
         services.add(processInstanceMigrationService);
         services.add(processInstanceAdminService);
         services.add(userTaskAdminService);
-        
+
         registerDefaultQueryDefinitions();
         initialized = true;
     }
@@ -222,7 +220,6 @@ public class JbpmKieServerExtension implements KieServerExtension {
         }
 
         this.isExecutorAvailable = isExecutorOnClasspath();
-
 
         EntityManagerFactory emf = build(getPersistenceProperties(config));
         EntityManagerFactoryManager.get().addEntityManagerFactory(persistenceUnitName, emf);
@@ -257,8 +254,8 @@ public class JbpmKieServerExtension implements KieServerExtension {
         ((RuntimeDataServiceImpl) runtimeDataService).setIdentityProvider(registry.getIdentityProvider());
         ((RuntimeDataServiceImpl) runtimeDataService).setTaskService(taskService);
         ((RuntimeDataServiceImpl) runtimeDataService).setTaskAuditService(TaskAuditServiceFactory.newTaskAuditServiceConfigurator()
-                .setTaskService(taskService)
-                .getTaskAuditService());
+                                                                                  .setTaskService(taskService)
+                                                                                  .getTaskAuditService());
         ((KModuleDeploymentService) deploymentService).setRuntimeDataService(runtimeDataService);
 
         // build process service
@@ -273,8 +270,8 @@ public class JbpmKieServerExtension implements KieServerExtension {
 
         // build query service
         queryService = new QueryServiceImpl();
-        ((QueryServiceImpl)queryService).setIdentityProvider(registry.getIdentityProvider());
-        ((QueryServiceImpl)queryService).setCommandService(new TransactionalCommandService(emf));
+        ((QueryServiceImpl) queryService).setIdentityProvider(registry.getIdentityProvider());
+        ((QueryServiceImpl) queryService).setCommandService(new TransactionalCommandService(emf));
         Function<String, String> kieServerDataSourceResolver = input -> {
             String dataSource = input;
             Matcher matcher = PARAMETER_MATCHER.matcher(dataSource);
@@ -284,11 +281,11 @@ public class JbpmKieServerExtension implements KieServerExtension {
                 dataSource = configuration.getConfigItemValue(paramName, "java:jboss/datasources/ExampleDS");
                 logger.info("Data source expression {} resolved to {}", input, dataSource);
             }
-            
+
             return dataSource;
-        };        
-        ((QueryServiceImpl) queryService).setDataSourceResolver(kieServerDataSourceResolver);        
-        ((QueryServiceImpl)queryService).init();
+        };
+        ((QueryServiceImpl) queryService).setDataSourceResolver(kieServerDataSourceResolver);
+        ((QueryServiceImpl) queryService).init();
 
         // set runtime data service as listener on deployment service
         ((KModuleDeploymentService) deploymentService).addListener(((RuntimeDataServiceImpl) runtimeDataService));
@@ -306,7 +303,6 @@ public class JbpmKieServerExtension implements KieServerExtension {
             executorService.setTimeunit(TimeUnit.valueOf(config.getConfigItemValue(KieServerConstants.CFG_EXECUTOR_TIME_UNIT, "SECONDS")));
 
             ((ExecutorImpl) ((ExecutorServiceImpl) executorService).getExecutor()).setQueueName(executorQueueName);
-
 
             ((KModuleDeploymentService) deploymentService).setExecutorService(executorService);
         }
@@ -326,17 +322,15 @@ public class JbpmKieServerExtension implements KieServerExtension {
         ((UserTaskAdminServiceImpl) this.userTaskAdminService).setCommandService(new TransactionalCommandService(emf));
 
         this.kieContainerCommandService = new JBPMKieContainerCommandServiceImpl(context, deploymentService, new DefinitionServiceBase(definitionService, context),
-                new ProcessServiceBase(processService, definitionService, runtimeDataService, context), new UserTaskServiceBase(userTaskService, context),
-                new RuntimeDataServiceBase(runtimeDataService, context), new ExecutorServiceBase(executorService, context), new QueryDataServiceBase(queryService, context),
-                new DocumentServiceBase(context), new ProcessAdminServiceBase(processInstanceMigrationService, processInstanceAdminService, context),
-                new UserTaskAdminServiceBase(userTaskAdminService, context));
-
+                                                                                 new ProcessServiceBase(processService, definitionService, runtimeDataService, context), new UserTaskServiceBase(userTaskService, context),
+                                                                                 new RuntimeDataServiceBase(runtimeDataService, context), new ExecutorServiceBase(executorService, context), new QueryDataServiceBase(queryService, context),
+                                                                                 new DocumentServiceBase(context), new ProcessAdminServiceBase(processInstanceMigrationService, processInstanceAdminService, context),
+                                                                                 new UserTaskAdminServiceBase(userTaskAdminService, context));
     }
-
 
     @Override
     public void destroy(KieServerImpl kieServer, KieServerRegistry registry) {
-        ((AbstractDeploymentService)deploymentService).shutdown();
+        ((AbstractDeploymentService) deploymentService).shutdown();
 
         if (executorService != null) {
             executorService.destroy();
@@ -370,7 +364,7 @@ public class JbpmKieServerExtension implements KieServerExtension {
             boolean hasStatefulSession = false;
             boolean hasDefaultSession = false;
             // let validate if they are any stateful sessions defined and in case there are not, skip this container
-            InternalKieContainer kieContainer = (InternalKieContainer)kieContainerInstance.getKieContainer();
+            InternalKieContainer kieContainer = (InternalKieContainer) kieContainerInstance.getKieContainer();
             Collection<String> kbaseNames = kieContainer.getKieBaseNames();
             Collection<String> ksessionNames = new ArrayList<String>();
             for (String kbaseName : kbaseNames) {
@@ -457,17 +451,17 @@ public class JbpmKieServerExtension implements KieServerExtension {
 
                 URL definitionsURL = queryDefinitionsFiles.nextElement();
                 InputStream qdStream = definitionsURL.openStream();
-                
+
                 loadAndRegisterQueryDefinitions(qdStream, kieContainerInstance.getMarshaller(MarshallingFormat.JSON), id);
             }
 
             logger.debug("Container {} created successfully by extension {}", id, this);
         } catch (Exception e) {
-            Throwable root = ExceptionUtils.getRootCause( e );
-            if ( root == null ) {
+            Throwable root = ExceptionUtils.getRootCause(e);
+            if (root == null) {
                 root = e;
             }
-            messages.add(new Message(Severity.ERROR, "Error when creating container " + id +" by extension " + this + " due to " + root.getMessage()));
+            messages.add(new Message(Severity.ERROR, "Error when creating container " + id + " by extension " + this + " due to " + root.getMessage()));
             logger.error("Error when creating container {} by extension {}", id, this, e);
         }
     }
@@ -475,8 +469,8 @@ public class JbpmKieServerExtension implements KieServerExtension {
     @Override
     public boolean isUpdateContainerAllowed(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {
 
-        // Allowing container updates for SNAPSHOTS
-        if(KieServerUtils.isSnapshot(kieContainerInstance.getKieContainer().getReleaseId())) {
+        // Allowing container updates when Kie Server runs in DEVELOPMENT mode.
+        if (kieServer.getInfo().getResult().getMode().equals(KieServerMode.DEVELOPMENT)) {
             return true;
         }
 
@@ -525,10 +519,10 @@ public class JbpmKieServerExtension implements KieServerExtension {
 
         KModuleDeploymentUnit unit = (KModuleDeploymentUnit) deploymentService.getDeployedUnit(id).getDeploymentUnit();
 
-        if(kieServer.getInfo().getResult().getMode().equals(KieServerMode.REGULAR)) {
+        if (kieServer.getInfo().getResult().getMode().equals(KieServerMode.REGULAR)) {
             deploymentService.undeploy(new CustomIdKmoduleDeploymentUnit(id, unit.getGroupId(), unit.getArtifactId(), unit.getVersion()));
         } else {
-            if(abortInstances) {
+            if (abortInstances) {
                 deploymentService.undeploy(new CustomIdKmoduleDeploymentUnit(id, unit.getGroupId(), unit.getArtifactId(), unit.getVersion()), PreUndeployOperations.abortUnitActiveProcessInstances(runtimeDataService, deploymentService));
             } else {
                 deploymentService.undeploy(new CustomIdKmoduleDeploymentUnit(id, unit.getGroupId(), unit.getArtifactId(), unit.getVersion()), PreUndeployOperations.doNothing());
@@ -564,9 +558,9 @@ public class JbpmKieServerExtension implements KieServerExtension {
     @Override
     public List<Object> getAppComponents(SupportedTransports type) {
         ServiceLoader<KieServerApplicationComponentsService> appComponentsServices
-            = ServiceLoader.load(KieServerApplicationComponentsService.class);
+                = ServiceLoader.load(KieServerApplicationComponentsService.class);
         List<Object> appComponentsList = new ArrayList<Object>();
-        Object [] services = {
+        Object[] services = {
                 deploymentService,
                 definitionService,
                 processService,
@@ -580,8 +574,8 @@ public class JbpmKieServerExtension implements KieServerExtension {
                 userTaskAdminService,
                 context
         };
-        for( KieServerApplicationComponentsService appComponentsService : appComponentsServices ) {
-           appComponentsList.addAll(appComponentsService.getAppComponents(EXTENSION_NAME, type, services));
+        for (KieServerApplicationComponentsService appComponentsService : appComponentsServices) {
+            appComponentsList.addAll(appComponentsService.getAppComponents(EXTENSION_NAME, type, services));
         }
         return appComponentsList;
     }
@@ -592,7 +586,7 @@ public class JbpmKieServerExtension implements KieServerExtension {
             return (T) kieContainerCommandService;
         }
 
-        Object [] services = {
+        Object[] services = {
                 deploymentService,
                 definitionService,
                 processService,
@@ -662,7 +656,7 @@ public class JbpmKieServerExtension implements KieServerExtension {
             final DeploymentDescriptor descriptor = getDeploymentDescriptor(unit, kieContainer);
             descriptor.getBuilder()
                     .addWorkItemHandler(new NamedObjectModel("mvel", "async",
-                            "new org.jbpm.executor.impl.wih.AsyncWorkItemHandler(org.jbpm.executor.ExecutorServiceFactory.newExecutorService(null),\"org.jbpm.executor.commands.PrintOutCommand\")"));
+                                                             "new org.jbpm.executor.impl.wih.AsyncWorkItemHandler(org.jbpm.executor.ExecutorServiceFactory.newExecutorService(null),\"org.jbpm.executor.commands.PrintOutCommand\")"));
 
             unit.setDeploymentDescriptor(descriptor);
         }
@@ -770,7 +764,7 @@ public class JbpmKieServerExtension implements KieServerExtension {
             throw new RuntimeException("Unable to create EntityManagerFactory due to " + e.getMessage(), e);
         }
     }
-    
+
     protected void loadAndRegisterQueryDefinitions(InputStream qdStream, org.kie.server.api.marshalling.Marshaller marshaller, String containerId) throws IOException {
         if (qdStream != null) {
             String qdString = IOUtils.toString(qdStream, Charset.forName("UTF-8"));
@@ -779,12 +773,12 @@ public class JbpmKieServerExtension implements KieServerExtension {
                 QueryDefinition[] queryDefinitionList = marshaller.unmarshall(qdString, QueryDefinition[].class);
                 List<String> queries = new ArrayList<>();
                 Arrays.asList(queryDefinitionList).forEach(qd ->
-                {
-                    queryService.replaceQuery(QueryDataServiceBase.build(context, qd));
-                    queries.add(qd.getName());
-                    logger.debug("Registered '{}' query from container '{}' successfully", qd.getName(), containerId);
-                });
-                
+                                                           {
+                                                               queryService.replaceQuery(QueryDataServiceBase.build(context, qd));
+                                                               queries.add(qd.getName());
+                                                               logger.debug("Registered '{}' query from container '{}' successfully", qd.getName(), containerId);
+                                                           });
+
                 if (containerId != null) {
                     containerQueries.put(containerId, queries);
                 }
@@ -793,20 +787,20 @@ public class JbpmKieServerExtension implements KieServerExtension {
             }
         }
     }
-    
+
     protected void registerDefaultQueryDefinitions() {
         try {
             // load any default query definitions
-            InputStream qdStream = this.getClass().getResourceAsStream("/default-query-definitions.json"); 
+            InputStream qdStream = this.getClass().getResourceAsStream("/default-query-definitions.json");
             if (qdStream == null) {
                 String externalLocationQueryDefinitions = System.getProperty(KieServerConstants.CFG_DEFAULT_QUERY_DEFS_LOCATION);
                 if (externalLocationQueryDefinitions != null) {
                     qdStream = new FileInputStream(externalLocationQueryDefinitions);
                 }
             }
-            
+
             loadAndRegisterQueryDefinitions(qdStream, MarshallerFactory.getMarshaller(MarshallingFormat.JSON, this.getClass().getClassLoader()), null);
-            
+
             if (qdStream != null) {
                 qdStream.close();
             }
@@ -820,7 +814,6 @@ public class JbpmKieServerExtension implements KieServerExtension {
         this.queryService = queryService;
     }
 
-    
     void setContext(KieServerRegistry context) {
         this.context = context;
     }
@@ -828,7 +821,7 @@ public class JbpmKieServerExtension implements KieServerExtension {
     @Override
     public List<Message> healthCheck(boolean report) {
         List<Message> messages = KieServerExtension.super.healthCheck(report);
-        
+
         try {
             // run base query to make sure data access layer is available
             runtimeDataService.getProcessInstanceById(-99999);
@@ -838,9 +831,7 @@ public class JbpmKieServerExtension implements KieServerExtension {
         } catch (Exception e) {
             messages.add(new Message(Severity.ERROR, getExtensionName() + " failed due to " + e.getMessage()));
         }
-        
+
         return messages;
     }
-
-    
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerExecutor.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerExecutor.java
@@ -15,7 +15,6 @@
  */
 package org.kie.server.integrationtests.shared;
 
-import org.kie.server.api.model.KieServerMode;
 import org.kie.server.integrationtests.shared.basetests.KieServerBaseIntegrationTest;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -73,7 +72,6 @@ public class KieServerExecutor {
         System.setProperty(KieServerConstants.KIE_SERVER_LOCATION, TestConfig.getEmbeddedKieServerHttpUrl());
         System.setProperty(KieServerConstants.KIE_SERVER_STATE_REPO, "./target");
         System.setProperty(KieServerConstants.CFG_SYNC_DEPLOYMENT, Boolean.toString(syncWithController));
-        System.setProperty(KieServerConstants.KIE_SERVER_MODE, KieServerMode.REGULAR.name());
 
         // kie server policy settings
         System.setProperty(KieServerConstants.KIE_SERVER_ACTIVATE_POLICIES, "KeepLatestOnly");

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -58,7 +58,6 @@
     <org.kie.server.datasource.username>sa</org.kie.server.datasource.username>
     <org.kie.server.datasource.password>sa</org.kie.server.datasource.password>
     <org.kie.server.datasource.driver.class>org.h2.jdbcx.JdbcDataSource</org.kie.server.datasource.driver.class>
-    <org.kie.server.mode.regular>REGULAR</org.kie.server.mode.regular>
 
     <!-- Springboot specific property which is overridden by production DBs profile -->
     <!-- By default we use bundled H2 database jar -->
@@ -231,7 +230,6 @@
                 <!-- Persistence configuration -->
                 <org.kie.server.persistence.ds>${org.kie.server.persistence.ds}</org.kie.server.persistence.ds>
                 <org.kie.server.persistence.dialect>${org.kie.server.persistence.dialect}</org.kie.server.persistence.dialect>
-                <org.kie.server.mode>${org.kie.server.mode.regular}</org.kie.server.mode>
               </systemProperties>
             </container>
             <deployables>
@@ -1237,7 +1235,6 @@
                       <argument>-Dorg.kie.server.persistence.ds=${org.kie.server.persistence.ds}</argument>
                       <argument>-Dorg.jbpm.document.storage=${org.jbpm.document.storage}</argument>
                       <argument>-Dkie.server.base.http.url=${kie.server.base.http.url}</argument>
-                      <argument>-Dorg.kie.server.mode=REGULAR</argument>
                       <!-- Enable Prometheus extension by system property as only enabled extensions can be used and published by Kie server SpringBoot in current implementation. -->
                       <argument>-Dorg.kie.prometheus.server.ext.disabled=false</argument>
                       <argument>org.springframework.boot.loader.JarLauncher</argument>


### PR DESCRIPTION
This changes makes Kie Server start in regular mode by default, this will avoid backward compatibility issues.

Also allows deploying -SNAPSHOT and non-SNAPSHOT  modules int dev mode kie-servers.

@tomasdavidorg @MarianMacik @mswiderski could you please take a look?