### PR TITLE
DROOLS-4440 Include whole project in kie-maven-plugin build

### DIFF
--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/BuildMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/BuildMojo.java
@@ -136,7 +136,8 @@ public class BuildMojo extends AbstractKieMojo {
 
             KieServices ks = KieServices.Factory.get();
             KieBuilderImpl kieBuilder = (KieBuilderImpl) ks.newKieBuilder(project.getBasedir());
-            kieBuilder.buildAll(DrlProject.SUPPLIER, s -> !s.contains("src/test/java") && !s.contains("src\\test\\java"));
+            kieBuilder.buildAll(DrlProject.SUPPLIER,
+                                s -> s.contains(sourceFolder.getAbsolutePath()) || s.endsWith("pom.xml"));
             InternalKieModule kModule = (InternalKieModule) kieBuilder.getKieModule();
             ResultsImpl messages = (ResultsImpl)kieBuilder.getResults();
 

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/BuildMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/BuildMojo.java
@@ -36,6 +36,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import javax.inject.Inject;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.artifact.resolver.filter.CumulativeScopeArtifactFilter;
@@ -58,15 +59,11 @@ import org.drools.compiler.kie.builder.impl.ResultsImpl;
 import org.drools.compiler.kie.builder.impl.ZipKieModule;
 import org.drools.compiler.kproject.ReleaseIdImpl;
 import org.drools.compiler.kproject.models.KieModuleModelImpl;
-import org.kie.api.KieServices;
-import org.kie.api.builder.KieFileSystem;
 import org.kie.api.builder.Message;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.builder.model.KieModuleModel;
-import org.kie.internal.io.ResourceFactory;
 
 import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.setDefaultsforEmptyKieModule;
-import static org.drools.compiler.kproject.models.KieModuleModelImpl.KMODULE_FILE_NAME;
 
 /**
  * This goal builds the Drools files belonging to the kproject.
@@ -150,19 +147,10 @@ public class BuildMojo extends AbstractKieMojo {
             throw new RuntimeException(e);
         }
 
-        KieServices ks = KieServices.Factory.get();
-
         try {
             setSystemProperties(properties);
 
-            KieFileSystem kfs = ks.newKieFileSystem();
-            for (File file : getResourceFiles(sourceFolder)) {
-                if (file.getName().equals( KMODULE_FILE_NAME ) || !file.getPath().contains("META-INF")) {
-                    kfs.write( ResourceFactory.newFileResource(file) );
-                }
-            }
-
-            KieBuilderImpl kieBuilder = new KieBuilderImpl(kfs);
+            KieBuilderImpl kieBuilder = new KieBuilderImpl(project.getBasedir());
             InternalKieModule kModule = (InternalKieModule)kieBuilder.getKieModule();
             for (InternalKieModule kmoduleDep : kmoduleDeps) {
                 kModule.addKieDependency(kmoduleDep);

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/BuildMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/BuildMojo.java
@@ -116,8 +116,6 @@ public class BuildMojo extends AbstractKieMojo {
     private void buildDrl() throws MojoFailureException {
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
 
-        List<InternalKieModule> kmoduleDeps = new ArrayList<>();
-
         try {
             Set<URL> urls = new HashSet<URL>();
             for (String element : project.getCompileClasspathElements()) {
@@ -129,11 +127,6 @@ public class BuildMojo extends AbstractKieMojo {
                 File file = artifact.getFile();
                 if (file != null) {
                     urls.add(file.toURI().toURL());
-                    KieModuleModel depModel = getDependencyKieModel(file);
-                    if (depModel != null) {
-                        ReleaseId releaseId = new ReleaseIdImpl(artifact.getGroupId(), artifact.getArtifactId(), artifact.getVersion());
-                        kmoduleDeps.add(new ZipKieModule(releaseId, depModel, file));
-                    }
                 }
             }
             urls.add(outputDirectory.toURI().toURL());
@@ -152,10 +145,6 @@ public class BuildMojo extends AbstractKieMojo {
 
             KieBuilderImpl kieBuilder = new KieBuilderImpl(project.getBasedir());
             InternalKieModule kModule = (InternalKieModule)kieBuilder.getKieModule();
-            for (InternalKieModule kmoduleDep : kmoduleDeps) {
-                kModule.addKieDependency(kmoduleDep);
-            }
-
             kieBuilder.buildAll();
             ResultsImpl messages = (ResultsImpl)kieBuilder.getResults();
 

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
@@ -20,8 +20,6 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
@@ -41,16 +39,12 @@ import org.drools.compiler.kie.builder.impl.KieBuilderImpl;
 import org.drools.compiler.kie.builder.impl.KieModuleKieProject;
 import org.drools.compiler.kie.builder.impl.MemoryKieModule;
 import org.drools.compiler.kie.builder.impl.ResultsImpl;
-import org.drools.compiler.kproject.models.KieModuleModelImpl;
 import org.drools.modelcompiler.CanonicalKieModule;
 import org.drools.modelcompiler.builder.CanonicalModelKieProject;
 import org.drools.modelcompiler.builder.ModelBuilderImpl;
 import org.drools.modelcompiler.builder.ModelWriter;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
-import org.kie.api.builder.model.KieModuleModel;
-
-import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.setDefaultsforEmptyKieModule;
 
 @Mojo(name = "generateModel",
         requiresDependencyResolution = ResolutionScope.NONE,
@@ -212,28 +206,6 @@ public class GenerateModelMojo extends AbstractKieMojo {
             e.printStackTrace();
             throw new MojoExecutionException("Unable to find .drl files");
         }
-    }
-
-    private KieModuleModel getDependencyKieModel(File jar) {
-        ZipFile zipFile = null;
-        try {
-            zipFile = new ZipFile(jar);
-            ZipEntry zipEntry = zipFile.getEntry(KieModuleModelImpl.KMODULE_JAR_PATH);
-            if (zipEntry != null) {
-                KieModuleModel kieModuleModel = KieModuleModelImpl.fromXML(zipFile.getInputStream(zipEntry));
-                setDefaultsforEmptyKieModule(kieModuleModel);
-                return kieModuleModel;
-            }
-        } catch (Exception e) {
-        } finally {
-            if (zipFile != null) {
-                try {
-                    zipFile.close();
-                } catch (IOException e) {
-                }
-            }
-        }
-        return null;
     }
 
     public static class ExecutableModelMavenProject implements KieBuilder.ProjectType {

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
@@ -135,9 +135,8 @@ public class GenerateModelMojo extends AbstractKieMojo {
             setSystemProperties(properties);
 
             final KieBuilderImpl kieBuilder = (KieBuilderImpl) ks.newKieBuilder(projectDir);
-            kieBuilder.buildAll(ExecutableModelMavenProject.SUPPLIER, s -> {
-                return !s.contains("src/test/java") && !s.contains("src\\test\\java");
-            });
+            kieBuilder.buildAll(ExecutableModelMavenProject.SUPPLIER,
+                                s -> !s.contains("src/test/java") && !s.contains("src\\test\\java"));
 
             InternalKieModule kieModule = (InternalKieModule) kieBuilder.getKieModule();
             List<String> generatedFiles = kieModule.getFileNames()

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
@@ -41,8 +41,6 @@ import org.drools.compiler.kie.builder.impl.KieBuilderImpl;
 import org.drools.compiler.kie.builder.impl.KieModuleKieProject;
 import org.drools.compiler.kie.builder.impl.MemoryKieModule;
 import org.drools.compiler.kie.builder.impl.ResultsImpl;
-import org.drools.compiler.kie.builder.impl.ZipKieModule;
-import org.drools.compiler.kproject.ReleaseIdImpl;
 import org.drools.compiler.kproject.models.KieModuleModelImpl;
 import org.drools.modelcompiler.CanonicalKieModule;
 import org.drools.modelcompiler.builder.CanonicalModelKieProject;
@@ -50,7 +48,6 @@ import org.drools.modelcompiler.builder.ModelBuilderImpl;
 import org.drools.modelcompiler.builder.ModelWriter;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
-import org.kie.api.builder.ReleaseId;
 import org.kie.api.builder.model.KieModuleModel;
 
 import static org.drools.compiler.kie.builder.impl.KieBuilderImpl.setDefaultsforEmptyKieModule;
@@ -93,9 +90,6 @@ public class GenerateModelMojo extends AbstractKieMojo {
 
     private void generateModel() throws MojoExecutionException {
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-
-        KieServices ks = KieServices.Factory.get();
-
         try {
             Set<URL> urls = new HashSet<>();
             for (String element : project.getCompileClasspathElements()) {
@@ -123,6 +117,7 @@ public class GenerateModelMojo extends AbstractKieMojo {
         try {
             setSystemProperties(properties);
 
+            KieServices ks = KieServices.Factory.get();
             final KieBuilderImpl kieBuilder = (KieBuilderImpl) ks.newKieBuilder(projectDir);
             kieBuilder.buildAll(ExecutableModelMavenProject.SUPPLIER,
                                 s -> !s.contains("src/test/java") && !s.contains("src\\test\\java"));

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
@@ -94,8 +94,6 @@ public class GenerateModelMojo extends AbstractKieMojo {
     private void generateModel() throws MojoExecutionException {
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
 
-        List<InternalKieModule> kmoduleDeps = new ArrayList<>();
-
         KieServices ks = KieServices.Factory.get();
 
         try {
@@ -110,15 +108,6 @@ public class GenerateModelMojo extends AbstractKieMojo {
                 File file = artifact.getFile();
                 if (file != null) {
                     urls.add(file.toURI().toURL());
-                    KieModuleModel depModel = getDependencyKieModel(file);
-                    if (depModel != null) {
-                        ReleaseId releaseId = new ReleaseIdImpl(artifact.getGroupId(),
-                                                                artifact.getArtifactId(),
-                                                                artifact.getVersion());
-                        kmoduleDeps.add(new ZipKieModule(releaseId,
-                                                         depModel,
-                                                         file));
-                    }
                 }
             }
             urls.add(outputDirectory.toURI().toURL());

--- a/kie-plugins-testing/src/test/projects/kjar-8-multimodule/modA/src/main/resources/META-INF/kmodule.xml
+++ b/kie-plugins-testing/src/test/projects/kjar-8-multimodule/modA/src/main/resources/META-INF/kmodule.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <kmodule xmlns="http://jboss.org/kie/6.0.0/kmodule">
-  <kbase name="modA">
+  <kbase name="modA" includes="modB">
     <ksession name="modA.stateful" type="stateful"/>
   </kbase>
 </kmodule>


### PR DESCRIPTION
Related Drools PR: https://github.com/kiegroup/drools/pull/2507

Fixes that now all project files are included in the build. Originally only resources were included, however when having a project pom.xml included in the build, the projects dependencies are automatically added to the build. This fixes a scenario when one KieBase includes another KieBase from a dependency KJar. 

JIRA: https://issues.jboss.org/browse/DROOLS-4440

@etirelli could you please review as Mario and Luca are on PTO? 