### PR TITLE
[7.18.x] RHPAM-1988 - KIE Server client does not reuse marshaller for JMS

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
@@ -505,11 +505,9 @@ public abstract class AbstractKieServicesClientImpl {
 
             // Create msg
             TextMessage textMsg;
-            Marshaller marshaller;
             try {
 
                 // serialize request
-                marshaller = MarshallerFactory.getMarshaller( config.getExtraClasses(), config.getMarshallingFormat(), classLoader );
                 String xmlStr = marshaller.marshall( command );
                 logger.debug("Message content to be sent '{}'", xmlStr);
                 textMsg = session.createTextMessage(xmlStr);


### PR DESCRIPTION
backport of #1775