### PR TITLE
BAPL-1148: updated to org.dom4j

### DIFF
--- a/camel-container-tests/camel-container-tests-api/pom.xml
+++ b/camel-container-tests/camel-container-tests-api/pom.xml
@@ -40,7 +40,7 @@
 
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/camel-container-tests/camel-container-tests-module/pom.xml
+++ b/camel-container-tests/camel-container-tests-module/pom.xml
@@ -116,7 +116,7 @@
        <exclusions>
          <exclusion>
            <groupId>org.jboss.spec.javax.ws.rs</groupId>
-           <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+           <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
          </exclusion>
        </exclusions>
     </dependency>

--- a/kie-camel/pom.xml
+++ b/kie-camel/pom.xml
@@ -63,7 +63,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.jboss.spec.javax.ws.rs</groupId>
-          <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+          <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/kie-osgi/kie-karaf-features/pom.xml
+++ b/kie-osgi/kie-karaf-features/pom.xml
@@ -684,7 +684,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features.xml
+++ b/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features.xml
@@ -158,7 +158,7 @@
     <bundle>mvn:org.kie/kie-dmn-model/${version.org.kie}</bundle> <!-- needed as the kie-server contains DMN client, which uses the kie-dmn-api, which needs kie-dmn-model -->
     <bundle>mvn:org.kie/kie-dmn-api/${version.org.kie}</bundle>   <!-- needed as the kie-server contains DMN client, which uses the kie-dmn-api -->
     <bundle>mvn:org.drools/kie-pmml/${version.org.kie}</bundle>
-    <bundle>wrap:mvn:org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.0_spec/${version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.0_spec}</bundle>
+    <bundle>wrap:mvn:org.jboss.spec.javax.ws.rs/jboss-jaxrs-api_2.1_spec/${version.org.jboss.spec.javax.ws.rs.jboss-jaxrs-api_2.1_spec}</bundle>
     <bundle>mvn:org.apache.commons/commons-lang3/${version.org.apache.commons.lang3}</bundle>
     <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/${version.com.fasterxml.jackson}</bundle>
     <bundle>mvn:com.fasterxml.jackson.core/jackson-core/${version.com.fasterxml.jackson}</bundle>

--- a/kie-server-parent/kie-server-common/pom.xml
+++ b/kie-server-parent/kie-server-common/pom.xml
@@ -30,7 +30,7 @@
     <!-- REST -->
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
     </dependency>
   
     <!-- logging -->

--- a/kie-server-parent/kie-server-controller/kie-server-controller-client/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-client/pom.xml
@@ -46,7 +46,7 @@
 
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/kie-server-parent/kie-server-controller/kie-server-controller-rest/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-rest/pom.xml
@@ -41,7 +41,7 @@
 
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
     </dependency>
 
     <dependency>

--- a/kie-server-parent/kie-server-controller/kie-server-controller-standalone-impl/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-standalone-impl/pom.xml
@@ -41,7 +41,7 @@
 
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
     </dependency>
 
     <dependency>

--- a/kie-server-parent/kie-server-remote/kie-server-client/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-client/pom.xml
@@ -62,7 +62,7 @@
     
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kie.server</groupId>

--- a/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
@@ -110,12 +110,18 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-jaxb-provider</artifactId>
       <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.glassfish.jaxb</groupId>
+          <artifactId>jaxb-runtime</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-client/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-client/pom.xml
@@ -41,7 +41,7 @@
 
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+      <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/src/test/java/org/kie/server/integrationtests/router/rest/KieServerRouterUnavailabilityIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/src/test/java/org/kie/server/integrationtests/router/rest/KieServerRouterUnavailabilityIntegrationTest.java
@@ -201,16 +201,9 @@ public class KieServerRouterUnavailabilityIntegrationTest extends RestOnlyBaseIn
 
             WebTarget clientRequest = newRequest(serverUrl + "/containers/container3/instances");
             logger.debug("[GET] " + clientRequest.getUri());
-            try {
-                response = clientRequest.request(getMediaType()).get();
-                fail("Should fail as this is an invalid host");
-            } catch (Exception e) {
-                // expected
-            } finally {
-                if(response != null) {
-                    response.close();
-                }
-            }
+            response = clientRequest.request(getMediaType()).get();
+            Assert.assertEquals(Response.Status.SERVICE_UNAVAILABLE.getStatusCode(), response.getStatus());
+            response.close();
 
             Configuration config = routerClient.getRouterConfig();
 

--- a/kie-server-parent/kie-server-wars/kie-server/pom.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/pom.xml
@@ -34,7 +34,7 @@
           <artifactId>commons-logging</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>dom4j</groupId>
+          <groupId>org.dom4j</groupId>
           <artifactId>dom4j</artifactId>
         </exclusion>
         <exclusion>
@@ -78,7 +78,7 @@
           <artifactId>jboss-transaction-api_1.1_spec</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>dom4j</groupId>
+          <groupId>org.dom4j</groupId>
           <artifactId>dom4j</artifactId>
         </exclusion>
         <exclusion>
@@ -96,7 +96,7 @@
           <artifactId>jboss-transaction-api_1.1_spec</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>dom4j</groupId>
