### PR TITLE
[JBPM-8399] Added test for complete error stacktrace returned by kie-server

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/util/RestUtils.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/src/main/java/org/kie/server/remote/rest/common/util/RestUtils.java
@@ -222,17 +222,17 @@ public class RestUtils {
     }
     
     public static String errorMessage(Throwable e, String defaultMessage) {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+
+        pw.println(defaultMessage);
+
         if (INCLUDE_STACKTRACE) {
-            StringWriter sw = new StringWriter();
-            PrintWriter pw = new PrintWriter(sw);
             e.printStackTrace(pw);
-            
-            String message = sw.toString();
-            pw.close();
-            return message;
         }
-        
-        return defaultMessage;
+
+        pw.close();
+        return sw.toString();
     }
     
     public static String errorMessage(Throwable e) {        

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
@@ -294,6 +294,8 @@
               <org.kie.prometheus.server.ext.disabled>${org.kie.prometheus.server.ext.disabled}</org.kie.prometheus.server.ext.disabled>
               <!-- For JMS executor tests. -->
               <org.kie.executor.jms>true</org.kie.executor.jms>
+              <!-- For including complete stack trace in the response -->
+              <org.kie.server.stacktrace.included>true</org.kie.server.stacktrace.included>
             </systemProperties>
           </container>
         </configuration>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/StackTraceIncludedIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/StackTraceIncludedIntegrationTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.integrationtests.jbpm.rest;
+
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.kie.server.api.rest.RestURI.DOCUMENT_URI;
+import static org.kie.server.api.rest.RestURI.build;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.Response;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.server.api.marshalling.MarshallingFormat;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.integrationtests.config.TestConfig;
+import org.kie.server.integrationtests.shared.KieServerDeployer;
+import org.kie.server.integrationtests.shared.KieServerUtil;
+import org.kie.server.integrationtests.shared.basetests.RestOnlyBaseIntegrationTest;
+
+
+public class StackTraceIncludedIntegrationTest extends RestOnlyBaseIntegrationTest {
+
+    private static ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "definition-project", "1.0.0.Final");
+   
+    private static Map<MarshallingFormat, String> acceptHeadersByFormat = new HashMap<MarshallingFormat, String>();
+    
+    private static final String CONTAINER = "definition-project";
+    
+    
+    @BeforeClass
+    public static void buildAndDeployArtifacts() {
+        KieServerDeployer.buildAndDeployCommonMavenParent();
+        KieServerDeployer.buildAndDeployMavenProjectFromResource("/kjars-sources/definition-project");
+        // set the accepted formats with quality param to express preference
+        acceptHeadersByFormat.put(MarshallingFormat.JAXB, "application/xml;q=0.9,application/json;q=0.3");// xml is preferred over json
+        acceptHeadersByFormat.put(MarshallingFormat.JSON, "application/json;q=0.9,application/xml;q=0.3");// json is preferred over xml
+
+        createContainer(CONTAINER, releaseId);
+    }
+  
+    @Test
+    public void testStoreDocumentError() throws Exception {
+        KieServerUtil.deleteDocumentStorageFolder();
+
+        String documentEntity="Bad-formed document";
+
+        Map<String, Object> empty = new HashMap<>();
+        Response response = null;
+        try {
+            // create document
+            WebTarget clientRequest = newRequest(build(TestConfig.getKieServerHttpUrl(), DOCUMENT_URI, empty));
+            response = clientRequest.request(acceptHeadersByFormat.get(marshallingFormat)).post(createEntity(documentEntity));
+            String responseBody = response.readEntity(String.class);
+            Assert.assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus()); 
+            Assert.assertThat(responseBody, 
+            		    allOf(containsString("at org.kie.server.remote.rest.jbpm.DocumentResource.createDocument"),
+            		          containsString("at org.kie.server.services.impl.marshal.MarshallerHelper.unmarshal")));    
+        } finally {
+            if(response != null) {
+                response.close();
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
@MarianMacik added test into kie-server-integ-tests-all and change _errorMessage_ method to print always default message (and then, complete stack trace if property is enabled)