### PR TITLE
[JBPM-8150] [RHPAM-1975] Allow users to change Kie server id in Deployment config and templates

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/KieServerControllerConstants.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/KieServerControllerConstants.java
@@ -27,7 +27,7 @@ public final class KieServerControllerConstants {
     public static final String KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE =
             "org.kie.server.controller.openshift.prefer.kieserver.service";
 
-    public static final String KIE_CONTROLLER_OCP_GLOBAL_DISCOVERY_ENABLED =
+    public static final String KIE_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED =
             "org.kie.server.controller.openshift.global.discovery.enabled";
 
 }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-openshift/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-openshift/pom.xml
@@ -121,13 +121,10 @@
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
           <systemPropertyVariables>
-            <org.kie.server.controller.openshift.prefer.kieserver.service>true</org.kie.server.controller.openshift.prefer.kieserver.service>
+            <org.kie.server.controller.openshift.prefer.kieserver.service>false</org.kie.server.controller.openshift.prefer.kieserver.service>
+            <org.kie.server.location>http://myapp2-kieserver-myproject.127.0.0.1.nip.io:80/services/rest/server</org.kie.server.location>
           </systemPropertyVariables>
           <environmentVariables>
-            <MYAPP2_KIESERVER_SERVICE_HOST>172.30.99.129</MYAPP2_KIESERVER_SERVICE_HOST>
-            <MYAPP2_KIESERVER_SERVICE_PORT>8080</MYAPP2_KIESERVER_SERVICE_PORT>
-            <MYAPP2_KIESERVER_FROM_TEMPLATE_SERVICE_HOST>172.30.99.129</MYAPP2_KIESERVER_FROM_TEMPLATE_SERVICE_HOST>
-            <MYAPP2_KIESERVER_FROM_TEMPLATE_SERVICE_PORT>8080</MYAPP2_KIESERVER_FROM_TEMPLATE_SERVICE_PORT>
             <KUBERNETES_MASTER />
             <KUBERNETES_API_VERSION />
             <KUBERNETES_TRUST_CERTIFICATES />

--- a/kie-server-parent/kie-server-controller/kie-server-controller-openshift/src/main/java/org/kie/server/controller/openshift/storage/ServerTemplateConverter.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-openshift/src/main/java/org/kie/server/controller/openshift/storage/ServerTemplateConverter.java
@@ -21,17 +21,16 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieScannerResource;
 import org.kie.server.api.model.KieServerConfig;
 import org.kie.server.api.model.KieServerConfigItem;
 import org.kie.server.api.model.KieServerMode;
-import org.kie.server.controller.api.KieServerControllerConstants;
 import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
 import org.kie.server.controller.api.model.spec.Capability;
 import org.kie.server.controller.api.model.spec.ContainerConfig;
