### PR TITLE
[RHBPMS-5252] Memory leak when repeatedly create and delete containers

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import javax.naming.InitialContext;
 
 import org.drools.compiler.kie.builder.impl.InternalKieContainer;
@@ -356,6 +357,7 @@ public class KieServerImpl {
                 synchronized (kci) {
                     kci.setStatus(KieContainerStatus.DISPOSING); // just in case
                     if (kci.getKieContainer() != null) {
+                        org.kie.api.builder.ReleaseId releaseId = kci.getKieContainer().getReleaseId();
                         List<KieServerExtension> disposedExtensions = new ArrayList<KieServerExtension>();
                         try {
                             // first attempt to dispose container on all extensions
@@ -371,7 +373,6 @@ public class KieServerImpl {
                             logger.warn("Dispose of container {} failed, putting it back to started state by recreating container on {}", containerId, disposedExtensions);
 
                             // since the dispose fail rollback must take place to put it back to running state
-                            org.kie.api.builder.ReleaseId releaseId = kci.getKieContainer().getReleaseId();
                             Map<String, Object> parameters = getCreateContainerParameters(releaseId);
                             for (KieServerExtension extension : disposedExtensions) {
                                 extension.createContainer(containerId, kci, parameters);
@@ -391,6 +392,7 @@ public class KieServerImpl {
                         kci.setKieContainer(null); // helps reduce concurrent access issues
                         // this may fail, but we already removed the container from the registry
                         kieContainer.dispose();
+                        ks.getRepository().removeKieModule(releaseId);
                         logger.info("Container {} (for release id {}) successfully stopped", containerId, kci.getResource().getReleaseId());
 
                         // store the current state of the server


### PR DESCRIPTION
backport from
http://git.app.eng.bos.redhat.com/git/kiegroup/droolsjbpm-integration.git/commit/?h=RHPAM-5212&id=260829a23bf0f48b02675f3c13f86bb7255a045a