### PR TITLE
[RHPAM-2008] HTTP 503 error is shown in Monitoring console #2

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/main/java/org/kie/server/controller/rest/RestKieServerControllerImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-rest/src/main/java/org/kie/server/controller/rest/RestKieServerControllerImpl.java
@@ -51,6 +51,10 @@ public class RestKieServerControllerImpl extends KieServerControllerImpl {
         String contentType = getContentType(headers);
         logger.debug("Received connect request from server with id {}", id);
         KieServerInfo serverInfo = unmarshal(serverInfoPayload, contentType, KieServerInfo.class);
+        if (serverInfo == null) {
+            serverInfo = new KieServerInfo();
+            serverInfo.setServerId(id);
+        }
         logger.debug("Server info {}", serverInfo);
         KieServerSetup serverSetup = connect(serverInfo);
 
@@ -68,7 +72,9 @@ public class RestKieServerControllerImpl extends KieServerControllerImpl {
                                         @PathParam("serverInstanceId") String id,
                                         @QueryParam("location") String serverLocation) {
         try {
-            KieServerInfo serverInfo = new KieServerInfo(id, "", "", Collections.<String>emptyList(), URLDecoder.decode(serverLocation, "UTF-8"));
+            String location = serverLocation == null || serverLocation.trim().length() == 0 
+                    ? "" : URLDecoder.decode(serverLocation, "UTF-8");
+            KieServerInfo serverInfo = new KieServerInfo(id, "", "", Collections.<String>emptyList(), location);
             disconnect(serverInfo);
             logger.info("Server with id '{}' disconnected", id);
         } catch (UnsupportedEncodingException e) {


### PR DESCRIPTION
This PR is a continuation towards completely addressing the issue specified by [RHPAM-2008]. It enhances KIE Server controller REST implementation with simplified CONNECT and DISCONNECT REST/API calls so that external utilities can send a 'signal' to simulate KIE Server instance connecting with/disconnecting from BC/WB->EmbeddedController.  

Related JIRA Comments:
https://issues.jboss.org/browse/RHPAM-2008?focusedCommentId=13722751&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13722751

Related PRs
https://github.com/kiegroup/droolsjbpm-integration/pull/1807