### PR TITLE
Extend timeout for PMML tests

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/pmml/ApplyPmmlMultipleTimesIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/pmml/ApplyPmmlMultipleTimesIntegrationTest.java
@@ -25,13 +25,15 @@ import org.drools.core.command.runtime.pmml.ApplyPmmlModelCommand;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.kie.api.KieServices;
 import org.kie.api.pmml.PMML4Result;
 import org.kie.api.pmml.PMMLRequestData;
 import org.kie.api.runtime.ExecutionResults;
 import org.kie.server.api.marshalling.MarshallingFormat;
+import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 
 public class ApplyPmmlMultipleTimesIntegrationTest extends PMMLApplyModelBaseTest {
@@ -41,16 +43,17 @@ public class ApplyPmmlMultipleTimesIntegrationTest extends PMMLApplyModelBaseTes
 
     private static final String CONTAINER_ID = "regression";
 
-    private static ClassLoader kjarClassLoader;
+    private static final long EXTENDED_TIMEOUT = 300000L;
 
     @BeforeClass
     public static void buildAndDeployArtifacts() {
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProjectFromResource("/kjars-sources/pmml-regression");
 
-        kjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId).getClassLoader();
-
-        createContainer(CONTAINER_ID, releaseId);
+        // Having timeout issues due to pmml -> raised timeout.
+        KieServicesClient client = createDefaultStaticClient(EXTENDED_TIMEOUT);
+        ServiceResponse<KieContainerResource> reply = client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
+        KieServerAssert.assertSuccess(reply);
     }
 
     @Test

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/pmml/ApplyRegressionModelIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/pmml/ApplyRegressionModelIntegrationTest.java
@@ -16,20 +16,21 @@
 
 package org.kie.server.integrationtests.drools.pmml;
 
-import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.drools.core.command.impl.CommandFactoryServiceImpl;
 import org.drools.core.command.runtime.pmml.ApplyPmmlModelCommand;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.kie.api.KieServices;
 import org.kie.api.pmml.PMML4Result;
 import org.kie.api.pmml.PMMLRequestData;
 import org.kie.api.runtime.ExecutionResults;
 import org.kie.server.api.marshalling.MarshallingFormat;
+import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 
 public class ApplyRegressionModelIntegrationTest extends PMMLApplyModelBaseTest {
@@ -39,16 +40,17 @@ public class ApplyRegressionModelIntegrationTest extends PMMLApplyModelBaseTest 
 
     private static final String CONTAINER_ID = "regression";
 
-    private static ClassLoader kjarClassLoader;
+    private static final long EXTENDED_TIMEOUT = 300000L;
 
     @BeforeClass
     public static void buildAndDeployArtifacts() {
         KieServerDeployer.buildAndDeployCommonMavenParent();
         KieServerDeployer.buildAndDeployMavenProjectFromResource("/kjars-sources/pmml-regression");
 
-        kjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId).getClassLoader();
-
-        createContainer(CONTAINER_ID, releaseId);
+        // Having timeout issues due to pmml -> raised timeout.
+        KieServicesClient client = createDefaultStaticClient(EXTENDED_TIMEOUT);
+        ServiceResponse<KieContainerResource> reply = client.createContainer(CONTAINER_ID, new KieContainerResource(CONTAINER_ID, releaseId));
+        KieServerAssert.assertSuccess(reply);
     }
 
     @Test


### PR DESCRIPTION
To prevent container creation timeout issues on slower machines.
@jiripetrlik Please take a look.