### PR TITLE
[DROOLS-4255] Add KIE server support for deploying custom Prometheus metrics

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-optaplanner/src/main/java/org/kie/server/services/optaplanner/SolverServiceBase.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-optaplanner/src/main/java/org/kie/server/services/optaplanner/SolverServiceBase.java
@@ -36,6 +36,7 @@ import org.kie.server.services.prometheus.PrometheusMetricsSolverListener;
 import org.optaplanner.core.api.score.Score;
 import org.optaplanner.core.api.solver.Solver;
 import org.optaplanner.core.api.solver.SolverFactory;
+import org.optaplanner.core.impl.phase.event.PhaseLifecycleListener;
 import org.optaplanner.core.impl.solver.AbstractSolver;
 import org.optaplanner.core.impl.solver.ProblemFactChange;
 import org.slf4j.Logger;
@@ -511,9 +512,12 @@ public class SolverServiceBase {
     }
 
     private void registerListener(Solver solver, String solverId) {
-        KieServerExtension extension = context.getServerExtension(PrometheusKieServerExtension.EXTENSION_NAME);
+        PrometheusKieServerExtension extension = (PrometheusKieServerExtension)context.getServerExtension(PrometheusKieServerExtension.EXTENSION_NAME);
         if (extension != null) {
             ((AbstractSolver) solver).addPhaseLifecycleListener(new PrometheusMetricsSolverListener(solverId));
+
+            // custom listeners; no need to check double listener registration as we call registerListener on solver create
+            extension.getOptaPlannerListeners(solverId).forEach(l -> ((AbstractSolver) solver).addPhaseLifecycleListener(l));
         }
     }
 