+          <groupId>org.dom4j</groupId>
           <artifactId>dom4j</artifactId>
         </exclusion>
         <exclusion>
@@ -114,7 +114,7 @@
           <artifactId>jboss-transaction-api_1.1_spec</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>dom4j</groupId>
+          <groupId>org.dom4j</groupId>
           <artifactId>dom4j</artifactId>
         </exclusion>
         <exclusion>
@@ -250,7 +250,7 @@
       <artifactId>hibernate-entitymanager</artifactId>
       <exclusions>
         <exclusion>
-          <groupId>dom4j</groupId>
+          <groupId>org.dom4j</groupId>
           <artifactId>dom4j</artifactId>
         </exclusion>
         <exclusion>
@@ -278,7 +278,7 @@
       <artifactId>hibernate-commons-annotations</artifactId>
     </dependency>
     <dependency>
-      <groupId>dom4j</groupId>
+      <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
     </dependency>
     <dependency>

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee7-container.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee7-container.xml
@@ -73,7 +73,7 @@
         <include>org.hibernate.common:hibernate-commons-annotations</include>
         <include>org.hibernate:hibernate-validator</include>
         
-        <include>dom4j:dom4j</include>
+        <include>org.dom4j:dom4j</include>
 
         <include>org.quartz-scheduler:quartz</include>
 

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee8-container.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-ee8-container.xml
@@ -71,7 +71,7 @@
         <include>org.hibernate:hibernate-entitymanager</include>
         <include>org.hibernate:hibernate-core</include>
         <include>org.hibernate:hibernate-validator</include>
-        <include>dom4j:dom4j</include>
+        <include>org.dom4j:dom4j</include>
 
         <include>org.quartz-scheduler:quartz</include>
 

--- a/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-servlet-container.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/src/main/assembly/assembly-servlet-container.xml
@@ -70,7 +70,7 @@
         <include>org.hibernate:hibernate-entitymanager</include>
         <include>org.hibernate:hibernate-core</include>
         <include>org.hibernate:hibernate-validator</include>
-        <include>dom4j:dom4j</include>
+        <include>org.dom4j:dom4j</include>
         <include>xerces:xercesImpl</include>
 
         <include>org.jboss.spec.javax.jms:jboss-jms-api_2.0_spec</include>

--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration-drools/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration-drools/pom.xml
@@ -43,7 +43,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.jboss.spec.javax.ws.rs</groupId>
-          <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+          <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.jboss.resteasy</groupId>

--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration-jbpm/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration-jbpm/pom.xml
@@ -86,7 +86,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.jboss.spec.javax.ws.rs</groupId>
-          <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+          <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.jboss.resteasy</groupId>
@@ -147,7 +147,7 @@
           <artifactId>jboss-transaction-api_1.1_spec</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>dom4j</groupId>
+          <groupId>org.dom4j</groupId>
           <artifactId>dom4j</artifactId>
         </exclusion>
         <exclusion>
@@ -173,7 +173,7 @@
           <artifactId>jboss-transaction-api_1.1_spec</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>dom4j</groupId>
+          <groupId>org.dom4j</groupId>
           <artifactId>dom4j</artifactId>
         </exclusion>
         <exclusion>
@@ -200,7 +200,7 @@
           <artifactId>jboss-transaction-api_1.1_spec</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>dom4j</groupId>
+          <groupId>org.dom4j</groupId>
           <artifactId>dom4j</artifactId>
         </exclusion>
         <exclusion>

--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration-optaplanner/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration-optaplanner/pom.xml
@@ -35,7 +35,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.jboss.spec.javax.ws.rs</groupId>
-          <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+          <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
         </exclusion>
         <exclusion>
           <groupId>aopalliance</groupId>

--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration/pom.xml
@@ -110,7 +110,7 @@
           <artifactId>commons-logging</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>dom4j</groupId>
+          <groupId>org.dom4j</groupId>
           <artifactId>dom4j</artifactId>
         </exclusion>
         <exclusion>
@@ -139,7 +139,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.jboss.spec.javax.ws.rs</groupId>
-          <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+          <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
         </exclusion>
         <exclusion>
           <groupId>aopalliance</groupId>

--- a/kie-spring-boot/kie-spring-boot-samples/keycloak-kie-server-spring-boot-sample/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-samples/keycloak-kie-server-spring-boot-sample/pom.xml
@@ -61,7 +61,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.jboss.spec.javax.ws.rs</groupId>
-          <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+          <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/pom.xml
@@ -30,7 +30,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.jboss.spec.javax.ws.rs</groupId>
-          <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+          <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
         </exclusion>
         <exclusion>
           <groupId>javax.activation</groupId>

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/pom.xml
@@ -97,7 +97,7 @@
       <exclusions>
         <exclusion>
           <groupId>org.jboss.spec.javax.ws.rs</groupId>
-          <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+          <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>


### PR DESCRIPTION
upgraded to jboss-jaxrs-api_2.1_spec
excluded org.glassfish.jaxb:jaxb-runtime from resteasy since duplicated classes were found