### PR TITLE
[JBPM-8864] not able to delete kieContainer after deploying container several times with same containerID due to an error

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/KieServerImpl.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+
 import javax.naming.InitialContext;
 
 import org.apache.commons.lang3.time.DurationFormatUtils;
@@ -99,7 +100,7 @@ public class KieServerImpl implements KieServer {
 
     private KieServerEventSupport eventSupport = new KieServerEventSupport();
 
-    private KieServices ks = KieServices.Factory.get();
+    private KieServices ks;
     
     private long startTimestamp;
     
@@ -112,7 +113,12 @@ public class KieServerImpl implements KieServer {
     }
 
     public KieServerImpl(KieServerStateRepository stateRepository) {
+        this(stateRepository, KieServices.Factory.get());
+    }
+
+    public KieServerImpl(KieServerStateRepository stateRepository, KieServices ks) {
         this.repository = stateRepository;
+        this.ks = ks;
 
         String modeParam = System.getProperty(KieServerConstants.KIE_SERVER_MODE, KieServerMode.DEVELOPMENT.toString());
 
@@ -267,13 +273,14 @@ public class KieServerImpl implements KieServer {
             // have to synchronize on the ci or a concurrent call to dispose may create inconsistencies
             synchronized (ci) {
 
-                previous = context.registerContainer(containerId, ci);
-                if (previous == null) {
+                previous = context.getContainer(containerId);
+                if (canBeDeployed(previous)) {
                     try {
                         eventSupport.fireBeforeContainerStarted(this, ci);
 
                         InternalKieContainer kieContainer = (InternalKieContainer) ks.newKieContainer(containerId, releaseId);
                         if (kieContainer != null) {
+                            previous = context.registerContainer(containerId, ci);
                             ci.setKieContainer(kieContainer);
                             ci.getResource().setConfigItems(container.getConfigItems());
                             ci.getResource().setMessages(messages);
@@ -297,24 +304,32 @@ public class KieServerImpl implements KieServer {
                                 }
                             }
 
-                            ci.getResource().setStatus(KieContainerStatus.STARTED);
-                            logger.info("Container {} (for release id {}) successfully started", containerId, releaseId);
-
-                            // store the current state of the server
-                            storeServerState(currentState -> {
-                                container.setStatus(KieContainerStatus.STARTED);
-                                currentState.getContainers().add(container);
-                            });
-
                             // add successful message only when there are no errors
                             if (!messages.stream().filter(m -> m.getSeverity().equals(Severity.ERROR)).findAny().isPresent()) {
                                 messages.add(new Message(Severity.INFO, "Container " + containerId + " successfully created with module " + releaseId + "."));
+
+                                ci.getResource().setStatus(KieContainerStatus.STARTED);
+                                logger.info("Container {} (for release id {}) successfully started", containerId, releaseId);
+
+                                // store the current state of the server
+                                storeServerState(currentState -> {
+                                    container.setStatus(KieContainerStatus.STARTED);
+                                    currentState.getContainers().add(container);
+                                });
                                 eventSupport.fireAfterContainerStarted(this, ci);
 
                                 return new ServiceResponse<KieContainerResource>(ServiceResponse.ResponseType.SUCCESS, "Container " + containerId + " successfully deployed with module " + releaseId + ".", ci.getResource());
                             } else {
                                 ci.getResource().setStatus(KieContainerStatus.FAILED);
                                 ci.getResource().setReleaseId(releaseId);
+
+                                logger.info("Container {} (for release id {}) cannot be deployed", containerId, releaseId);
+
+                                // store the current state of the server
+                                storeServerState(currentState -> {
+                                    container.setStatus(KieContainerStatus.FAILED);
+                                    currentState.getContainers().add(container);
+                                });
                                 return new ServiceResponse<KieContainerResource>(ServiceResponse.ResponseType.FAILURE, "Failed to create container " + containerId + " with module " + releaseId + ".");
                             }
                         } else {
@@ -343,6 +358,10 @@ public class KieServerImpl implements KieServer {
         } finally {
             this.containerMessages.put(containerId, messages);
         }
+    }
+
+    private boolean canBeDeployed(KieContainerInstanceImpl previous) {
+        return previous == null || previous.getStatus().equals(KieContainerStatus.FAILED);
     }
 
     private <T> ServiceResponse<T> validateContainerReleaseAndMode(String preffix, KieContainerResource container) {

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerImplOperationTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/KieServerImplOperationTest.java
@@ -15,30 +15,40 @@
 
 package org.kie.server.services.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import java.io.File;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.drools.compiler.kie.builder.impl.InternalKieScanner;
 import org.drools.core.impl.InternalKieContainer;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieRepository;
 import org.kie.api.builder.KieScanner;
+import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.KieServerEnvironment;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieContainerStatus;
 import org.kie.server.api.model.Message;
 import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.Severity;
 import org.kie.server.services.impl.storage.KieServerState;
 import org.kie.server.services.impl.storage.KieServerStateRepository;
 import org.kie.server.services.impl.storage.file.KieServerStateFileRepository;
+import org.kie.server.services.impl.util.DummyKieServerExtension;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class KieServerImplOperationTest {
 
@@ -49,8 +59,14 @@ public class KieServerImplOperationTest {
     private String origServerId = null;
     private KieServerStateRepository repository;
 
+    private DummyKieServerExtension errorKieServerExtension;
+
+    @Mock
+    private KieServices services;
+
     @Before
     public void setupKieServerImpl() throws Exception {
+        MockitoAnnotations.initMocks(this);
         origServerId = KieServerEnvironment.getServerId();
         System.setProperty("org.kie.server.id", KIE_SERVER_ID);
         KieServerEnvironment.setServerId(KIE_SERVER_ID);
@@ -58,16 +74,21 @@ public class KieServerImplOperationTest {
         FileUtils.deleteDirectory(REPOSITORY_DIR);
         FileUtils.forceMkdir(REPOSITORY_DIR);
         repository = new KieServerStateFileRepository(REPOSITORY_DIR);
-        kieServer = new KieServerImpl(repository) {
+        errorKieServerExtension = new DummyKieServerExtension();
+
+        kieServer = new KieServerImpl(repository, services) {
 
             @Override
             protected Map<String, Object> getContainerParameters(org.kie.api.builder.ReleaseId releaseId, List<Message> messages) {
-                
-                return Collections.emptyMap();
+                Map<String, Object> parameters = new HashMap<String, Object>();
+                parameters.put(KieServerConstants.KIE_SERVER_PARAM_MESSAGES, messages);
+                return parameters;
             }
-            
+
         };
+
         kieServer.init();
+        kieServer.getServerRegistry().registerServerExtension(errorKieServerExtension);
     }
 
     @After
@@ -101,7 +122,7 @@ public class KieServerImplOperationTest {
         Mockito.verify(kieContainerInstance, Mockito.times(1)).stopScanner();
         
     }
-    
+
     @Test
     public void testDisposeContainerWithNoScanner() {
         
@@ -164,5 +185,43 @@ public class KieServerImplOperationTest {
         assertNotNull(container);
         assertEquals(KieContainerStatus.STARTED, container.getStatus());
     }
-    
+
+    @Test
+    public void testDeletionContainer() {
+        String containerId = "test-container";
+        ReleaseId releaseId = new ReleaseId("g", "a", "v");
+        KieContainerResource container = new KieContainerResource("id", releaseId);
+        container.setMessages(Collections.singletonList(new Message(Severity.ERROR, "Compilation failure")));
+
+        InternalKieContainer mockedKieContainer = Mockito.mock(InternalKieContainer.class);
+        KieRepository mockedKieRepository = Mockito.mock(KieRepository.class);
+        Mockito.when(mockedKieContainer.getReleaseId()).thenReturn(new ReleaseId("g", "a", "v"));
+        Mockito.when(mockedKieContainer.getContainerReleaseId()).thenReturn(new ReleaseId("g", "a", "v"));
+        Mockito.when(services.getRepository()).thenReturn(mockedKieRepository);
+
+        MutableBoolean fail = new MutableBoolean(false);
+        Mockito.when(services.newKieContainer(containerId, releaseId)).then(e -> {
+            if (fail.isTrue()) {
+                throw new IllegalStateException("already exists in container");
+            } else {
+                return mockedKieContainer;
+            }
+        });
+        // the first time it throws an error 
+        errorKieServerExtension.addMessage(new Message(Severity.ERROR, "compilation failure"));
+        kieServer.createContainer(containerId, container);
+        Assert.assertTrue(kieServer.getContainerInfo(containerId).getResult().getStatus().equals(KieContainerStatus.FAILED));
+        errorKieServerExtension.clear();
+
+        // now it throws an already exists
+        fail.setTrue();
+        kieServer.createContainer(containerId, container);
+        Assert.assertTrue(kieServer.getContainerInfo(containerId).getResult().getStatus().equals(KieContainerStatus.FAILED));
+
+        // delete
+        kieServer.disposeContainer(containerId);
+        Assert.assertNull(kieServer.getContainerInfo(containerId).getResult());
+        Mockito.verify(mockedKieContainer, Mockito.times(1)).dispose();
+
+    }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/util/DummyKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/util/DummyKieServerExtension.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.services.impl.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.model.Message;
+import org.kie.server.services.api.KieContainerInstance;
+import org.kie.server.services.api.KieServerExtension;
+import org.kie.server.services.api.KieServerRegistry;
+import org.kie.server.services.api.SupportedTransports;
+import org.kie.server.services.impl.KieServerImpl;
+
+
+public class DummyKieServerExtension implements KieServerExtension {
+
+    private List<Message> messages;
+
+    public DummyKieServerExtension() {
+        this.messages = new ArrayList<>();
+    }
+
+    public void clear() {
+        this.messages.clear();
+    }
+
+    public void addMessage(Message message) {
+        this.messages.add(message);
+    }
+
+    @Override
+    public List<Message> healthCheck(boolean report) {
+        return KieServerExtension.super.healthCheck(report);
+    }
+
+    @Override
+    public void updateContainer(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {
+    }
+
+    @Override
+    public boolean isUpdateContainerAllowed(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {
+        return false;
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return true;
+    }
+
+    @Override
+    public boolean isActive() {
+        return true;
+    }
+
+    @Override
+    public void init(KieServerImpl kieServer, KieServerRegistry registry) {
+    }
+
+    @Override
+    public Integer getStartOrder() {
+        return 10;
+    }
+
+    @Override
+    public List<Object> getServices() {
+        return null;
+    }
+
+    @Override
+    public String getImplementedCapability() {
+        return "TEST";
+    }
+
+    @Override
+    public String getExtensionName() {
+        return "TEST";
+    }
+
+    @Override
+    public <T> T getAppComponents(Class<T> serviceType) {
+        return null;
+    }
+
+    @Override
+    public List<Object> getAppComponents(SupportedTransports type) {
+        return null;
+    }
+
+    @Override
+    public void disposeContainer(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {
+    }
+
+    @Override
+    public void destroy(KieServerImpl kieServer, KieServerRegistry registry) {
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Override
+    public void createContainer(String id, KieContainerInstance kieContainerInstance, Map<String, Object> parameters) {
+        ((List) parameters.get(KieServerConstants.KIE_SERVER_PARAM_MESSAGES)).addAll(messages);
+    }
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerExecutor.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerExecutor.java
@@ -15,8 +15,6 @@
  */
 package org.kie.server.integrationtests.shared;
 
-import org.kie.server.api.model.KieServerMode;
-import org.kie.server.integrationtests.shared.basetests.KieServerBaseIntegrationTest;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
@@ -26,7 +24,9 @@ import org.jboss.resteasy.plugins.server.tjws.TJWSEmbeddedJaxrsServer;
 import org.kie.api.KieServices;
 import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.KieServerEnvironment;
+import org.kie.server.api.model.KieServerMode;
 import org.kie.server.integrationtests.config.TestConfig;
+import org.kie.server.integrationtests.shared.basetests.KieServerBaseIntegrationTest;
 import org.kie.server.remote.rest.common.resource.KieServerRestImpl;
 import org.kie.server.services.api.KieServerExtension;
 import org.kie.server.services.api.SupportedTransports;
@@ -39,6 +39,8 @@ public class KieServerExecutor {
     // Need to hold kie server instance because we need to manually handle startup/shutdown behavior defined in
     // context listener org.kie.server.services.Bootstrap. Embedded server doesn't support ServletContextListeners.
     private KieServerImpl kieServer;
+
+    private String serverActivePolicies = "KeepLatestOnly";
 
     private static SimpleDateFormat serverIdSuffixDateFormat = new SimpleDateFormat("yyyy-MM-DD-HHmmss_SSS");
 
@@ -61,6 +63,11 @@ public class KieServerExecutor {
 
         addServerSingletonResources();
     }
+
+    public void setServerActivePolicies(String serverActivePolicies) {
+        this.serverActivePolicies = serverActivePolicies;
+    }
+
     protected void setKieServerProperties(boolean syncWithController) {
         System.setProperty(KieServerConstants.CFG_BYPASS_AUTH_USER, "true");
         System.setProperty(KieServerConstants.CFG_HT_CALLBACK, "custom");
@@ -76,9 +83,10 @@ public class KieServerExecutor {
         System.setProperty(KieServerConstants.KIE_SERVER_MODE, KieServerMode.PRODUCTION.name());
 
         // kie server policy settings
-        System.setProperty(KieServerConstants.KIE_SERVER_ACTIVATE_POLICIES, "KeepLatestOnly");
+        System.setProperty(KieServerConstants.KIE_SERVER_ACTIVATE_POLICIES, serverActivePolicies);
         System.setProperty("policy.klo.interval", "5000");
     }
+
     private void registerKieServerId() {
         if (KieServerEnvironment.getServerId() == null) {
             KieServerEnvironment.setServerId(KieServerBaseIntegrationTest.class.getSimpleName() + "@" + serverIdSuffixDateFormat.format(new Date()));

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/KieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/KieServerBaseIntegrationTest.java
@@ -77,12 +77,17 @@ public abstract class KieServerBaseIntegrationTest {
 
     @BeforeClass
     public static void setupClass() throws Exception {
+        setupClass("KeepLatestOnly");
+    }
+
+    public static void setupClass(String oldServerActivePolicy) throws Exception {
         router = new KieServerRouterExecutor();
         router.startKieRouter();
         if (TestConfig.isLocalServer()) {
             controller = new KieControllerExecutor();
             controller.startKieController();
             server = new KieServerExecutor();
+            server.setServerActivePolicies(oldServerActivePolicy);
             server.startKieServer();
         }
         setupCustomSettingsXml();


### PR DESCRIPTION
the system registers the container even before the container was created causing problem during unregistering (cannot dispose because the container is null in the registered instance so it cannot 
dispose in kieservice container map. The solution is to delay till we have the container active and then
overwrite the container.