### PR TITLE
BAQE-982: Remove cargo-core-uberjar from Kie server test dependencies

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
@@ -125,6 +125,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.json</groupId>
+      <artifactId>json</artifactId>
+      <scope>test</scope>
+    </dependency>
 
    <!--  Stay with httpcomponents: it will save us pain (as opposed to changing from resteasy to cxf to cxf 3.0, etc. --> 
     <dependency>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/FormServiceRestSubFormsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/rest/FormServiceRestSubFormsIntegrationTest.java
@@ -24,13 +24,12 @@ import java.util.Map;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.json.simple.JSONArray;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.rest.RestURI;
 import org.kie.server.integrationtests.config.TestConfig;
@@ -90,8 +89,7 @@ public class FormServiceRestSubFormsIntegrationTest extends RestJbpmBaseIntegrat
         // make sure fields from the two sub-forms are included in the result
         // checking for json only (same will apply for xml as well)
         if(getMediaType().getSubtype().equals("json")) {
-            JSONParser parser = new JSONParser();
-            JSONObject resultJSON = (JSONObject) parser.parse(result);
+            JSONObject resultJSON = new JSONObject(result);
             assertNotNull(resultJSON);
 
             JSONObject formKey = (JSONObject) resultJSON.get("form");
@@ -99,7 +97,7 @@ public class FormServiceRestSubFormsIntegrationTest extends RestJbpmBaseIntegrat
 
             assertNotNull(allFormFields);
             // two subforms
-            assertEquals(2, allFormFields.size());
+            assertEquals(2, allFormFields.length());
             assertEquals("component-ticket.form", ((JSONObject) allFormFields.get(0)).get("defaultSubform"));
             assertEquals("issue-subform.form", ((JSONObject) allFormFields.get(1)).get("defaultSubform"));
 
@@ -107,10 +105,10 @@ public class FormServiceRestSubFormsIntegrationTest extends RestJbpmBaseIntegrat
             JSONArray allFormInfo = (JSONArray) formKey.get("form");
             assertNotNull(allFormInfo);
             // two subform info
-            assertEquals(2, allFormInfo.size());
+            assertEquals(2, allFormInfo.length());
 
-            assertEquals(2, ((JSONArray) ((JSONObject) allFormInfo.get(0)).get("field")).size());
-            assertEquals(5, ((JSONArray) ((JSONObject) allFormInfo.get(1)).get("field")).size());
+            assertEquals(2, ((JSONArray) ((JSONObject) allFormInfo.get(0)).get("field")).length());
+            assertEquals(5, ((JSONArray) ((JSONObject) allFormInfo.get(1)).get("field")).length());
         } else if(getMediaType().getSubtype().equals("xml")) {
             try (ByteArrayInputStream stream = new java.io.ByteArrayInputStream(result.getBytes("UTF-8"))) {
                 Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(stream);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
@@ -196,14 +196,26 @@
 
     <!-- Cargo dependencies -->
     <dependency>
-     <groupId>org.codehaus.cargo</groupId>
-     <artifactId>cargo-core-uberjar</artifactId>
+      <groupId>org.codehaus.cargo</groupId>
+      <artifactId>cargo-core-api-container</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.cargo</groupId>
+      <artifactId>cargo-core-api-generic</artifactId>
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.cargo</groupId>
+      <artifactId>cargo-core-container-weblogic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.cargo</groupId>
+      <artifactId>cargo-core-container-wildfly</artifactId>
     </dependency>
 
     <dependency>

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -161,7 +161,22 @@
       </dependency>
       <dependency>
         <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-core-uberjar</artifactId>
+        <artifactId>cargo-core-api-container</artifactId>
+        <version>${version.org.codehaus.cargo}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.cargo</groupId>
+        <artifactId>cargo-core-api-generic</artifactId>
+        <version>${version.org.codehaus.cargo}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.cargo</groupId>
+        <artifactId>cargo-core-container-weblogic</artifactId>
+        <version>${version.org.codehaus.cargo}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.cargo</groupId>
+        <artifactId>cargo-core-container-wildfly</artifactId>
         <version>${version.org.codehaus.cargo}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
To fix build issues.