### PR TITLE
[RHDM-851] Xerces is needed to run camel tests on IBM JDK

### DIFF
--- a/kie-camel/pom.xml
+++ b/kie-camel/pom.xml
@@ -141,6 +141,11 @@
     </dependency>
 
     <dependency>
+      <groupId>xerces</groupId>
+      <artifactId>xercesImpl</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-cxf</artifactId>
       <exclusions>


### PR DESCRIPTION
According to this

https://stackoverflow.com/a/44442682/4206

XercesImpl is needed