### PR TITLE
RHDM-975 Add missing ANLT4 library to DMN Fuse feature

### DIFF
--- a/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features-fuse.xml
+++ b/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features-fuse.xml
@@ -38,6 +38,7 @@
 
   <feature name="kie-dmn" description="Kie DMN" version="${project.version}">
     <feature version="${project.version}">drools-module</feature>
+    <bundle>mvn:org.antlr/antlr4-runtime/${version.org.antlr4}</bundle>
     <bundle>mvn:ch.obermuhlner/big-math/${version.ch.obermuhlner}</bundle>
     <bundle>mvn:org.drools/drools-constraint-parser/${version.org.kie}</bundle>
     <bundle>mvn:org.kie/kie-dmn-model/${version.org.kie}</bundle>


### PR DESCRIPTION
follows what was done with
https://github.com/kiegroup/droolsjbpm-integration/pull/1737

@jiripetrlik can you please check? I cannot reproduce the reproducer locally.

/cc @etirelli 