### PR TITLE
[JBPM-8885] Nodes after multi-Instance subprocess are not blurred eventhough process instance is completed.

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
@@ -55,6 +55,7 @@ public class KieServerConstants {
     public static final String KIE_SERVER_MODE = "org.kie.server.mode";
     public static final String KIE_SERVER_INCLUDE_STACKTRACE = "org.kie.server.stacktrace.included";
     public static final String KIE_SERVER_STRICT_ID_FORMAT = "org.kie.server.strict.id.format";
+    public static final String KIE_SERVER_IMAGESERVICE_MAX_NODES = "org.kie.server.service.image.max_nodes";
 
     // configuration parameters
     public static final String CFG_PERSISTANCE_DS = "org.kie.server.persistence.ds";

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/ImageServiceBase.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/ImageServiceBase.java
@@ -41,10 +41,18 @@ import org.slf4j.LoggerFactory;
 import static org.jbpm.process.svg.processor.SVGProcessor.ACTIVE_BORDER_COLOR;
 import static org.jbpm.process.svg.processor.SVGProcessor.COMPLETED_BORDER_COLOR;
 import static org.jbpm.process.svg.processor.SVGProcessor.COMPLETED_COLOR;
+import static org.kie.server.api.KieServerConstants.KIE_SERVER_IMAGESERVICE_MAX_NODES;
 
 public class ImageServiceBase {
 
     private static final Logger logger = LoggerFactory.getLogger(ImageServiceBase.class);
+
+    /**
+     * This causes the image service to limit the number of nodes (performance). 
+     * Due to this limitation it could cause a known issue not blurring all the nodes active or completed depending on
+     * the process size.
+     */
+    private static final int MAX_NODES = Integer.parseInt(System.getProperty(KIE_SERVER_IMAGESERVICE_MAX_NODES, "1000"));
 
     private RuntimeDataService dataService;
     private Map<String, ImageReference> imageReferenceMap;
@@ -121,8 +129,9 @@ public class ImageServiceBase {
         if (imageSVG != null) {
             // find active nodes and modify image
             Map<String, String> subProcessLinks = new HashMap<>();
-            Collection<NodeInstanceDesc> activeLogs = dataService.getProcessInstanceHistoryActive(procInstId, new QueryContext(0, 1000));
-            Collection<NodeInstanceDesc> completedLogs = dataService.getProcessInstanceHistoryCompleted(procInstId, new QueryContext(0, 1000));
+            QueryContext qc = MAX_NODES > 0 ? new QueryContext(0, MAX_NODES) : null;
+            Collection<NodeInstanceDesc> activeLogs = dataService.getProcessInstanceHistoryActive(procInstId, qc);
+            Collection<NodeInstanceDesc> completedLogs = dataService.getProcessInstanceHistoryCompleted(procInstId, qc);
             Map<Long, String> active = new HashMap<Long, String>();
             List<String> completed = new ArrayList<String>();
 


### PR DESCRIPTION
Added a property to increase the number of nodes retrieved from database