### PR TITLE
AF-2011: Redeploy does not abort running process instances when their process definition is deleted

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieServerExtension.java
@@ -58,7 +58,11 @@ public interface KieServerExtension {
     String getExtensionName();
 
     Integer getStartOrder();
-    
+
+    default void prepareContainerUpdate(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {
+
+    }
+
     default List<Message> healthCheck(boolean report) {
         List<Message> messages = new ArrayList<>();
         if (!isInitialized()) {

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
@@ -958,7 +958,7 @@ public class KieServerImpl implements KieServer {
     private void prepareUpdateExtensions(KieContainerInstanceImpl kci, ReleaseId releaseId, List<Message> messages, boolean resetBeforeUpdate) {
         Map<String, Object> parameters = getReleaseUpdateParameters(releaseId, messages, resetBeforeUpdate);
 
-        // once the upgrade was successful, notify all extensions so they can be upgraded (if needed)
+        // some extensions may require to do some operations before updating the container.
         for (KieServerExtension extension : getServerExtensions()) {
             extension.prepareContainerUpdate(kci.getContainerId(), kci, parameters);
             logger.debug("Preparing update for container {} (for release id {}) on {}.", kci.getContainerId(), releaseId, extension);

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
@@ -877,6 +877,8 @@ public class KieServerImpl implements KieServer {
                     logger.debug("Container {} (for release id {}) on {} ready to be updated", containerId, releaseId, extension);
                 }
 
+                prepareUpdateExtensions(kci, releaseId, messages, resetBeforeUpdate);
+
                 ReleaseId originalReleaseId = kci.getResource().getReleaseId();
                 Message updateMessage = updateKieContainerToVersion(kci, releaseId);
                 if (updateMessage.getSeverity().equals(Severity.WARN)) {
@@ -953,7 +955,17 @@ public class KieServerImpl implements KieServer {
         return response;
     }
 
-    private List<Message> updateExtensions(KieContainerInstanceImpl kci, ReleaseId releaseId, List<Message> messages, boolean resetBeforeUpdate) {
+    private void prepareUpdateExtensions(KieContainerInstanceImpl kci, ReleaseId releaseId, List<Message> messages, boolean resetBeforeUpdate) {
+        Map<String, Object> parameters = getReleaseUpdateParameters(releaseId, messages, resetBeforeUpdate);
+
+        // once the upgrade was successful, notify all extensions so they can be upgraded (if needed)
+        for (KieServerExtension extension : getServerExtensions()) {
+            extension.prepareContainerUpdate(kci.getContainerId(), kci, parameters);
+            logger.debug("Preparing update for container {} (for release id {}) on {}.", kci.getContainerId(), releaseId, extension);
+        }
+    }
+
+    private void updateExtensions(KieContainerInstanceImpl kci, ReleaseId releaseId, List<Message> messages, boolean resetBeforeUpdate) {
         String containerId = kci.getContainerId();
         List<KieServerExtension> extensions = getServerExtensions();
         Map<String, Object> parameters = getReleaseUpdateParameters(releaseId, messages, resetBeforeUpdate);
@@ -963,8 +975,6 @@ public class KieServerImpl implements KieServer {
             extension.updateContainer(containerId, kci, parameters);
             logger.debug("Container {} (for release id {}) on {} updated successfully", containerId, releaseId, extension);
         }
-
-        return messages;
     }
 
     public ServiceResponse<KieServerStateInfo> getServerState() {

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerImplDevelopmentModeTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerImplDevelopmentModeTest.java
@@ -94,6 +94,7 @@ public class KieServerImplDevelopmentModeTest extends AbstractKieServerImplTest 
         Assertions.assertThat(updateResponse.getType()).isEqualTo(ServiceResponse.ResponseType.SUCCESS);
 
         verify(extension).isUpdateContainerAllowed(anyString(), any(), any());
+        verify(extension).prepareContainerUpdate(anyString(), any(), any());
         verify(extension).updateContainer(any(), any(), any());
 
         kieServer.disposeContainer(containerId);


### PR DESCRIPTION
@mswiderski  @domhanak would you mind take a look?

This is part of an ensemble, please merge with:
https://github.com/kiegroup/kie-wb-common/pull/2681
https://github.com/kiegroup/droolsjbpm-integration/pull/1839