--- a/kie-server-parent/kie-server-services/kie-server-services-prometheus/src/main/java/org/kie/server/services/prometheus/PrometheusCustomMetricsSupport.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-prometheus/src/main/java/org/kie/server/services/prometheus/PrometheusCustomMetricsSupport.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.services.prometheus;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import org.apache.commons.collections.keyvalue.MultiKey;
+import org.jbpm.executor.AsynchronousJobListener;
+import org.jbpm.services.api.DeploymentEventListener;
+import org.kie.api.event.rule.AgendaEventListener;
+import org.kie.dmn.api.core.event.DMNRuntimeEventListener;
+import org.kie.server.services.api.KieContainerInstance;
+import org.optaplanner.core.impl.phase.event.PhaseLifecycleListener;
+
+class PrometheusCustomMetricsSupport {
+
+    private final Map<Class, List<?>> customMetricsInstances;
+
+    private final Map<MultiKey, List<AgendaEventListener>> agendaEventListeners;
+    private final Map<String, List<DMNRuntimeEventListener>> dmnRuntimeEventListeners;
+    private final Map<String, List<PhaseLifecycleListener>> phaseLifecycleListeners;
+
+    private ServiceLoader<PrometheusMetricsProvider> loader;
+
+    PrometheusCustomMetricsSupport(PrometheusKieServerExtension extension) {
+        loader = ServiceLoader.load(PrometheusMetricsProvider.class);
+        customMetricsInstances = new HashMap<>();
+        agendaEventListeners = new HashMap<>();
+        dmnRuntimeEventListeners = new HashMap<>();
+        phaseLifecycleListeners = new HashMap<>();
+    }
+
+    boolean hasCustomMetrics() {
+        return loader.iterator().hasNext();
+    }
+
+    List<PrometheusMetricsProvider> customMetricsProviders() {
+        List<PrometheusMetricsProvider> providers = new ArrayList<>();
+        loader.forEach(p -> providers.add(p));
+        return providers;
+    }
+
+    List<DMNRuntimeEventListener> getDMNRuntimeEventListener(KieContainerInstance kContainer) {
+        synchronized (dmnRuntimeEventListeners) {
+            if (!dmnRuntimeEventListeners.containsKey(kContainer.getContainerId())) {
+                List<DMNRuntimeEventListener> customListeners = new ArrayList<>();
+                //customer listeners, if any
+                loader.forEach(p -> {
+                    DMNRuntimeEventListener l = p.createDMNRuntimeEventListener(kContainer);
+                    if (l != null) {
+                        customListeners.add(l);
+                    }
+                });
+                dmnRuntimeEventListeners.put(kContainer.getContainerId(), customListeners);
+            }
+            return dmnRuntimeEventListeners.get(kContainer.getContainerId());
+        }
+    }
+
+    List<AgendaEventListener> getAgendaEventListener(String kieSessionId, KieContainerInstance kContainer) {
+        final MultiKey key = new MultiKey(kieSessionId, kContainer);
+        synchronized (agendaEventListeners) {
+            if (!agendaEventListeners.containsKey(key)) {
+                List<AgendaEventListener> customListeners = new ArrayList<>();
+                // customs listeners, if any
+                loader.forEach(p -> {
+                    AgendaEventListener l = p.createAgendaEventListener(kieSessionId, kContainer);
+                    if (l != null) {
+                        customListeners.add(l);
+                    }
+                });
+                agendaEventListeners.put(key, customListeners);
+            }
+            return agendaEventListeners.get(key);
+        }
+    }
+
+    List<PhaseLifecycleListener> getPhaseLifecycleListener(String solverId) {
+        synchronized (phaseLifecycleListeners) {
+            if (!phaseLifecycleListeners.containsKey(solverId)) {
+                List<PhaseLifecycleListener> customListeners = new ArrayList<>();
+                //customer listeners, if any
+                loader.forEach(p -> {
+                    PhaseLifecycleListener l = p.createPhaseLifecycleListener(solverId);
+                    if (l != null) {
+                        customListeners.add(l);
+                    }
+                });
+                phaseLifecycleListeners.put(solverId, customListeners);
+            }
+            return phaseLifecycleListeners.get(solverId);
+        }
+    }
+
+    List<AsynchronousJobListener> getAsynchronousJobListener() {
+        return getListener(AsynchronousJobListener.class);
+    }
+
+    List<DeploymentEventListener> getDeploymentEventListener() {
+        return getListener(DeploymentEventListener.class);
+    }
+
+    private <T> List<T> getListener(Class<T> clazz) {
+        synchronized (customMetricsInstances) {
+            if (!customMetricsInstances.containsKey(clazz)) {
+                List<T> customMetricsTargets = new ArrayList<>();
+                loader.forEach(p -> {
+                    T l = createListener(p, clazz);
+                    if (l != null) {
+                        customMetricsTargets.add(l);
+                    }
+                });
+                customMetricsInstances.put(clazz, customMetricsTargets);
+            }
+            return (List<T>) customMetricsInstances.get(clazz);
+        }
+    }
+
+    private <T> T createListener(PrometheusMetricsProvider p , Class<T> clazz) {
+        T l = null;
+        if (DeploymentEventListener.class.isAssignableFrom(clazz)) {
+            l = (T) p.createDeploymentEventListener();
+        }
+        if (AsynchronousJobListener.class.isAssignableFrom(clazz)) {
+            l = (T) p.createAsynchronousJobListener();
+        }
+        return l;
+    }
+
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-prometheus/src/main/java/org/kie/server/services/prometheus/PrometheusMetricsProvider.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-prometheus/src/main/java/org/kie/server/services/prometheus/PrometheusMetricsProvider.java
@@ -1,0 +1,24 @@
+package org.kie.server.services.prometheus;
+
+import org.jbpm.executor.AsynchronousJobListener;
+import org.jbpm.services.api.DeploymentEventListener;
+import org.kie.api.event.rule.AgendaEventListener;
+import org.kie.dmn.api.core.event.DMNRuntimeEventListener;
+import org.kie.server.services.api.KieContainerInstance;
+import org.optaplanner.core.impl.phase.event.PhaseLifecycleListener;
+
+public interface PrometheusMetricsProvider {
+
+    //Drools & DMN
+    DMNRuntimeEventListener createDMNRuntimeEventListener(KieContainerInstance kContainer);
+
+    AgendaEventListener createAgendaEventListener(String kieSessionId, KieContainerInstance kContainer);
+
+    //Optaplanner
+    PhaseLifecycleListener createPhaseLifecycleListener(String solverId);
+
+    //jBPM
+    AsynchronousJobListener createAsynchronousJobListener();
+
+    DeploymentEventListener createDeploymentEventListener();
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-prometheus/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-prometheus/pom.xml
@@ -1,0 +1,78 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.kie.server</groupId>
+    <artifactId>kie-server-integ-tests-custom-extension</artifactId>
+    <version>7.26.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>kie-server-integ-tests-custom-extension-prometheus</artifactId>
+
+  <name>KIE :: Execution Server :: Tests :: Custom extension :: Prometheus</name>
+  <description>KIE Custom Extension Prometheus</description>
+
+  <properties>
+    <java.module.name>org.kie.server.itests.custom.extension.prometheus</java.module.name>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-api</artifactId>
+    </dependency>
+
+    <!-- https://mvnrepository.com/artifact/io.prometheus/simpleclient -->
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-services-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-executor</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.optaplanner</groupId>
+      <artifactId>optaplanner-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-services-drools</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-services-prometheus</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-services-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-core</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-prometheus/src/main/java/org/kie/server/ext/prometheus/MyPrometheusMetricsProvider.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-prometheus/src/main/java/org/kie/server/ext/prometheus/MyPrometheusMetricsProvider.java
@@ -1,0 +1,35 @@
+package org.kie.server.ext.prometheus;
+
+import org.jbpm.executor.AsynchronousJobListener;
+import org.jbpm.services.api.DeploymentEventListener;
+import org.kie.api.event.rule.AgendaEventListener;
+import org.kie.api.event.rule.DefaultAgendaEventListener;
+import org.kie.dmn.api.core.event.DMNRuntimeEventListener;
+import org.kie.server.services.api.KieContainerInstance;
+import org.kie.server.services.prometheus.PrometheusMetricsProvider;
+import org.optaplanner.core.impl.phase.event.PhaseLifecycleListener;
+import org.optaplanner.core.impl.phase.event.PhaseLifecycleListenerAdapter;
+
+public class MyPrometheusMetricsProvider implements PrometheusMetricsProvider {
+
+    public DMNRuntimeEventListener createDMNRuntimeEventListener(KieContainerInstance kContainer) {
+        return new ExampleCustomPrometheusMetricListener(kContainer);
+    }
+
+    public AgendaEventListener createAgendaEventListener(String kieSessionId, KieContainerInstance kContainer) {
+        return new DefaultAgendaEventListener();
+    }
+
+    public PhaseLifecycleListener createPhaseLifecycleListener(String solverId) {
+        return new PhaseLifecycleListenerAdapter() {
+        };
+    }
+
+    public AsynchronousJobListener createAsynchronousJobListener() {
+        return null;
+    }
+
+    public DeploymentEventListener createDeploymentEventListener() {
+        return null;
+    }
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-prometheus/src/main/resources/META-INF/services/org.kie.server.services.prometheus.PrometheusMetricsProvider
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-prometheus/src/main/resources/META-INF/services/org.kie.server.services.prometheus.PrometheusMetricsProvider
@@ -1,0 +1,1 @@
+org.kie.server.ext.prometheus.MyPrometheusMetricsProvider

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/pom.xml
@@ -15,6 +15,7 @@
   <properties>
     <java.module.name>org.kie.server.itests.custom.extension.test</java.module.name>
     <org.drools.server.ext.disabled>false</org.drools.server.ext.disabled>
+    <org.kie.prometheus.server.ext.disabled>false</org.kie.prometheus.server.ext.disabled>
   </properties>
 
   <dependencies>
@@ -31,6 +32,11 @@
     <dependency>
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-integ-tests-custom-extension-services</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-integ-tests-custom-extension-prometheus</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -81,6 +87,7 @@
                 <target>
                   <unzip src="${maven.dependency.org.kie.server.kie-server.ee7.war.path}" dest="${project.build.directory}/unzipped-kie-server"/>
                   <copy file="${maven.dependency.org.kie.server.kie-server-integ-tests-custom-extension-services.jar.path}" todir="${project.build.directory}/unzipped-kie-server/WEB-INF/lib"/>
+                  <copy file="${maven.dependency.org.kie.server.kie-server-integ-tests-custom-extension-prometheus.jar.path}" todir="${project.build.directory}/unzipped-kie-server/WEB-INF/lib"/>
                   <copy file="${maven.dependency.org.kie.server.kie-server-integ-tests-custom-extension-rest.jar.path}" todir="${project.build.directory}/unzipped-kie-server/WEB-INF/lib"/>
                   <zip destfile="${project.build.directory}/kie-server.war" basedir="${project.build.directory}/unzipped-kie-server"/>
                 </target>
@@ -111,6 +118,7 @@
               <org.jbpm.server.ext.disabled>true</org.jbpm.server.ext.disabled>
               <org.drools.server.ext.disabled>${org.drools.server.ext.disabled}</org.drools.server.ext.disabled>
               <org.optaplanner.server.ext.disabled>true</org.optaplanner.server.ext.disabled>
+              <org.kie.prometheus.server.ext.disabled>${org.kie.prometheus.server.ext.disabled}</org.kie.prometheus.server.ext.disabled>
               <kie.server.testing.kjars.build.settings.xml>${kie.server.testing.kjars.build.settings.xml}</kie.server.testing.kjars.build.settings.xml>
             </systemPropertyVariables>
           </configuration>
@@ -141,6 +149,7 @@
               <org.jbpm.server.ext.disabled>true</org.jbpm.server.ext.disabled>
               <org.drools.server.ext.disabled>${org.drools.server.ext.disabled}</org.drools.server.ext.disabled>
               <org.optaplanner.server.ext.disabled>true</org.optaplanner.server.ext.disabled>
+              <org.kie.prometheus.server.ext.disabled>${org.kie.prometheus.server.ext.disabled}</org.kie.prometheus.server.ext.disabled>
             </systemProperties>
           </container>
           <deployables>
@@ -170,6 +179,7 @@
                     <target>
                       <unzip src="${maven.dependency.org.kie.server.kie-server.webc.war.path}" dest="${project.build.directory}/unzipped-kie-server"/>
                       <copy file="${maven.dependency.org.kie.server.kie-server-integ-tests-custom-extension-services.jar.path}" todir="${project.build.directory}/unzipped-kie-server/WEB-INF/lib"/>
+                      <copy file="${maven.dependency.org.kie.server.kie-server-integ-tests-custom-extension-prometheus.jar.path}" todir="${project.build.directory}/unzipped-kie-server/WEB-INF/lib"/>
                       <copy file="${maven.dependency.org.kie.server.kie-server-integ-tests-custom-extension-rest.jar.path}" todir="${project.build.directory}/unzipped-kie-server/WEB-INF/lib"/>
                       <zip destfile="${project.build.directory}/kie-server.war" basedir="${project.build.directory}/unzipped-kie-server"/>
                     </target>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/src/test/filtered-resources/kjars-sources/function-definition/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/src/test/filtered-resources/kjars-sources/function-definition/pom.xml
@@ -1,0 +1,24 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.kie.server.testing</groupId>
+    <artifactId>common-parent</artifactId>
+    <version>1.0.0.Final</version>
+  </parent>
+
+  <artifactId>function-definition</artifactId>
+  <version>1.0.0.Final</version>
+  <packaging>kjar</packaging>
+
+<!-- there should be no need for Kie, Kie-DMN, etc dependencies here -->
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/src/test/filtered-resources/kjars-sources/function-definition/src/main/resources/FunctionDefinition.dmn
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/src/test/filtered-resources/kjars-sources/function-definition/src/main/resources/FunctionDefinition.dmn
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2016 Red Hat, Inc. and/or its affiliates.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<definitions id="_function-definition" 
+    name="function-definition"
+    namespace="https://www.drools.org/kie-dmn/function-definition"
+    xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+    xmlns:kie="https://www.drools.org/kie-dmn/function-definition"
+    xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
+  <decision id="_b459d12a-f00f-4846-a12e-2883455f7d7b" name="Math">
+    <variable id="_e2be00de-3280-4ca8-a6e6-6804876c045b" name="Math"/>
+    <informationRequirement>
+      <requiredInput href="#_38863c23-d5e1-4af3-aeef-fc84706ee46b"/>
+    </informationRequirement>
+    <informationRequirement>
+      <requiredInput href="#_29fb05e4-387f-4180-aad7-8680787bb45a"/>
+    </informationRequirement>
+    <context>
+      <contextEntry>
+        <variable id="_d6970f58-cacc-4028-a04d-5fc38b9846b2" name="SumFunction" typeRef="feel:function"/>
+        <functionDefinition>
+          <formalParameter name="v1" typeRef="feel:number"/>
+          <formalParameter name="v2" typeRef="feel:number"/>
+          <literalExpression typeRef="feel:number">
+            <text>v1+v2</text>
+          </literalExpression>
+        </functionDefinition>
+      </contextEntry>
+      <contextEntry>
+        <variable id="_f2392e71-805f-4404-98ee-c510b229fccd" name="Sum" typeRef="feel:number"/>
+        <invocation>
+          <literalExpression>
+            <text>SumFunction</text>
+          </literalExpression>
+          <binding>
+            <parameter name="v1"/>
+            <literalExpression>
+              <text>a</text>
+            </literalExpression>
+          </binding>
+          <binding>
+            <parameter name="v2"/>
+            <literalExpression>
+              <text>b</text>
+            </literalExpression>
+          </binding>
+        </invocation>
+      </contextEntry>
+    </context>
+  </decision>
+  <inputData id="_38863c23-d5e1-4af3-aeef-fc84706ee46b" name="a">
+    <variable id="_102502ce-b714-4d1b-ad8f-82635b9fd2f1" name="a" typeRef="feel:number"/>
+  </inputData>
+  <inputData id="_29fb05e4-387f-4180-aad7-8680787bb45a" name="b">
+    <variable id="_e876cfa3-f9dc-4f59-b3fe-bbab5b8a450e" name="b" typeRef="feel:number"/>
+  </inputData>
+</definitions>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/src/test/filtered-resources/kjars-sources/function-definition/src/main/resources/META-INF/kmodule.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/src/test/filtered-resources/kjars-sources/function-definition/src/main/resources/META-INF/kmodule.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kmodule xmlns="http://www.drools.org/xsd/kmodule">
+  <!-- This is a minimal kmodule.xml. Ref Drools documentation, see http://docs.jboss.org/drools/release/6.1.0.Final/drools-docs/html_single/index.html#d0e1112 -->
+</kmodule>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/src/test/java/org/kie/server/integrationtests/extension/custom/PrometheusCustomExtensionIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/src/test/java/org/kie/server/integrationtests/extension/custom/PrometheusCustomExtensionIntegrationTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.integrationtests.extension.custom;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.assertj.core.api.Assertions;
+import org.jboss.resteasy.client.jaxrs.BasicAuthentication;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.dmn.api.core.DMNContext;
+import org.kie.dmn.api.core.DMNResult;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.client.DMNServicesClient;
+import org.kie.server.client.KieServicesClient;
+import org.kie.server.integrationtests.config.TestConfig;
+import org.kie.server.integrationtests.shared.KieServerAssert;
+import org.kie.server.integrationtests.shared.KieServerDeployer;
+import org.kie.server.integrationtests.shared.basetests.KieServerBaseIntegrationTest;
+import org.kie.server.integrationtests.shared.basetests.RestJmsSharedBaseIntegrationTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+
+public class PrometheusCustomExtensionIntegrationTest extends RestJmsSharedBaseIntegrationTest {
+
+    private static ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "function-definition", "1.0.0.Final");
+
+    private static final String CONTAINER_ID  = "function-definition";
+
+    private static Client httpClient;
+
+    private DMNServicesClient dmnClient;
+
+    @BeforeClass
+    public static void deployArtifacts() {
+        KieServerDeployer.buildAndDeployCommonMavenParent();
+        KieServerDeployer.buildAndDeployMavenProjectFromResource("/kjars-sources/function-definition");
+
+        kieContainer = KieServices.Factory.get().newKieContainer(releaseId);
+
+        KieServerBaseIntegrationTest.createContainer(CONTAINER_ID, releaseId);
+    }
+
+    @AfterClass
+    public static void disposeContainers() {
+        disposeAllContainers();
+    }
+
+    @AfterClass
+    public static void closeHttpClient() {
+        if (httpClient != null) {
+            httpClient.close();
+            httpClient = null;
+        }
+    }
+
+    @Override
+    protected void setupClients(KieServicesClient client) {
+        dmnClient = client.getServicesClient( DMNServicesClient.class );
+    }
+
+    @Test
+    public void test_evaluateAll() {
+        DMNContext dmnContext = dmnClient.newContext();
+        dmnContext.set( "a", 10 );
+        dmnContext.set( "b", 5 );
+        ServiceResponse<DMNResult> evaluateAll = dmnClient.evaluateAll(CONTAINER_ID, dmnContext);
+        KieServerAssert.assertSuccess(evaluateAll);
+
+        DMNResult dmnResult = evaluateAll.getResult();
+
+        Map<String, Object> mathInCtx = (Map<String, Object>) dmnResult.getContext().get( "Math" );
+        Assertions.assertThat(mathInCtx).containsEntry("Sum", BigDecimal.valueOf( 15 ));
+
+        Map<String, Object> dr0 = (Map<String, Object>) dmnResult.getDecisionResultByName("Math").getResult();
+        Assertions.assertThat(dr0).containsEntry("Sum", BigDecimal.valueOf( 15 ));
+
+        assertThat(getMetrics()).contains("random_gauge_nanosecond");
+    }
+
+    private String getMetrics() {
+        if (httpClient == null) {
+            httpClient = new ResteasyClientBuilder().readTimeout(10, TimeUnit.SECONDS).build();
+        }
+
+        WebTarget webTarget = httpClient.target(URI.create(TestConfig.getKieServerHttpUrl()).resolve("../rest/metrics"));
+        webTarget.register(new BasicAuthentication(TestConfig.getUsername(), TestConfig.getPassword()));
+
+        try (Response response = webTarget.request(MediaType.TEXT_PLAIN).get()) {
+            assertEquals(200, response.getStatus());
+            return response.readEntity(String.class);
+        }
+    }
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/pom.xml
@@ -17,6 +17,7 @@
   <modules>
     <module>kie-server-integ-tests-custom-extension-services</module>
     <module>kie-server-integ-tests-custom-extension-rest</module>
+    <module>kie-server-integ-tests-custom-extension-prometheus</module>
     <module>kie-server-integ-tests-custom-extension-client</module>
     <module>kie-server-integ-tests-custom-extension-test</module>
   </modules>

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -160,6 +160,11 @@
         <version>${version.org.kie}</version>
       </dependency>
       <dependency>
+        <groupId>org.kie.server</groupId>
+        <artifactId>kie-server-integ-tests-custom-extension-prometheus</artifactId>
+        <version>${version.org.kie}</version>
+      </dependency>
+      <dependency>
         <groupId>org.codehaus.cargo</groupId>
         <artifactId>cargo-core-api-container</artifactId>
         <version>${version.org.codehaus.cargo}</version>


### PR DESCRIPTION
**Preview only** Adds support for user-provided custom Prometheus metrics. @cristianonicolai would you please help me review the jBPM part? It still needs some work. Custom listeners need to be packaged as a jar and included in WEB-INF/lib of the kie server similar to @mswiderski example at http://mswiderski.blogspot.com/2015/12/kie-server-extend-existing-server.html 

An example project to demonstrate custom listeners is at https://github.com/vblagoje/example-prometheus See custom listeners at https://github.com/vblagoje/example-prometheus/tree/master/custom-kie-ext