### PR TITLE
Fix for DROOLS-4278 integration test

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/scorecard_mm/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/scorecard_mm/pom.xml
@@ -10,7 +10,16 @@
   <artifactId>scorecard_mm</artifactId>
   <version>1.0.0.Final</version>
   <packaging>kjar</packaging>
-  
+
+  <dependencies>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-api</artifactId>
+      <version>${version.org.kie}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/scorecard_mm/src/main/resources/META-INF/kmodule.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/scorecard_mm/src/main/resources/META-INF/kmodule.xml
@@ -1,6 +1,6 @@
 <kmodule xmlns="http://www.drools.org/xsd/kmodule" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <kbase name="kieBase1" default="true" eventProcessingMode="stream" equalsBehavior="identity" packages="org.kie.scorecard">
-    <ksession name="defaultkieSession" type="stateless" default="true" clockType="realtime"/>
+    <ksession name="defaultkieSession" type="stateful" default="true" clockType="realtime"/>
   </kbase>
   <kbase name="kieBase2" default="false" eventProcessingMode="stream" equalsBehavior="identity" packages="org.kie.extrarules">
     <ksession name="kieSession2" type="stateless" default="false" clockType="realtime"/>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/pmml/ApplyScorecardMultiModuleIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/pmml/ApplyScorecardMultiModuleIntegrationTest.java
@@ -32,6 +32,7 @@ public class ApplyScorecardMultiModuleIntegrationTest extends PMMLApplyModelBase
     private static ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "scorecard_mm", "1.0.0.Final");
 
     private static final String CONTAINER_ID = "scorecard_mm";
+    private static final String KJAR_RESOURCE_PATH = "/kjars-sources/scorecard_mm";
 
     private static final long EXTENDED_TIMEOUT = 300000L;
     private static ClassLoader classLoader;
@@ -39,7 +40,7 @@ public class ApplyScorecardMultiModuleIntegrationTest extends PMMLApplyModelBase
     @BeforeClass
     public static void buildAndDeployArtifacts() {
         KieServerDeployer.buildAndDeployCommonMavenParent();
-        KieServerDeployer.buildAndDeployMavenProjectFromResource("/kjars-sources/scorecard");
+        KieServerDeployer.buildAndDeployMavenProjectFromResource(KJAR_RESOURCE_PATH);
         KieMavenRepository kmp = KieMavenRepository.getKieMavenRepository();
         File artifact = kmp.resolveArtifact(releaseId).getFile();
         if (artifact != null) {


### PR DESCRIPTION
@lanceleverich Can you please take a look? This is the fix for https://github.com/kiegroup/droolsjbpm-integration/pull/1860 .
However it is not fully working yet. The PMML call fails on "Cannot find a default KieSession". The problem is that Kie server expect container to have stateful Kie session by default unless specified otherwise. I am not sure about the PMML backgroud, should stateful or stateless session be used?