### PR TITLE
[RHPAM-1975] ServerTemplateConverter breaks with KieServerMode mixed-case

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-openshift/src/main/java/org/kie/server/controller/openshift/storage/ServerTemplateConverter.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-openshift/src/main/java/org/kie/server/controller/openshift/storage/ServerTemplateConverter.java
@@ -120,8 +120,9 @@ public class ServerTemplateConverter {
         }
 
         template.setCapabilities(capabilities);
-        template.setMode(KieServerMode.valueOf(mode));
-
+        //https://issues.jboss.org/projects/RHPAM/issues/RHPAM-1975
+        template.setMode(KieServerMode.valueOf(mode.toUpperCase()));
+        
         return template;
     }
 


### PR DESCRIPTION
Improve resiliency by accommodating unexpected character case.     

Related JIRAs
https://issues.jboss.org/projects/RHPAM/issues/RHPAM-1975
https://issues.jboss.org/browse/KIECLOUD-121