### PR TITLE
[JBPM-8491] Do not allow filter by container alias

### DIFF
--- a/process-migration-service/frontend/server.js
+++ b/process-migration-service/frontend/server.js
@@ -36,6 +36,9 @@ app.get('/rest/kieserver/instances', (req, res) => {
 });
 
 app.get('/rest/kieserver/definitions', (req, res) => {
+  if (req.query.sourceContainerId === "error" || req.query.sourceProcessId === "error") {
+    return res.status(404).send('Not found');
+  }
   return res.send(readFile("definitions.json"));
 });
 

--- a/process-migration-service/frontend/src/component/tabMigrationPlan/wizardAddPlan/PageDefinition.js
+++ b/process-migration-service/frontend/src/component/tabMigrationPlan/wizardAddPlan/PageDefinition.js
@@ -110,6 +110,9 @@ export default class PageDefinition extends Component {
         //once fired the event, this currentInputValue will be saved in the wizard form's values
         ev = new Event("input", { bubbles: true });
         input.dispatchEvent(ev);
+      })
+      .catch(() => {
+        this.props.setInfo("", "");
       });
   };
 

--- a/process-migration-service/src/main/java/org/kie/processmigration/model/exceptions/ProcessDefinitionNotFoundException.java
+++ b/process-migration-service/src/main/java/org/kie/processmigration/model/exceptions/ProcessDefinitionNotFoundException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.processmigration.model.exceptions;
+
+public class ProcessDefinitionNotFoundException extends InvalidMigrationException {
+
+    private static final long serialVersionUID = 8119544485261592740L;
+
+    private final String kieServerID;
+    private final String containerID;
+    private final String processID;
+
+    public ProcessDefinitionNotFoundException(String kieServerID, String containerId, String processID) {
+        super(kieServerID);
+        this.kieServerID = kieServerID;
+        this.containerID = containerId;
+        this.processID = processID;
+    }
+
+    @Override
+    public String getMessage() {
+        return String.format("Cound not find ContainerID: %s and Process Definition: %s Running in KieServer: %s", this.containerID, this.processID, this.kieServerID);
+    }
+
+}

--- a/process-migration-service/src/main/java/org/kie/processmigration/rest/KieServiceResource.java
+++ b/process-migration-service/src/main/java/org/kie/processmigration/rest/KieServiceResource.java
@@ -18,6 +18,7 @@ package org.kie.processmigration.rest;
 import org.kie.processmigration.model.ProcessInfos;
 import org.kie.processmigration.model.RunningInstance;
 import org.kie.processmigration.model.exceptions.InvalidKieServerException;
+import org.kie.processmigration.model.exceptions.ProcessDefinitionNotFoundException;
 import org.kie.processmigration.service.KieService;
 
 import javax.inject.Inject;
@@ -53,7 +54,12 @@ public class KieServiceResource {
             @QueryParam("targetProcessId") String targetProcessId, @QueryParam("targetContainerId") String targetContainerId,
             @QueryParam("kieServerId") String kieServerId
     ) throws InvalidKieServerException {
-        ProcessInfos result = kieService.getProcessDefinitions(sourceContainerId, sourceProcessId, targetContainerId, targetProcessId, kieServerId);
+        ProcessInfos result = null;
+        try {
+            result = kieService.getProcessDefinitions(sourceContainerId, sourceProcessId, targetContainerId, targetProcessId, kieServerId);
+        } catch (ProcessDefinitionNotFoundException e) {
+            return Response.status(Response.Status.NOT_FOUND).entity(e.getMessage()).build();
+        }
         return Response.ok(result).build();
     }
 

--- a/process-migration-service/src/main/java/org/kie/processmigration/service/KieService.java
+++ b/process-migration-service/src/main/java/org/kie/processmigration/service/KieService.java
@@ -24,6 +24,7 @@ import org.kie.processmigration.model.KieServerConfig;
 import org.kie.processmigration.model.ProcessInfos;
 import org.kie.processmigration.model.RunningInstance;
 import org.kie.processmigration.model.exceptions.InvalidKieServerException;
+import org.kie.processmigration.model.exceptions.ProcessDefinitionNotFoundException;
 import org.kie.server.client.ProcessServicesClient;
 import org.kie.server.client.QueryServicesClient;
 import org.kie.server.client.UIServicesClient;
@@ -43,6 +44,6 @@ public interface KieService {
 
     List<RunningInstance> getRunningInstances(String containerId, String kieServerId, Integer page, Integer pageSize) throws InvalidKieServerException;
 
-    ProcessInfos getProcessDefinitions(String sourceContainerId, String sourceProcessId, String targetContainerId, String targetProcessId, String kieServerId) throws InvalidKieServerException;
+    ProcessInfos getProcessDefinitions(String sourceContainerId, String sourceProcessId, String targetContainerId, String targetProcessId, String kieServerId) throws InvalidKieServerException, ProcessDefinitionNotFoundException;
 
 }


### PR DESCRIPTION
Fix https://issues.jboss.org/browse/JBPM-8491

Propagate 404 when necessary instead of throwing 500 error.
The KieServer API filters by container alias and container id. In order to prevent inconsistencies when migrating, an additional validation has been added to enforce containerID matches the request.

Besides, in the frontend side the errors are captured to prevent user from moving forward with invalid data

Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>