### PR TITLE
[RHPAM-2008] HTTP 503 error is shown in Monitoring console (3)

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/api/KieServerOpenShift.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/main/java/org/kie/server/services/openshift/api/KieServerOpenShift.java
@@ -40,7 +40,9 @@ public interface KieServerOpenShift {
         List<DeploymentConfig> deployments = client.deploymentConfigs()
                 .withLabel(CFG_MAP_LABEL_SERVER_ID_KEY, serverId).list().getItems();
         if (deployments.isEmpty()) { return Optional.empty();}
-        if (deployments.size() == 1) { return Optional.ofNullable(deployments.get(0)); }
+        if (deployments.size() == 1) {
+            return deployments.stream().filter(dc -> dc.getSpec().getReplicas().intValue() > 0).findFirst();
+        }
         throw new IllegalStateException("Ambiguous KIE server id: [" + serverId + 
                                         "]; more than one KIE server DeploymentConfig exists.");
     }

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryDetachedCMBCTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryDetachedCMBCTest.java
@@ -30,7 +30,7 @@ public class KieServerStateOpenShiftRepositoryDetachedCMBCTest extends KieServer
 
     @Test
     public void testDetachedKieServerCMatBCEnv() {
-        createDummyDCandRC("myapp2-kieserver-6", "myapp2-kieserver-detached-bc", UUID.randomUUID().toString());
+        createDummyDCandRC("myapp2-kieserver-6", "myapp2-kieserver-detached-bc", UUID.randomUUID().toString(),1);
         ConfigMap cfm = client.configMaps()
                 .load(KieServerStateOpenShiftRepositoryTest.class
                 .getResourceAsStream("/test-kieserver-state-config-map-detached-bc.yml")).get();

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryDetachedCMKIETest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryDetachedCMKIETest.java
@@ -35,7 +35,7 @@ public class KieServerStateOpenShiftRepositoryDetachedCMKIETest extends KieServe
         // By setting org.kie.server.id property, simulates a KIE server runtime. (isKieServerRuntime -> true)
         System.setProperty(KIE_SERVER_ID, "myapp2-kieserver-detached-kie");
         System.setProperty(KIE_SERVER_LOCATION, "http://myapp2-kieserver-5-myproject.127.0.0.1.nip.io:80/services/rest/server");
-        createDummyDCandRC("myapp2-kieserver-5", "myapp2-kieserver-detached-kie", UUID.randomUUID().toString());
+        createDummyDCandRC("myapp2-kieserver-5", "myapp2-kieserver-detached-kie", UUID.randomUUID().toString(), 1);
         ConfigMap cfm = client.configMaps()
                 .load(KieServerStateOpenShiftRepositoryTest.class
                 .getResourceAsStream("/test-kieserver-state-config-map-detached-kie.yml")).get();

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryRegularTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryRegularTest.java
@@ -274,7 +274,7 @@ public class KieServerStateOpenShiftRepositoryRegularTest extends KieServerState
     
         kieServerState.getConfiguration().getConfigItem(KIE_SERVER_ID).setValue(newKieServerID);
         // Create a dummy KIE server DC
-        createDummyDCandRC(newKieServerID, kieServerDCUID);
+        createDummyDCandRC(newKieServerID, kieServerDCUID, 1);
 
         repo.create(kieServerState);
         assertTrue(repo.getKieServerCM(client, newKieServerID).isPresent());
@@ -424,4 +424,20 @@ public class KieServerStateOpenShiftRepositoryRegularTest extends KieServerState
         System.clearProperty(KIE_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED);
     }
     
+    @Test
+    public void testCreateAndLoadWithZeroReplica() {
+        String newKieServerID = TEST_KIE_SERVER_ID + "_NEW";
+        String kieServerDCUID = UUID.randomUUID().toString();
+        createDummyDCandRC(newKieServerID, kieServerDCUID, 0);
+        assertFalse(repo.getKieServerDC(client, newKieServerID).isPresent());
+    }
+
+    @Test
+    public void testCreateAndLoadWithMoreReplicas() {
+        String newKieServerID = TEST_KIE_SERVER_ID + "_NEW";
+        String kieServerDCUID = UUID.randomUUID().toString();
+        createDummyDCandRC(newKieServerID, kieServerDCUID, 2);
+        assertTrue(repo.getKieServerDC(client, newKieServerID).isPresent());
+    }
+
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/src/test/java/org/kie/server/services/openshift/impl/storage/cloud/KieServerStateOpenShiftRepositoryTest.java
@@ -138,13 +138,13 @@ public abstract class KieServerStateOpenShiftRepositoryTest {
     }
     
     protected void createDummyDCandRC() {
-        createDummyDCandRC(TEST_KIE_SERVER_ID, UUID.randomUUID().toString());
+        createDummyDCandRC(TEST_KIE_SERVER_ID, UUID.randomUUID().toString(), 1);
     }
 
-    protected void createDummyDCandRC(String kieServerID, String kieServerDCUID) {
-        createDummyDCandRC(UUID.randomUUID().toString(), kieServerID, kieServerDCUID);
+    protected void createDummyDCandRC(String kieServerID, String kieServerDCUID, int replicas) {
+        createDummyDCandRC(UUID.randomUUID().toString(), kieServerID, kieServerDCUID, replicas);
     }
-    protected void createDummyDCandRC(String name, String kieServerID, String kieServerDCUID) {
+    protected void createDummyDCandRC(String name, String kieServerID, String kieServerDCUID, int replicas) {
         Map<String, String> labels = new HashMap<>();
         labels.put(CFG_MAP_LABEL_APP_NAME_KEY, TEST_APP_NAME);
         labels.put(CFG_MAP_LABEL_SERVER_ID_KEY, kieServerID);
@@ -157,7 +157,7 @@ public abstract class KieServerStateOpenShiftRepositoryTest {
                                   .withUid(kieServerDCUID)
                                 .endMetadata()
                                 .withNewSpec()
-                                  .withReplicas(0)
+                                  .withReplicas(replicas)
                                   .addNewTrigger()
                                     .withType("ConfigChange")
                                   .endTrigger()


### PR DESCRIPTION
This PR is a continuation towards completely addressing the issue specified by [RHPAM-2008]. It fixes a subtle issue which is that the value of kie-server-state label can be overwritten (Expected value: DETACHED; but being changed to USED) during the KIE Server termination when DC scales down to 0. As a result, it will defeat the capability introduced by the lifecycle hook script.    

Related JIRA Comments:
https://issues.jboss.org/browse/RHPAM-2008?focusedCommentId=13737574&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13737574

Related PRs
#1809