### PR TITLE
Missing component registration in kie-maven-plugin

### DIFF
--- a/kie-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/kie-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -34,6 +34,14 @@
                 <language>java</language>
             </configuration>
         </component>
+        
+        <component>
+            <role>org.codehaus.plexus.component.configurator.ComponentConfigurator</role>
+            <role-hint>include-project-dependencies</role-hint>
+            <implementation>org.kie.maven.plugin.IncludeProjectDependenciesComponentConfigurator</implementation>
+            <description></description>
+            <isolated-realm>false</isolated-realm>
+        </component>
 
     </components>
 


### PR DESCRIPTION
The `kie-maven-plugin` fails if on goal serialize fails (tested with maven 3.5.3) on a pom using
~~~xml
<build>
  <plugins>
    <plugin>
      <groupId>org.kie</groupId>
      <artifactId>kie-maven-plugin</artifactId>
      <version>7.21.0.Final</version>
      <configuration>
        <kiebases>
        <kiebase>HelloKB</kiebase>
        </kiebases>
        <resDirectory>${basedir}/src/main/res/raw</resDirectory>
      </configuration>
        <executions>
          <execution>
            <id>touch</id>
            <goals>
              <goal>touch</goal>
            </goals>
            <phase>initialize</phase>
          </execution>
          <execution>
            <id>compile-kbase</id>
              <goals>
                <goal>build</goal>
              </goals>
              <phase>compile</phase>
          </execution>
          <execution>
            <id>serialize</id>
            <goals>
              <goal>serialize</goal>
            </goals>
            <phase>compile</phase>
          </execution>
        </executions>
     </plugin>
  </plugins>
</build>
~~~
with the following error:
~~~
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 23.688 s
[INFO] Finished at: 2019-05-24T15:30:35+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.kie:kie-maven-plugin:7.21.0.Final:serialize (serialize) on project drools-test: Unable to retrieve component configurator include-project-dependencies for configuration of mojo org.kie:kie-maven-plugin:7.21.0.Final:serialize: java.util.NoSuchElementException
[ERROR]       role: org.codehaus.plexus.component.configurator.ComponentConfigurator
[ERROR]   roleHint: include-project-dependencies
[ERROR] -> [Help 1]
~~~

`SerializeMojo` references `IncludeProjectDependenciesComponentConfigurator` in its Mojo-definition but that component is not registered in the plugin's `components.xml` and it does not autodetect it.
It does not fail with the extra definition: 
```xml
<component-set>
    <components>
        ...
        <component>
            <role>org.codehaus.plexus.component.configurator.ComponentConfigurator</role>
            <role-hint>include-project-dependencies</role-hint>
            <implementation>org.kie.maven.plugin.IncludeProjectDependenciesComponentConfigurator</implementation>
            <description></description>
            <isolated-realm>false</isolated-realm>
        </component>
    </components>
</component-set>
```