### PR TITLE
DROOLS-4602 Create PomModel for KieBuilder directly in kie-maven-plugin

### DIFF
--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -227,6 +227,16 @@
       <artifactId>takari-plugin-testing</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!--Logs-->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/BuildMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/BuildMojo.java
@@ -37,6 +37,7 @@ import javax.inject.Inject;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.artifact.resolver.filter.CumulativeScopeArtifactFilter;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -66,6 +67,9 @@ import org.kie.api.builder.Message;
         defaultPhase = LifecyclePhase.COMPILE)
 public class BuildMojo extends AbstractKieMojo {
 
+    @Parameter(defaultValue = "${session}", required = true, readonly = true)
+    private MavenSession mavenSession;
+
     /**
      * Directory containing the generated JAR.
      */
@@ -86,8 +90,6 @@ public class BuildMojo extends AbstractKieMojo {
 
     @Parameter(required = false, defaultValue = "no")
     private String usesPMML;
-
-
 
     /**
      * This container is the same accessed in the KieMavenCli in the kie-wb-common
@@ -136,6 +138,7 @@ public class BuildMojo extends AbstractKieMojo {
 
             KieServices ks = KieServices.Factory.get();
             KieBuilderImpl kieBuilder = (KieBuilderImpl) ks.newKieBuilder(project.getBasedir());
+            kieBuilder.setPomModel(new ProjectPomModel(mavenSession));
             kieBuilder.buildAll(DrlProject.SUPPLIER,
                                 s -> s.contains(sourceFolder.getAbsolutePath()) || s.endsWith("pom.xml"));
             InternalKieModule kModule = (InternalKieModule) kieBuilder.getKieModule();

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.DependencyResolutionRequiredException;
 import org.apache.maven.artifact.resolver.filter.CumulativeScopeArtifactFilter;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -53,6 +54,9 @@ import org.kie.api.builder.KieBuilder;
 public class GenerateModelMojo extends AbstractKieMojo {
 
     public static PathMatcher drlFileMatcher = FileSystems.getDefault().getPathMatcher("glob:**.drl");
+
+    @Parameter(defaultValue = "${session}", required = true, readonly = true)
+    private MavenSession mavenSession;
 
     @Parameter(required = true, defaultValue = "${project.build.directory}")
     private File targetDirectory;
@@ -113,6 +117,7 @@ public class GenerateModelMojo extends AbstractKieMojo {
 
             KieServices ks = KieServices.Factory.get();
             final KieBuilderImpl kieBuilder = (KieBuilderImpl) ks.newKieBuilder(projectDir);
+            kieBuilder.setPomModel(new ProjectPomModel(mavenSession));
             kieBuilder.buildAll(ExecutableModelMavenProject.SUPPLIER,
                                 s -> !s.contains("src/test/java") && !s.contains("src\\test\\java"));
 

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/ProjectPomModel.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/ProjectPomModel.java
@@ -1,0 +1,90 @@
+package org.kie.maven.plugin;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
+import org.appformer.maven.support.AFReleaseId;
+import org.appformer.maven.support.AFReleaseIdImpl;
+import org.appformer.maven.support.DependencyFilter;
+import org.appformer.maven.support.PomModel;
+
+public class ProjectPomModel implements PomModel {
+
+    private final AFReleaseId releaseId;
+    private final AFReleaseId parentReleaseId;
+    private final Map<String, Set<AFReleaseId>> dependenciesByScope;
+
+    public ProjectPomModel(final MavenSession mavenSession) {
+        this.releaseId = getReleaseIdFromMavenProject(mavenSession.getCurrentProject());
+        final MavenProject parentProject = mavenSession.getCurrentProject().getParent();
+        if (parentProject != null) {
+            this.parentReleaseId = getReleaseIdFromMavenProject(parentProject);
+        } else {
+            this.parentReleaseId = null;
+        }
+        this.dependenciesByScope = getDirectDependenciesFromMavenSession(mavenSession);
+    }
+
+    @Override
+    public AFReleaseId getReleaseId() {
+        return releaseId;
+    }
+
+    @Override
+    public AFReleaseId getParentReleaseId() {
+        return parentReleaseId;
+    }
+
+    @Override
+    public Collection<AFReleaseId> getDependencies() {
+        return dependenciesByScope.values()
+                .stream()
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<AFReleaseId> getDependencies(final DependencyFilter filter) {
+        final Set<AFReleaseId> filteredDependencies = new HashSet<>();
+        for (Map.Entry<String, Set<AFReleaseId>> entry : dependenciesByScope.entrySet()) {
+            for (AFReleaseId dependencyReleaseId : entry.getValue()) {
+                if (filter.accept( dependencyReleaseId, entry.getKey() )) {
+                    filteredDependencies.add(dependencyReleaseId);
+                }
+            }
+        }
+        return filteredDependencies;
+    }
+
+    private AFReleaseId getReleaseIdFromMavenProject(final MavenProject mavenProject) {
+        return new AFReleaseIdImpl(mavenProject.getGroupId(),
+                                   mavenProject.getArtifactId(),
+                                   mavenProject.getVersion(),
+                                   mavenProject.getPackaging());
+    }
+
+    private AFReleaseId getReleaseIdFromDependency(final Dependency dependency) {
+        return new AFReleaseIdImpl(dependency.getGroupId(),
+                                   dependency.getArtifactId(),
+                                   dependency.getVersion(),
+                                   dependency.getType());
+    }
+
+    private Map<String, Set<AFReleaseId>> getDirectDependenciesFromMavenSession(final MavenSession mavenSession) {
+        final List<Dependency> dependencies = mavenSession.getCurrentProject().getDependencies();
+        final Map<String, Set<AFReleaseId>> result = new HashMap<>();
+        for (Dependency dependency : dependencies) {
+            final Set<AFReleaseId> scopeDependencies = result.computeIfAbsent(dependency.getScope(), s -> new HashSet<>());
+            scopeDependencies.add(getReleaseIdFromDependency(dependency));
+        }
+        return result;
+    }
+}

--- a/kie-maven-plugin/src/test/java/org/kie/maven/plugin/ProjectPomModelTest.java
+++ b/kie-maven-plugin/src/test/java/org/kie/maven/plugin/ProjectPomModelTest.java
@@ -1,0 +1,153 @@
+package org.kie.maven.plugin;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.project.MavenProject;
+import org.appformer.maven.support.AFReleaseId;
+import org.appformer.maven.support.AFReleaseIdImpl;
+import org.appformer.maven.support.DependencyFilter;
+import org.assertj.core.api.Condition;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ProjectPomModelTest {
+
+    private static final String GROUP_ID = "org.kie.test.groupid";
+    private static final String ARTIFACT_ID = "test-artifact";
+    private static final String PARENT_ARTIFACT_ID = "parent-artifact";
+    private static final String VERSION = "1.0";
+    private static final String PACKAGING = "kjar";
+
+    private static final String DEPENDENCY_GROUP_ID = "org.kie.test.dependency.groupid";
+    private static final String DEPENDENCY_ARTIFACT_ID1 = "dependency-artifact1";
+    private static final String DEPENDENCY_ARTIFACT_ID2 = "dependency-artifact2";
+    private static final String DEPENDENCY_VERSION = "1.0";
+    private static final String DEPENDENCY_PACKAGING = "jar";
+    private static final String DEPENDENCY_SCOPE1 = "compile";
+    private static final String DEPENDENCY_SCOPE2 = "test";
+
+    @Test
+    public void getReleaseId() {
+        final MavenSession mavenSession = mockMavenSession(false);
+        final ProjectPomModel pomModel = new ProjectPomModel(mavenSession);
+        final AFReleaseId releaseId = pomModel.getReleaseId();
+        assertReleaseId(releaseId, ARTIFACT_ID);
+    }
+
+    @Test
+    public void getParentReleaseId() {
+        final MavenSession mavenSession = mockMavenSession(true);
+        final ProjectPomModel pomModel = new ProjectPomModel(mavenSession);
+        final AFReleaseId releaseId = pomModel.getParentReleaseId();
+        assertReleaseId(releaseId, PARENT_ARTIFACT_ID);
+    }
+
+    @Test
+    public void getParentReleaseIdNull() {
+        final MavenSession mavenSession = mockMavenSession(false);
+        final ProjectPomModel pomModel = new ProjectPomModel(mavenSession);
+        assertThat(pomModel.getParentReleaseId()).isNull();
+    }
+
+    @Test
+    public void getDependencies() {
+        final MavenSession mavenSession = mockMavenSession(false);
+        mockDependencies(mavenSession.getCurrentProject());
+        final ProjectPomModel pomModel = new ProjectPomModel(mavenSession);
+        final Collection<AFReleaseId> dependencies = pomModel.getDependencies();
+        assertThat(dependencies).isNotNull().hasSize(2);
+        assertThat(dependencies).areExactly(1, new Condition<>(
+                releaseId -> releaseId instanceof AFReleaseIdImpl
+                        && DEPENDENCY_GROUP_ID.equals(releaseId.getGroupId())
+                        && DEPENDENCY_ARTIFACT_ID1.equals(releaseId.getArtifactId())
+                        && DEPENDENCY_VERSION.equals(releaseId.getVersion())
+                        && DEPENDENCY_PACKAGING.equals(((AFReleaseIdImpl) releaseId).getType()),
+                "Is dependency 1"));
+        assertThat(dependencies).areExactly(1, new Condition<>(
+                releaseId -> releaseId instanceof AFReleaseIdImpl
+                        && DEPENDENCY_GROUP_ID.equals(releaseId.getGroupId())
+                        && DEPENDENCY_ARTIFACT_ID2.equals(releaseId.getArtifactId())
+                        && DEPENDENCY_VERSION.equals(releaseId.getVersion())
+                        && DEPENDENCY_PACKAGING.equals(((AFReleaseIdImpl) releaseId).getType()),
+                "Is dependency 2"));
+    }
+
+    @Test
+    public void getDependenciesEmpty() {
+        final MavenSession mavenSession = mockMavenSession(false);
+        final ProjectPomModel pomModel = new ProjectPomModel(mavenSession);
+        final Collection<AFReleaseId> dependencies = pomModel.getDependencies();
+        assertThat(dependencies).isNotNull().isEmpty();
+    }
+
+    @Test
+    public void getDependenciesWithFilter() {
+        final MavenSession mavenSession = mockMavenSession(false);
+        mockDependencies(mavenSession.getCurrentProject());
+        final ProjectPomModel pomModel = new ProjectPomModel(mavenSession);
+        final Collection<AFReleaseId> dependencies = pomModel.getDependencies(
+                (releaseId, scope) -> DEPENDENCY_SCOPE1.equals(scope));
+        assertThat(dependencies).isNotNull().hasSize(1);
+        assertThat(dependencies).areExactly(1, new Condition<>(
+                releaseId -> releaseId instanceof AFReleaseIdImpl
+                        && DEPENDENCY_GROUP_ID.equals(releaseId.getGroupId())
+                        && DEPENDENCY_ARTIFACT_ID1.equals(releaseId.getArtifactId())
+                        && DEPENDENCY_VERSION.equals(releaseId.getVersion())
+                        && DEPENDENCY_PACKAGING.equals(((AFReleaseIdImpl) releaseId).getType()),
+                "Is dependency 1"));
+    }
+
+    private MavenSession mockMavenSession(final boolean addParentProject) {
+        final MavenSession mavenSession = mock(MavenSession.class);
+        final MavenProject currentProject = mockMavenProject(ARTIFACT_ID);
+        if (addParentProject) {
+            final MavenProject parentProject = mockMavenProject(PARENT_ARTIFACT_ID);
+            when(currentProject.getParent()).thenReturn(parentProject);
+        }
+
+        when(mavenSession.getCurrentProject()).thenReturn(currentProject);
+
+        return mavenSession;
+    }
+
+    private MavenProject mockMavenProject(final String artifactId) {
+        final MavenProject mavenProject = mock(MavenProject.class);
+        when(mavenProject.getGroupId()).thenReturn(GROUP_ID);
+        when(mavenProject.getArtifactId()).thenReturn(artifactId);
+        when(mavenProject.getVersion()).thenReturn(VERSION);
+        when(mavenProject.getPackaging()).thenReturn(PACKAGING);
+        return mavenProject;
+    }
+
+    private void mockDependencies(final MavenProject mavenProject) {
+        final List<Dependency> dependencies = new ArrayList<>();
+        dependencies.add(mockDependency(DEPENDENCY_ARTIFACT_ID1, DEPENDENCY_SCOPE1));
+        dependencies.add(mockDependency(DEPENDENCY_ARTIFACT_ID2, DEPENDENCY_SCOPE2));
+        when(mavenProject.getDependencies()).thenReturn(dependencies);
+    }
+
+    private Dependency mockDependency(final String artifactId, final String scope) {
+        final Dependency dependency = mock(Dependency.class);
+        when(dependency.getGroupId()).thenReturn(DEPENDENCY_GROUP_ID);
+        when(dependency.getArtifactId()).thenReturn(artifactId);
+        when(dependency.getVersion()).thenReturn(VERSION);
+        when(dependency.getType()).thenReturn(DEPENDENCY_PACKAGING);
+        when(dependency.getScope()).thenReturn(scope);
+        return dependency;
+    }
+
+    private void assertReleaseId(final AFReleaseId releaseId, final String artifactId) {
+        assertThat(releaseId).isNotNull().isInstanceOf(AFReleaseIdImpl.class);
+        assertThat(releaseId.getGroupId()).isEqualTo(GROUP_ID);
+        assertThat(releaseId.getArtifactId()).isEqualTo(artifactId);
+        assertThat(releaseId.getVersion()).isEqualTo(VERSION);
+        assertThat(((AFReleaseIdImpl) releaseId).getType()).isEqualTo(PACKAGING);
+    }
+}


### PR DESCRIPTION
- kie-maven-plugin creates a PomModel for KieBuilder instead of KieBuilder creating the PomModel itself. KieBuilder doesn't have access to all Maven build information to build a proper model. kie-maven-plugin does have this information, therefore is used to build the PomModel. 

This needs to be merged with https://github.com/kiegroup/drools/pull/2572