### PR TITLE
Include stack trace configuration for Spring Boot KIE Server

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
@@ -429,6 +429,8 @@
         <kieserver.casemgmt.enabled>true</kieserver.casemgmt.enabled>
         <kieserver.prometheus.enabled>true</kieserver.prometheus.enabled>
         <jbpm.executor.disabled>true</jbpm.executor.disabled>
+        <!-- For including complete stack trace in the response -->
+        <org.kie.server.stacktrace.included>true</org.kie.server.stacktrace.included>
       </properties>
       <build>
         <plugins>

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -1173,6 +1173,8 @@
         <org.kie.server.persistence.ds>dummyDataSource</org.kie.server.persistence.ds>
         <!-- Same groups as for Tomcat -->
         <failsafe.excluded.groups>org.kie.server.integrationtests.category.JEEOnly,org.kie.server.integrationtests.category.JMSOnly,org.kie.server.integrationtests.category.Email,org.kie.server.integrationtests.category.RemotelyControlled</failsafe.excluded.groups>
+        <!-- Disable stacktrace inclusion by default -->
+        <org.kie.server.stacktrace.included>false</org.kie.server.stacktrace.included>
       </properties>
       <build>
         <pluginManagement>
@@ -1238,6 +1240,7 @@
                       <argument>-Dorg.jbpm.document.storage=${org.jbpm.document.storage}</argument>
                       <argument>-Dkie.server.base.http.url=${kie.server.base.http.url}</argument>
                       <argument>-Dorg.kie.server.mode=${org.kie.server.mode.production}</argument>
+                      <argument>-Dorg.kie.server.stacktrace.included=${org.kie.server.stacktrace.included}</argument>
                       <argument>org.springframework.boot.loader.JarLauncher</argument>
                     </arguments>
                   </configuration>


### PR DESCRIPTION
This fixes stack trace inclusion tests for Spring Boot.