### PR TITLE
Reduce the Kie server controller ping timeout

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
@@ -225,6 +225,7 @@
                 <org.kie.server.controller.pwd>usetheforce123@</org.kie.server.controller.pwd>
                 <org.kie.server.user>yoda</org.kie.server.user>
                 <org.kie.server.pwd>usetheforce123@</org.kie.server.pwd>
+                <org.kie.controller.ping.alive.timeout>1000</org.kie.controller.ping.alive.timeout>
               </systemProperties>
             </container>
             <deployables combine.children="append">

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerCrashIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerCrashIntegrationTest.java
@@ -167,6 +167,16 @@ public class KieControllerCrashIntegrationTest extends KieControllerManagementBa
         // Check that kie server is registered.
         serverUp.await(5, TimeUnit.SECONDS);
         ServerInstanceKeyList list = controllerClient.getServerInstances(instanceList.getServerTemplates()[0].getId());
+
+        if (list.getServerInstanceKeys().length == 0) {
+            // Race condition when health check deleted server instance sooner than we were able to check. Resubmitting server instance again.
+            serverUp = new CountDownLatch(1);
+            serverDown = new CountDownLatch(1);
+            controller.connect(kieServerInfo);
+
+            serverUp.await(5, TimeUnit.SECONDS);
+            list = controllerClient.getServerInstances(instanceList.getServerTemplates()[0].getId());
+        }
         assertNotNull(list.getServerInstanceKeys());
         assertEquals(1, list.getServerInstanceKeys().length);
 


### PR DESCRIPTION
To make KieControllerCrashIntegrationTest more reliable on slower machines.

@elguardian  Can you please take a look?