@@ -44,6 +43,21 @@ import org.kie.server.services.impl.storage.KieServerState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.kie.server.api.KieServerConstants.CAPABILITY_BPM;
+import static org.kie.server.api.KieServerConstants.KIE_DROOLS_SERVER_EXT_DISABLED;
+import static org.kie.server.api.KieServerConstants.KIE_JBPM_SERVER_EXT_DISABLED;
+import static org.kie.server.api.KieServerConstants.KIE_OPTAPLANNER_SERVER_EXT_DISABLED;
+import static org.kie.server.api.KieServerConstants.KIE_SERVER_ID;
+import static org.kie.server.api.KieServerConstants.KIE_SERVER_LOCATION;
+import static org.kie.server.api.KieServerConstants.KIE_SERVER_MODE;
+import static org.kie.server.api.KieServerConstants.PCFG_KIE_BASE;
+import static org.kie.server.api.KieServerConstants.PCFG_KIE_SESSION;
+import static org.kie.server.api.KieServerConstants.PCFG_MERGE_MODE;
+import static org.kie.server.api.KieServerConstants.PCFG_RUNTIME_STRATEGY;
+import static org.kie.server.controller.api.KieServerControllerConstants.KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE;
+import static org.kie.server.services.openshift.api.KieServerOpenShiftConstants.KIE_SERVER_SERVICES_OPENSHIFT_SERVICE_NAME;
+import static org.kie.server.services.openshift.api.KieServerOpenShiftConstants.UNKNOWN;
+
 public class ServerTemplateConverter {
 
     private static final Logger logger = LoggerFactory.getLogger(ServerTemplateConverter.class);
@@ -51,7 +65,7 @@ public class ServerTemplateConverter {
     private static final String SERVICE_HOST_ENV_SUFFIX = "_SERVICE_HOST";
     private static final String SERVICE_PATH = "/services/rest/server";
     protected static final boolean PREFER_KIESERVER_SERVICE =
-            Boolean.parseBoolean(System.getProperty(KieServerControllerConstants.KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE, "true"));
+            Boolean.parseBoolean(System.getProperty(KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE, "true"));
 
     private ServerTemplateConverter() {}
 
@@ -63,13 +77,14 @@ public class ServerTemplateConverter {
             throw new IllegalArgumentException("Kie server configuration can not be empty.");
         }
         ServerTemplate template = new ServerTemplate();
-        String id = state.getConfiguration().getConfigItemValue(KieServerConstants.KIE_SERVER_ID);
-        String url = resolveServerUrl(state);
-        String mode = state.getConfiguration().getConfigItemValue(KieServerConstants.KIE_SERVER_MODE, KieServerMode.DEVELOPMENT.name());
+        String id = state.getConfiguration().getConfigItemValue(KIE_SERVER_ID);
+        String name = state.getConfiguration().getConfigItemValue(KIE_SERVER_SERVICES_OPENSHIFT_SERVICE_NAME, id);
+        String mode = state.getConfiguration().getConfigItemValue(KIE_SERVER_MODE, KieServerMode.DEVELOPMENT.name());
+        Optional<String> urlOpt = resolveServerUrl(state);
 
         template.setId(id);
-        template.setName(id);
-        template.addServerInstance(new ServerInstanceKey(id, id, id, url));
+        template.setName(name);
+        urlOpt.ifPresent(url -> template.addServerInstance(new ServerInstanceKey(id, id, id, url)));
 
         for (KieContainerResource conRes : state.getContainers()) {
             Map<Capability, ContainerConfig> configs = new EnumMap<>(Capability.class);
@@ -80,18 +95,18 @@ public class ServerTemplateConverter {
             }
             ProcessConfig pcfg = null;
             for (KieServerConfigItem item : conRes.getConfigItems()) {
-                if (KieServerConstants.CAPABILITY_BPM.equals(item.getType())) {
+                if (CAPABILITY_BPM.equals(item.getType())) {
                     pcfg = pcfg == null ? new ProcessConfig() : pcfg;
-                    if (KieServerConstants.PCFG_KIE_BASE.equals(item.getName())) {
+                    if (PCFG_KIE_BASE.equals(item.getName())) {
                         pcfg.setKBase(item.getValue());
                     }
-                    if (KieServerConstants.PCFG_KIE_SESSION.equals(item.getName())) {
+                    if (PCFG_KIE_SESSION.equals(item.getName())) {
                         pcfg.setKSession(item.getValue());
                     }
-                    if (KieServerConstants.PCFG_MERGE_MODE.equals(item.getName())) {
+                    if (PCFG_MERGE_MODE.equals(item.getName())) {
                         pcfg.setMergeMode(item.getValue());
                     }
-                    if (KieServerConstants.PCFG_RUNTIME_STRATEGY.equals(item.getName())) {
+                    if (PCFG_RUNTIME_STRATEGY.equals(item.getName())) {
                         pcfg.setRuntimeStrategy(item.getValue());
                     }
                 }
@@ -109,34 +124,37 @@ public class ServerTemplateConverter {
 
         List<String> capabilities = Stream.of(Capability.values()).map(Capability::name).collect(Collectors.toList());
         KieServerConfig kcfg = state.getConfiguration();
-        if (kcfg.getConfigItem(KieServerConstants.KIE_JBPM_SERVER_EXT_DISABLED) != null) {
+        if (kcfg.getConfigItem(KIE_JBPM_SERVER_EXT_DISABLED) != null) {
             capabilities.remove(Capability.PROCESS.name());
         }
-        if (kcfg.getConfigItem(KieServerConstants.KIE_DROOLS_SERVER_EXT_DISABLED) != null) {
+        if (kcfg.getConfigItem(KIE_DROOLS_SERVER_EXT_DISABLED) != null) {
             capabilities.remove(Capability.RULE.name());
         }
-        if (kcfg.getConfigItem(KieServerConstants.KIE_OPTAPLANNER_SERVER_EXT_DISABLED) != null) {
+        if (kcfg.getConfigItem(KIE_OPTAPLANNER_SERVER_EXT_DISABLED) != null) {
             capabilities.remove(Capability.PLANNING.name());
         }
 
         template.setCapabilities(capabilities);
-        template.setMode(KieServerMode.valueOf(mode));
+        //https://issues.jboss.org/projects/RHPAM/issues/RHPAM-1975
+        template.setMode(KieServerMode.valueOf(mode.toUpperCase()));
 
         return template;
     }
 
     public static KieServerState toState(ServerTemplate template) {
         String id = template.getId();
+        String name = template.getName();
         KieServerMode mode = template.getMode() == null ? KieServerMode.DEVELOPMENT : template.getMode();
         KieServerState state = new KieServerState();
         KieServerConfig config = new KieServerConfig();
         Set<KieContainerResource> containers = new HashSet<>();
 
-        config.addConfigItem(new KieServerConfigItem(KieServerConstants.KIE_SERVER_ID, id, String.class.getName()));
-        config.addConfigItem(new KieServerConfigItem(KieServerConstants.KIE_SERVER_MODE, mode.name(), String.class.getName()));
+        config.addConfigItem(new KieServerConfigItem(KIE_SERVER_ID, id, String.class.getName()));
+        config.addConfigItem(new KieServerConfigItem(KIE_SERVER_SERVICES_OPENSHIFT_SERVICE_NAME, name, String.class.getName()));
+        config.addConfigItem(new KieServerConfigItem(KIE_SERVER_MODE, mode.name(), String.class.getName()));
 
         if (template.getServerInstance(id) != null) {
-            config.addConfigItem(new KieServerConfigItem(KieServerConstants.KIE_SERVER_LOCATION,
+            config.addConfigItem(new KieServerConfigItem(KIE_SERVER_LOCATION,
                                                          template.getServerInstance(id).getUrl(), String.class.getName()));
         }
         List<String> capabilities = template.getCapabilities();
@@ -145,19 +163,19 @@ public class ServerTemplateConverter {
                 case PROCESS:
                     if (!capabilities.contains(cap.name()))
                         config.addConfigItem(
-                                             new KieServerConfigItem(KieServerConstants.KIE_JBPM_SERVER_EXT_DISABLED,
+                                             new KieServerConfigItem(KIE_JBPM_SERVER_EXT_DISABLED,
                                                                      "true", String.class.getName()));
                     break;
                 case RULE:
                     if (!capabilities.contains(cap.name()))
                         config.addConfigItem(
-                                             new KieServerConfigItem(KieServerConstants.KIE_DROOLS_SERVER_EXT_DISABLED,
+                                             new KieServerConfigItem(KIE_DROOLS_SERVER_EXT_DISABLED,
                                                                      "true", String.class.getName()));
                     break;
                 case PLANNING:
                     if (!capabilities.contains(cap.name()))
                         config.addConfigItem(
-                                             new KieServerConfigItem(KieServerConstants.KIE_OPTAPLANNER_SERVER_EXT_DISABLED,
+                                             new KieServerConfigItem(KIE_OPTAPLANNER_SERVER_EXT_DISABLED,
                                                                      "true", String.class.getName()));
                     break;
 
@@ -175,10 +193,10 @@ public class ServerTemplateConverter {
                 switch (conCfgEntry.getKey()) {
                     case PROCESS:
                         ProcessConfig pcfg = (ProcessConfig) conCfgEntry.getValue();
-                        conRes.addConfigItem(new KieServerConfigItem(KieServerConstants.PCFG_KIE_BASE, pcfg.getKBase(), KieServerConstants.CAPABILITY_BPM));
-                        conRes.addConfigItem(new KieServerConfigItem(KieServerConstants.PCFG_KIE_SESSION, pcfg.getKSession(), KieServerConstants.CAPABILITY_BPM));
-                        conRes.addConfigItem(new KieServerConfigItem(KieServerConstants.PCFG_MERGE_MODE, pcfg.getMergeMode(), KieServerConstants.CAPABILITY_BPM));
-                        conRes.addConfigItem(new KieServerConfigItem(KieServerConstants.PCFG_RUNTIME_STRATEGY, pcfg.getRuntimeStrategy(), KieServerConstants.CAPABILITY_BPM));
+                        conRes.addConfigItem(new KieServerConfigItem(PCFG_KIE_BASE, pcfg.getKBase(), CAPABILITY_BPM));
+                        conRes.addConfigItem(new KieServerConfigItem(PCFG_KIE_SESSION, pcfg.getKSession(), CAPABILITY_BPM));
+                        conRes.addConfigItem(new KieServerConfigItem(PCFG_MERGE_MODE, pcfg.getMergeMode(), CAPABILITY_BPM));
+                        conRes.addConfigItem(new KieServerConfigItem(PCFG_RUNTIME_STRATEGY, pcfg.getRuntimeStrategy(), CAPABILITY_BPM));
                         break;
                     case RULE:
                         RuleConfig rcfg = (RuleConfig) conCfgEntry.getValue();
@@ -198,25 +216,33 @@ public class ServerTemplateConverter {
         return state;
     }
 
-    protected static String resolveServerUrl(KieServerState state) {
-        String serverId = state.getConfiguration().getConfigItemValue(KieServerConstants.KIE_SERVER_ID);
-        String resolvedUrl = state.getConfiguration().getConfigItemValue(KieServerConstants.KIE_SERVER_LOCATION);
+    protected static Optional<String> resolveServerUrl(KieServerState state) {
+        String serverId = state.getConfiguration().getConfigItemValue(KIE_SERVER_ID, UNKNOWN);
+        String serviceName = state.getConfiguration().getConfigItemValue(KIE_SERVER_SERVICES_OPENSHIFT_SERVICE_NAME, UNKNOWN);
+        Optional<String> resolvedUrl = Optional.ofNullable(state.getConfiguration().getConfigItemValue(KIE_SERVER_LOCATION));
 
-        if (PREFER_KIESERVER_SERVICE) {
-            String envPrefix = serverId.replace('-', '_').toUpperCase();
+        if (PREFER_KIESERVER_SERVICE && resolvedUrl.isPresent()) {
+            String envPrefix = serviceName.replace('-', '_').toUpperCase();
             String servicePortEnv = System.getenv(envPrefix.concat(SERVICE_PORT_ENV_SUFFIX));
             String serviceHostEnv = System.getenv(envPrefix.concat(SERVICE_HOST_ENV_SUFFIX));
             servicePortEnv = servicePortEnv == null ? "8080" : servicePortEnv;
             if (serviceHostEnv != null) {
-                resolvedUrl = new StringBuffer("http://")
-                                                         .append(serviceHostEnv).append(":").append(servicePortEnv).append(SERVICE_PATH).toString();
+                resolvedUrl = Optional.of(new StringBuffer("http://")
+                                             .append(serviceHostEnv)
+                                             .append(":")
+                                             .append(servicePortEnv)
+                                             .append(SERVICE_PATH)
+                                             .toString());
 
             } else {
-                logger.warn("Environment variable: [" + envPrefix.concat(SERVICE_HOST_ENV_SUFFIX) +
-                            "] defined by OpenShift Cluster Service for kie server: [" + serverId +
-                            "] not found. Kie server location will be set by the value [" + resolvedUrl +
-                            "] from kie server template.");
-            }
+                logger.warn("Environment variable: [{}] defined by OpenShift Cluster Service for KIE server: [{}] not found.", 
+                            envPrefix.concat(SERVICE_HOST_ENV_SUFFIX), serverId);
+                if (resolvedUrl.isPresent()) { 
+                    logger.warn("Use kie server location [{}]", resolvedUrl.get());
+                } else {
+                    logger.warn("Undefined kie server location");
+                }
+             }
         }
         return resolvedUrl;
     }

--- a/kie-server-parent/kie-server-controller/kie-server-controller-openshift/src/test/resources/test-kieserver-state-config-map.yml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-openshift/src/test/resources/test-kieserver-state-config-map.yml
@@ -24,6 +24,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: myapp2-kieserver
+  labels:
+    services.server.kie.org/kie-server-state: USED
+    services.server.kie.org/kie-server-id: myapp2-kieserver
+    application: myapp2
   annotations:
     test.annotation: must_be_kept
 data:
@@ -32,6 +36,11 @@ data:
       <controllers/>
       <configuration>
         <configItems>
+          <config-item>
+            <name>org.kie.server.services.openshift.service.name</name>
+            <value>myapp2-kieserver</value>
+            <type>java.lang.String</type>
+          </config-item>
           <config-item>
             <name>org.kie.server.mode</name>
             <value>DEVELOPMENT</value>

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/api/KieServerOpenShiftConstants.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/api/KieServerOpenShiftConstants.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.services.openshift.api;
+
+public class KieServerOpenShiftConstants {
+
+    public static final String CFG_MAP_DATA_KEY = "kie-server-state";
+    public static final String CFG_MAP_LABEL_SERVER_ID_KEY = "services.server.kie.org/kie-server-id";
+    public static final String CFG_MAP_LABEL_SERVER_STATE_KEY = "services.server.kie.org/kie-server-state";
+    public static final String CFG_MAP_LABEL_SERVER_STATE_VALUE_DETACHED = "DETACHED";
+    public static final String CFG_MAP_LABEL_SERVER_STATE_VALUE_IMMUTABLE = "IMMUTABLE";
+    public static final String CFG_MAP_LABEL_SERVER_STATE_VALUE_USED = "USED";
+    public static final String CFG_MAP_LABEL_APP_NAME_KEY = "application";
+    public static final String CFG_MAP_NAME_SYNTHETIC_NAME = "kieserver";
+    public static final String ENV_HOSTNAME = "HOSTNAME";
+    public static final String KIE_SERVER_SERVICES_OPENSHIFT_SERVICE_NAME = "org.kie.server.services.openshift.service.name";
+    public static final String ROLLOUT_REQUIRED = "services.server.kie.org/openshift-startup-strategy.rolloutRequired";
+    public static final String STATE_CHANGE_TIMESTAMP = "services.server.kie.org/kie-server-state.changeTimestamp";
+    public static final String UNKNOWN = "unknown";
+
+    private KieServerOpenShiftConstants() {}
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateCloudRepository.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateCloudRepository.java
@@ -17,7 +17,6 @@ package org.kie.server.services.openshift.impl.storage.cloud;
 
 import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider;
-import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieServerConfigItem;
 import org.kie.server.services.impl.storage.KieServerState;
@@ -26,17 +25,11 @@ import org.kie.soup.commons.xstream.XStreamUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.kie.server.api.KieServerConstants.KIE_SERVER_ID;
+import static org.kie.server.services.openshift.api.KieServerOpenShiftConstants.CFG_MAP_DATA_KEY;
+
 public abstract class KieServerStateCloudRepository implements KieServerStateRepository, CloudClientFactory {
 
-    public static final String ROLLOUT_REQUIRED = "services.server.kie.org/openshift-startup-strategy.rolloutRequired";
-    public static final String CFG_MAP_DATA_KEY = "kie-server-state";
-    public static final String CFG_MAP_LABEL_NAME = "services.server.kie.org/kie-server-state";
-    public static final String CFG_MAP_LABEL_VALUE_USED = "USED";
-    public static final String CFG_MAP_LABEL_VALUE_IMMUTABLE = "IMMUTABLE";
-    public static final String CFG_MAP_LABEL_APP_NAME = "application";
-    public static final String ENV_HOSTNAME = "HOSTNAME";
-    
-    protected static final String STATE_CHANGE_TIMESTAMP = "services.server.kie.org/kie-server-state.changeTimestamp";
     private static final Logger logger = LoggerFactory.getLogger(KieServerStateCloudRepository.class);
 
     protected final XStream xs;
@@ -59,7 +52,7 @@ public abstract class KieServerStateCloudRepository implements KieServerStateRep
     protected String retrieveKieServerId(KieServerState kieServerState) {
         String kssServerId = null;
         try {
-            kssServerId = kieServerState.getConfiguration().getConfigItemValue(KieServerConstants.KIE_SERVER_ID);
+            kssServerId = kieServerState.getConfiguration().getConfigItemValue(KIE_SERVER_ID);
         } catch (Exception e) {
             logger.error("Failed to retrieve server id from KieServerState", e);
         }

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryDetachedCMBCTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryDetachedCMBCTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.services.openshift.impl.storage.cloud;
+
+import java.util.UUID;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import org.junit.Test;
+import org.kie.server.services.impl.storage.KieServerState;
+
+import static org.junit.Assert.assertTrue;
+import static org.kie.server.api.KieServerConstants.KIE_SERVER_LOCATION;
+import static org.kie.server.services.openshift.api.KieServerOpenShiftConstants.CFG_MAP_LABEL_SERVER_STATE_VALUE_DETACHED;
+
+public class KieServerStateOpenShiftRepositoryDetachedCMBCTest extends KieServerStateOpenShiftRepositoryTest {
+
+    @Test
+    public void testDetachedKieServerCMatBCEnv() {
+        createDummyDCandRC("myapp2-kieserver-6", "myapp2-kieserver-detached-bc", UUID.randomUUID().toString());
+        ConfigMap cfm = client.configMaps()
+                .load(KieServerStateOpenShiftRepositoryTest.class
+                .getResourceAsStream("/test-kieserver-state-config-map-detached-bc.yml")).get();
+    
+        repo.createOrReplaceCM(client, cfm);
+        // When BC/WB loads 'DETACHED' KieServerCM, should remove KIE server location config item. 
+        KieServerState state = repo.load("myapp2-kieserver-detached-bc");
+        ConfigMap updatedCfm = client.configMaps().inNamespace(testNamespace)
+                                     .withName("myapp2-kieserver-6").get();
+        
+        assertTrue(state.getConfiguration().getConfigItem(KIE_SERVER_LOCATION) == null);
+        assertTrue(updatedCfm.getMetadata().getLabels().containsValue(CFG_MAP_LABEL_SERVER_STATE_VALUE_DETACHED));
+    }
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryDetachedCMKIETest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryDetachedCMKIETest.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.services.openshift.impl.storage.cloud;
+
+import java.util.UUID;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import org.junit.Test;
+import org.kie.server.services.impl.storage.KieServerState;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.kie.server.api.KieServerConstants.KIE_SERVER_ID;
+import static org.kie.server.api.KieServerConstants.KIE_SERVER_LOCATION;
+import static org.kie.server.services.openshift.api.KieServerOpenShiftConstants.CFG_MAP_LABEL_SERVER_STATE_VALUE_USED;
+
+public class KieServerStateOpenShiftRepositoryDetachedCMKIETest extends KieServerStateOpenShiftRepositoryTest {
+
+    @Test
+    public void testDetachedKieServerCMatKieServerEnv() {
+        // By setting org.kie.server.id property, simulates a KIE server runtime. (isKieServerRuntime -> true)
+        System.setProperty(KIE_SERVER_ID, "myapp2-kieserver-detached-kie");
+        System.setProperty(KIE_SERVER_LOCATION, "http://myapp2-kieserver-5-myproject.127.0.0.1.nip.io:80/services/rest/server");
+        createDummyDCandRC("myapp2-kieserver-5", "myapp2-kieserver-detached-kie", UUID.randomUUID().toString());
+        ConfigMap cfm = client.configMaps()
+                .load(KieServerStateOpenShiftRepositoryTest.class
+                .getResourceAsStream("/test-kieserver-state-config-map-detached-kie.yml")).get();
+    
+        repo.createOrReplaceCM(client, cfm);
+        // When KIE server loads 'DETACHED' KieServerCM, should change it to 'USED' and adding server location. 
+        KieServerState state = repo.load("myapp2-kieserver-detached-kie");
+        ConfigMap updatedCfm = client.configMaps().inNamespace(testNamespace)
+                                     .withName("myapp2-kieserver-5").get();
+        
+        assertNotNull(state.getConfiguration().getConfigItem(KIE_SERVER_LOCATION));
+        assertTrue(updatedCfm.getMetadata().getLabels().containsValue(CFG_MAP_LABEL_SERVER_STATE_VALUE_USED));
+    }
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryTest.java
@@ -16,13 +16,15 @@
 
 package org.kie.server.services.openshift.impl.storage.cloud;
 
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
 
 import com.thoughtworks.xstream.XStream;
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.client.OpenShiftClient;
@@ -30,12 +32,14 @@ import io.fabric8.openshift.client.server.mock.OpenShiftServer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
-import org.kie.server.api.KieServerConstants;
-import org.kie.server.controller.api.KieServerControllerConstants;
 
+import static org.kie.server.api.KieServerConstants.*;
+import static org.kie.server.controller.api.KieServerControllerConstants.*;
+import static org.kie.server.services.openshift.api.KieServerOpenShiftConstants.CFG_MAP_LABEL_APP_NAME_KEY;
+import static org.kie.server.services.openshift.api.KieServerOpenShiftConstants.CFG_MAP_LABEL_SERVER_ID_KEY;
 import static org.kie.server.services.openshift.impl.storage.cloud.KieServerStateCloudRepository.initializeXStream;
 
-public class KieServerStateOpenShiftRepositoryTest {
+public abstract class KieServerStateOpenShiftRepositoryTest {
 
     protected static final String KIE_SERVER_STARTUP_IN_PROGRESS_KEY_PREFIX = "org.kie.server.services/";
     protected static final String KIE_SERVER_STARTUP_IN_PROGRESS_VALUE = "kie.server.startup_in_progress";
@@ -51,7 +55,8 @@ public class KieServerStateOpenShiftRepositoryTest {
      *  Must match current project name associated with OpenShift login
      *  if test against real OCP/K8S cluster
      */
-    protected String testNamespace = "myproject";
+    // The default namespace for MockKubernetes Server is 'test'
+    protected String testNamespace = "test";
     protected OpenShiftClient client;
     protected KieServerStateOpenShiftRepository repo;
 
@@ -69,23 +74,13 @@ public class KieServerStateOpenShiftRepositoryTest {
          *  	KIE_SERVER_ID (Value doesn't matter)
          */
         if (System.getenv("KIE_SERVER_ID") != null) {
-            System.setProperty(KieServerConstants.KIE_SERVER_STARTUP_STRATEGY, "OpenShiftStartupStrategy");
+            System.setProperty(KIE_SERVER_STARTUP_STRATEGY, "OpenShiftStartupStrategy");
             // If KIE_SERVER_ID is set, connect to real OCP/K8S server
             client = clouldClientHelper.get();
         } else {
             // Get client from MockKubernetes Server
             client = server.getOpenshiftClient();
-
-            // The default namespace for MockKubernetes Server is 'test'
-            testNamespace = "test";
         }
-
-        // Load testing KieServerState ConfigMap data into mock server from file
-        ConfigMap cfm = client.configMaps()
-                              .load(KieServerStateOpenShiftRepositoryTest.class
-                              .getResourceAsStream("/test-kieserver-state-config-map-used.yml")).get();
-
-        client.configMaps().inNamespace(testNamespace).createOrReplace(cfm);
 
         // Create cloud repository instance with mock K8S server test client
         repo = new KieServerStateOpenShiftRepository() {
@@ -114,52 +109,133 @@ public class KieServerStateOpenShiftRepositoryTest {
             public Optional<String> getAppNameFromPod(OpenShiftClient client) {
                 return Optional.of(TEST_APP_NAME);
             }
+            
+            @Override
+            public ConfigMap createOrReplaceCM(OpenShiftClient client, ConfigMap cm) {
+                // Issue workaround: MockKubenetes Server ignores update 
+                client.configMaps().inNamespace(testNamespace).delete(cm);
+                return client.configMaps().inNamespace(testNamespace).createOrReplace(cm);
+            }
         };
 
+        // Load testing KieServerState ConfigMap data into mock server from file
+        ConfigMap cfm = client.configMaps()
+                              .load(KieServerStateOpenShiftRepositoryTest.class
+                              .getResourceAsStream("/test-kieserver-state-config-map-used.yml")).get();
+
+        repo.createOrReplaceCM(client, cfm);
         repo.load(TEST_KIE_SERVER_ID);
     }
 
     @After
     public void tearDown() {
-        System.clearProperty(KieServerConstants.KIE_SERVER_ID);
-        System.clearProperty(KieServerControllerConstants.KIE_CONTROLLER_OCP_GLOBAL_DISCOVERY_ENABLED);
+        System.clearProperty(KIE_SERVER_ID);
+        System.clearProperty(KIE_SERVER_LOCATION);
+        System.clearProperty(KIE_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED);
         client.configMaps().inNamespace(testNamespace).delete();
         client.deploymentConfigs().inNamespace(testNamespace).delete();
         client.close();
     }
-
-    protected void createDummyDC() {
-        createDummyDC(TEST_KIE_SERVER_ID, UUID.randomUUID().toString());
+    
+    protected void createDummyDCandRC() {
+        createDummyDCandRC(TEST_KIE_SERVER_ID, UUID.randomUUID().toString());
     }
 
-    protected void createDummyDC(String kieServerID, String kieServerDCUID) {
-        client.deploymentConfigs().inNamespace(testNamespace).createOrReplaceWithNew()
+    protected void createDummyDCandRC(String kieServerID, String kieServerDCUID) {
+        createDummyDCandRC(UUID.randomUUID().toString(), kieServerID, kieServerDCUID);
+    }
+    protected void createDummyDCandRC(String name, String kieServerID, String kieServerDCUID) {
+        Map<String, String> labels = new HashMap<>();
+        labels.put(CFG_MAP_LABEL_APP_NAME_KEY, TEST_APP_NAME);
+        labels.put(CFG_MAP_LABEL_SERVER_ID_KEY, kieServerID);
+        
+        DeploymentConfig dc = client.deploymentConfigs().inNamespace(testNamespace)
+                                .createOrReplaceWithNew()
+                                .withNewMetadata()
+                                  .withName(name)
+                                  .withLabels(labels)
+                                  .withUid(kieServerDCUID)
+                                .endMetadata()
+                                .withNewSpec()
+                                  .withReplicas(0)
+                                  .addNewTrigger()
+                                    .withType("ConfigChange")
+                                  .endTrigger()
+                                  .addToSelector("app", "kieserver")
+                                  .withNewTemplate()
+                                    .withNewMetadata()
+                                      .addToLabels("app", "kieserver")
+                                      .addToLabels(CFG_MAP_LABEL_SERVER_ID_KEY,kieServerID)
+                                    .endMetadata()
+                                    .withNewSpec()
+                                      .addNewContainer()
+                                        .withName("kieserver")
+                                        .withImage("kieserver")
+                                        .addNewPort()
+                                          .withContainerPort(80)
+                                        .endPort()
+                                      .endContainer()
+                                    .endSpec()
+                                  .endTemplate()
+                                .endSpec()
+                                .done();
+        
+        ReplicationController rc = client.replicationControllers().inNamespace(testNamespace)
+                                    .createOrReplaceWithNew()
+                                    .withNewMetadata()
+                                      .withName("decoupled-with-kie-server-id")
+                                      .withUid(kieServerDCUID)
+                                      .addNewOwnerReference()
+                                        .withApiVersion(dc.getApiVersion())
+                                        .withKind(dc.getKind())
+                                        .withName(dc.getMetadata().getName())
+                                        .withUid(dc.getMetadata().getUid())
+                                      .endOwnerReference()
+                                    .endMetadata()
+                                    .withNewSpec()
+                                    .withReplicas(0)
+                                    .addToSelector("app", "kieserver")
+                                    .withNewTemplate()
+                                      .withNewMetadata()
+                                        .addToLabels("app", "kieserver")
+                                        .addToLabels(CFG_MAP_LABEL_SERVER_ID_KEY,kieServerID)
+                                      .endMetadata()
+                                      .withNewSpec()
+                                        .addNewContainer()
+                                          .withName("kieserver")
+                                          .withImage("kieserver")
+                                          .addNewPort()
+                                            .withContainerPort(80)
+                                          .endPort()
+                                        .endContainer()
+                                      .endSpec()
+                                    .endTemplate()
+                                  .endSpec()
+                                  .done();
+
+        client.pods().inNamespace(testNamespace)
+            .createOrReplaceWithNew()
             .withNewMetadata()
-              .withName(kieServerID)
-              .withLabels(Collections.singletonMap(KieServerStateCloudRepository.CFG_MAP_LABEL_APP_NAME, TEST_APP_NAME))
-              .withUid(kieServerDCUID)
+              .withName("decoupled-with-kie-server-id")
+              .addToLabels("app", "kieserver")
+              .addToLabels(CFG_MAP_LABEL_SERVER_ID_KEY,kieServerID)
+              .addNewOwnerReference()
+                .withApiVersion(rc.getApiVersion())
+                .withKind(rc.getKind())
+                .withName(rc.getMetadata().getName())
+                .withUid(rc.getMetadata().getUid())
+              .endOwnerReference()
             .endMetadata()
             .withNewSpec()
-              .withReplicas(0)
-              .addNewTrigger()
-                .withType("ConfigChange")
-              .endTrigger()
-              .addToSelector("app", "kieserver")
-              .withNewTemplate()
-                .withNewMetadata()
-                  .addToLabels("app", "kieserver")
-                .endMetadata()
-                .withNewSpec()
-                  .addNewContainer()
-                    .withName("kieserver")
-                    .withImage("kieserver")
-                    .addNewPort()
-                      .withContainerPort(80)
-                    .endPort()
-                  .endContainer()
-                .endSpec()
-              .endTemplate()
+              .addNewContainer()
+                .withName("kieserver")
+                .withImage("kieserver")
+                .addNewPort()
+                  .withContainerPort(80)
+                .endPort()
+              .endContainer()
             .endSpec()
             .done();
+        
     }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/resources/test-kieserver-state-config-map-detached-bc.yml
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/resources/test-kieserver-state-config-map-detached-bc.yml
@@ -23,10 +23,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: myapp2-kieserver-1
+  name: myapp2-kieserver-6
   labels:
-    services.server.kie.org/kie-server-id: myapp2-kieserver-immutable
-    services.server.kie.org/kie-server-state: IMMUTABLE
+    services.server.kie.org/kie-server-state: DETACHED
+    services.server.kie.org/kie-server-id: myapp2-kieserver-detached-bc
     application: myapp2
   annotations:
     test.annotation: must_be_kept
@@ -38,6 +38,11 @@ data:
       </controllers>
       <configuration>
         <configItems>
+          <config-item>
+            <name>org.kie.server.location</name>
+            <value>http://myapp2-kieserver-myproject.127.0.0.1.nip.io:80/services/rest/server</value>
+            <type>java.lang.String</type>
+          </config-item>
           <config-item>
             <name>org.kie.server.persistence.ds</name>
             <value>java:/jboss/datasources/ExampleDS</value>
@@ -51,11 +56,6 @@ data:
           <config-item>
             <name>org.kie.server.sync.deploy</name>
             <value>true</value>
-            <type>java.lang.String</type>
-          </config-item>
-          <config-item>
-            <name>org.kie.server.location</name>
-            <value>http://myapp2-kieserver-myproject.127.0.0.1.nip.io:80/services/rest/server</value>
             <type>java.lang.String</type>
           </config-item>
           <config-item>
@@ -95,7 +95,7 @@ data:
           </config-item>
           <config-item>
             <name>org.kie.server.id</name>
-            <value>myapp2-kieserver</value>
+            <value>myapp2-kieserver-detached-bc</value>
             <type>java.lang.String</type>
           </config-item>
           <config-item>

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/resources/test-kieserver-state-config-map-detached-kie.yml
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/resources/test-kieserver-state-config-map-detached-kie.yml
@@ -23,10 +23,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: myapp2-kieserver-1
+  name: myapp2-kieserver-5
   labels:
-    services.server.kie.org/kie-server-id: myapp2-kieserver-immutable
-    services.server.kie.org/kie-server-state: IMMUTABLE
+    services.server.kie.org/kie-server-state: DETACHED
+    services.server.kie.org/kie-server-id: myapp2-kieserver-detached-kie
     application: myapp2
   annotations:
     test.annotation: must_be_kept
@@ -51,11 +51,6 @@ data:
           <config-item>
             <name>org.kie.server.sync.deploy</name>
             <value>true</value>
-            <type>java.lang.String</type>
-          </config-item>
-          <config-item>
-            <name>org.kie.server.location</name>
-            <value>http://myapp2-kieserver-myproject.127.0.0.1.nip.io:80/services/rest/server</value>
             <type>java.lang.String</type>
           </config-item>
           <config-item>
@@ -95,7 +90,7 @@ data:
           </config-item>
           <config-item>
             <name>org.kie.server.id</name>
-            <value>myapp2-kieserver</value>
+            <value>myapp2-kieserver-detached-kie</value>
             <type>java.lang.String</type>
           </config-item>
           <config-item>

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/resources/test-kieserver-state-config-map-used-with-container.yml
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/resources/test-kieserver-state-config-map-used-with-container.yml
@@ -23,8 +23,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: myapp2-kieserver-container
+  name: myapp2-kieserver-2
   labels:
+    services.server.kie.org/kie-server-id: myapp2-kieserver-container
     services.server.kie.org/kie-server-state: USED
     application: myapp2
   annotations:

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/resources/test-kieserver-state-config-map-used-with-stopped-container.yml
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/resources/test-kieserver-state-config-map-used-with-stopped-container.yml
@@ -23,8 +23,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: myapp2-kieserver-stopped
+  name: myapp2-kieserver-3
   labels:
+    services.server.kie.org/kie-server-id: myapp2-kieserver-stopped
     services.server.kie.org/kie-server-state: USED
     application: myapp2
   annotations:

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/resources/test-kieserver-state-config-map-used-without-container.yml
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/resources/test-kieserver-state-config-map-used-without-container.yml
@@ -23,8 +23,9 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: myapp2-kieserver-nocontainer
+  name: myapp2-kieserver-4
   labels:
+    services.server.kie.org/kie-server-id: myapp2-kieserver-nocontainer
     services.server.kie.org/kie-server-state: USED
     application: myapp2
   annotations:

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/resources/test-kieserver-state-config-map-used.yml
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/resources/test-kieserver-state-config-map-used.yml
@@ -23,9 +23,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: myapp2-kieserver
+  name: myapp2-kieserver-0
   labels:
     services.server.kie.org/kie-server-state: USED
+    services.server.kie.org/kie-server-id: myapp2-kieserver
     application: myapp2
   annotations:
     test.annotation: must_be_kept


### PR DESCRIPTION
In response to request from (https://issues.jboss.org/projects/JBPM/issues/JBPM-8150), this PR includes the implementation remove the coupling between KIE server id and name of KIE server Deployment config, allowing users to choose whatever KIE server id they want, during creation of template or later.

