### PR TITLE
[RHPAM-2008] HTTP 503 error is shown in Monitoring console when Kie server is scaled to 0

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepository.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepository.java
@@ -101,7 +101,7 @@ public class KieServerStateOpenShiftRepository extends KieServerStateCloudReposi
                          .list()
                          .getItems()
                          .stream()
-                         .map(cfg -> (KieServerState) xs.fromXML(cfg.getData().get(CFG_MAP_DATA_KEY)))
+                         .map(this::getKieServerState)
                          .collect(Collectors.toList())
         );
     }


### PR DESCRIPTION
This PR is one of the step towards completely addressing this issue. It will be coordinated with other Kie Operator changes which updates the KieServerCM label from 'USED' to 'DETACHED' once KieServerDC scale down to 0. Then, the new capability brought by this PR will remove the correspondent 'serverInstances' from the 'ServerTemplate'. As a result, the 'REMOTE SERVER' list will be empty by revisiting the BC->AdminServer section or manually clicking SERVER CONFIGURATION 'refresh' button.

Related PRs
https://github.com/kiegroup/droolsjbpm-integration/pull/1780