### PR TITLE
[DROOLS-4263 ]kbase.cache is not generated in kjar by kie-maven-plugin #1855

### DIFF
--- a/kie-integration-test-coverage/kie-maven-plugin-tests/test-suite/src/test/java/org/kie/integration/testcoverage/instrumentation/InstrumentationTest.java
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/test-suite/src/test/java/org/kie/integration/testcoverage/instrumentation/InstrumentationTest.java
@@ -15,6 +15,8 @@
 
 package org.kie.integration.testcoverage.instrumentation;
 
+import org.drools.compiler.kie.builder.impl.ZipKieModule;
+import org.drools.core.impl.InternalKieContainer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -29,6 +31,7 @@ import org.kie.integration.testcoverage.instrumentation.model.Person;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Collection;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -89,4 +92,12 @@ public class InstrumentationTest {
         assertThat(results).containsExactlyInAnyOrder("Lassie", "The Cat");
     }
 
+    @Test
+    public void testMetaInfoExists() {
+        ZipKieModule zipKieModule = (ZipKieModule)((InternalKieContainer)kieContainer).getMainKieModule();
+        Collection<String> fileNames = zipKieModule.getFileNames();
+
+        assertThat(fileNames).contains("META-INF/kmodule.info");
+        assertThat(fileNames).contains("META-INF/instrumentationKBase/kbase.cache");
+    }
 }

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/BuildMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/BuildMojo.java
@@ -173,14 +173,10 @@ public class BuildMojo extends AbstractKieMojo {
 
             List<Message> errors = messages != null ? messages.filterMessages( Message.Level.ERROR): Collections.emptyList();
 
-            if (container != null) {
-                Map<String, Object> kieMap = getKieMap();
-                if (!kieMap.isEmpty()) {
-                    CompilerHelper helper = new CompilerHelper();
-                    helper.share(kieMap, kModule, getLog());
-                }else{
-                    getLog().info("Kie Map empty");
-                }
+            Map<String, Object> kieMap = getKieMap();
+            if (container != null && !kieMap.isEmpty()) {
+                CompilerHelper helper = new CompilerHelper();
+                helper.share(kieMap, kModule, getLog());
             } else {
                 new KieMetaInfoBuilder(kModule).writeKieModuleMetaInfo(new DiskResourceStore(outputDirectory));
             }


### PR DESCRIPTION
Fix includes the unit test of @tkobayas
https://github.com/kiegroup/droolsjbpm-integration/pull/1855/commits/3564f00ea05315dc659c9b4919ab889dbb1d0201