### PR TITLE
[7.26.x] [JBPM-8400] Logs are constantly flooded with 'Unable to load key store. Using password from configuration'

### DIFF
--- a/kie-server-parent/kie-server-common/src/main/java/org/kie/server/common/KeyStoreHelperUtil.java
+++ b/kie-server-parent/kie-server-common/src/main/java/org/kie/server/common/KeyStoreHelperUtil.java
@@ -1,5 +1,8 @@
 package org.kie.server.common;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.drools.core.util.KeyStoreHelper;
 import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.model.KieServerConfig;
@@ -19,21 +22,11 @@ public class KeyStoreHelperUtil {
 
     private static final Logger logger = LoggerFactory.getLogger(KeyStoreHelperUtil.class);
 
+    private static Set<String> invocationCache = new HashSet<>();
+
     public static String loadServerPassword() {
-        String passwordKey;
-        KeyStoreHelper keyStoreHelper = new KeyStoreHelper();
-
-        try {
-            String pwdKeyAlias = System.getProperty(PROP_PWD_SERVER_ALIAS, "");
-            char[] pwdKeyPassword = System.getProperty(PROP_PWD_SERVER_PWD, "").toCharArray();
-
-            passwordKey = keyStoreHelper.getPasswordKey(pwdKeyAlias, pwdKeyPassword);
-        } catch (RuntimeException re) {
-            logger.warn("Unable to load key store. Using password from configuration");
-            passwordKey = System.getProperty(KieServerConstants.CFG_KIE_PASSWORD, "kieserver1!");
-        }
-
-        return passwordKey;
+        String defaultPassword = System.getProperty(KieServerConstants.CFG_KIE_PASSWORD, "kieserver1!");
+        return loadPasswordKey(PROP_PWD_SERVER_ALIAS, PROP_PWD_SERVER_PWD, defaultPassword);
     }
 
     public static String loadControllerPassword(final KieServerConfig config) {
@@ -41,16 +34,31 @@ public class KeyStoreHelperUtil {
     }
 
     public static String loadControllerPassword(final String defaultPassword) {
+        return loadPasswordKey(PROP_PWD_CTRL_ALIAS, PROP_PWD_CTRL_PWD, defaultPassword);
+    }
+
+    private static String loadPasswordKey(String pwdKeyAliasProperty, String pwdKeyPasswordProperty, String defaultPassword) {
+        String passwordKey;
         KeyStoreHelper keyStoreHelper = new KeyStoreHelper();
-
         try {
-            String pwdKeyAlias = System.getProperty(PROP_PWD_CTRL_ALIAS, "");
-            char[] pwdKeyPassword = System.getProperty(PROP_PWD_CTRL_PWD, "").toCharArray();
-
-            return keyStoreHelper.getPasswordKey(pwdKeyAlias, pwdKeyPassword);
+            String pwdKeyAlias = System.getProperty(pwdKeyAliasProperty, "");
+            String pwdKeyPassword = System.getProperty(pwdKeyPasswordProperty, "");
+            passwordKey = keyStoreHelper.getPasswordKey(pwdKeyAlias, pwdKeyPassword.toCharArray());
         } catch (RuntimeException re) {
-            logger.warn("Unable to load key store. Using password from configuration");
-            return defaultPassword;
+            passwordKey = defaultPassword;
+            if (hasNotBeenInvoked(pwdKeyAliasProperty, pwdKeyPasswordProperty, passwordKey)) {
+                // only print when it has not been invoked
+                logger.warn("Unable to load key store. Using password from configuration");
+            }
         }
+        return passwordKey;
+    }
+
+    private static boolean hasNotBeenInvoked(String pwdKeyAliasProperty, String pwdKeyPasswordProperty, String passwordKey) {
+        if (invocationCache.contains(pwdKeyAliasProperty)) {
+            return false;
+        }
+        invocationCache.add(pwdKeyAliasProperty);
+        return true;
     }
 }


### PR DESCRIPTION
added some logic to print the message just the first time