### PR TITLE
[DROOLS-3875] Shade drools-model file based on the GAV of the KJar 

### DIFF
--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
@@ -174,7 +174,8 @@ public class GenerateModelMojo extends AbstractKieMojo {
             }
 
             // copy the META-INF packages file
-            final MemoryFile packagesMemoryFile = (MemoryFile) mfs.getFile(CanonicalKieModule.MODEL_FILE);
+            final String path = CanonicalKieModule.getModelFileWithGAV(kieModule.getReleaseId());
+            final MemoryFile packagesMemoryFile = (MemoryFile) mfs.getFile(path);
             final String packagesMemoryFilePath = packagesMemoryFile.getFolder().getPath().toPortableString();
             final Path packagesDestinationPath = Paths.get(targetDirectory.getPath(), "classes", packagesMemoryFilePath, packagesMemoryFile.getName());
 
@@ -260,7 +261,7 @@ public class GenerateModelMojo extends AbstractKieMojo {
                     final Folder targetFolder = trgMfs.getFolder(".");
                     srcMfs.copyFolder(sourceFolder, trgMfs, targetFolder);
                 }
-                modelWriter.writeModelFile(modelFiles, trgMfs);
+                modelWriter.writeModelFile(modelFiles, trgMfs, getInternalKieModule().getReleaseId());
             }
         }
     }


### PR DESCRIPTION
Shade drools-model file based on the GAV of the KJar in order to support multiple modules in a KieClassPathContainer

No test attached, but there's a repdroducer attached in  
https://issues.jboss.org/browse/DROOLS-3875
