### PR TITLE
[JBPM-8931] Form Retrieval not honouring bypass auth user setting

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-client/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/build/revapi-config.json
@@ -44,7 +44,7 @@
       "ignore": [
         {
           "code": "java.method.addedToInterface",
-          "new": "method java.lang.String org.kie.server.client.UIServicesClient::getTaskFormAsUser(java.lang.String, java.lang.String, java.lang.Long, java.lang.String)",
+          "new": "method java.lang.String org.kie.server.client.UIServicesClient::getTaskFormAsUser(java.lang.String, java.lang.Long, java.lang.String, java.lang.String)",
           "package": "org.kie.server.client",
           "classSimpleName": "UIServicesClient",
           "methodName": "getTaskFormAsUser",
@@ -53,7 +53,7 @@
         },
         {
           "code": "java.method.addedToInterface",
-          "new": "method java.lang.String org.kie.server.client.UIServicesClient::getTaskFormByTypeAsUser(java.lang.String, java.lang.String, java.lang.Long, java.lang.String, java.lang.String)",
+          "new": "method java.lang.String org.kie.server.client.UIServicesClient::getTaskFormByTypeAsUser(java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.lang.String)",
           "package": "org.kie.server.client",
           "classSimpleName": "UIServicesClient",
           "methodName": "getTaskFormByTypeAsUser",
@@ -62,7 +62,7 @@
         },
         {
           "code": "java.method.addedToInterface",
-          "new": "method java.lang.String org.kie.server.client.UIServicesClient::getTaskRawFormAsUser(java.lang.String, java.lang.String, java.lang.Long)",
+          "new": "method java.lang.String org.kie.server.client.UIServicesClient::getTaskRawFormAsUser(java.lang.String, java.lang.Long, java.lang.String)",
           "package": "org.kie.server.client",
           "classSimpleName": "UIServicesClient",
           "methodName": "getTaskRawFormAsUser",

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/build/revapi-config.json
@@ -41,7 +41,35 @@
   "ignores": {
     "revapi": {
       "_comment": "Changes between 7.26.0.Final and the current branch. These changes are desired and thus ignored.",
-      "ignore": []
+      "ignore": [
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.lang.String org.kie.server.client.UIServicesClient::getTaskFormAsUser(java.lang.String, java.lang.String, java.lang.Long, java.lang.String)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "UIServicesClient",
+          "methodName": "getTaskFormAsUser",
+          "elementKind": "method",
+          "justification": "JBPM-8931 Make form retrieval to honour bypass auth user setting. Add new method to bypass auth user when getting task form'user'"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.lang.String org.kie.server.client.UIServicesClient::getTaskFormByTypeAsUser(java.lang.String, java.lang.String, java.lang.Long, java.lang.String, java.lang.String)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "UIServicesClient",
+          "methodName": "getTaskFormByTypeAsUser",
+          "elementKind": "method",
+          "justification": "JBPM-8931 Make form retrieval to honour bypass auth user setting. Add new method to bypass auth user when getting task form'user'"
+        },
+        {
+          "code": "java.method.addedToInterface",
+          "new": "method java.lang.String org.kie.server.client.UIServicesClient::getTaskRawFormAsUser(java.lang.String, java.lang.String, java.lang.Long)",
+          "package": "org.kie.server.client",
+          "classSimpleName": "UIServicesClient",
+          "methodName": "getTaskRawFormAsUser",
+          "elementKind": "method",
+          "justification": "JBPM-8931 Make form retrieval to honour bypass auth user setting. Add new method to bypass auth user when getting task form'user'"
+        }
+      ]
     }
   }
 }

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/UIServicesClient.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/UIServicesClient.java
@@ -124,6 +124,41 @@ public interface UIServicesClient {
     String getTaskFormByType(String containerId, Long taskId, String formType);
 
     /**
+     * Returns task form for given task id that belongs to given container as specified user. It returns default form type
+     * which is (FORM - build with form modeler). If there is a need to select the type use #getProcessFormForUserByType
+     * Introduced to allow client to take advantage of bypass auth user connecting to server.
+     * @param userId userId making the request to bypass auth user
+     * @param containerId container identifier where task resides
+     * @param taskId unique task id
+     * @param language language that form should be filtered for
+     * @return  string representation (json or xml depending on client marshaling selection) of the task form
+     */
+    String getTaskFormAsUser(String userId, String containerId, Long taskId, String language);
+
+    /**
+     * Returns task form for given task id that belongs to given container as specified user.
+     * Introduced to allow client to take advantage of bypass auth user connecting to server.
+     * @param userId userId making the request to bypass auth user
+     * @param containerId container identifier where task resides
+     * @param taskId unique task id
+     * @param language language that form should be filtered for
+     * @param formType type of form to be returned (FORM - default (form modeler), FRM - v7 forms, FTL - freemarker template)
+     * @return  string representation (json or xml depending on client marshaling selection) of the task form
+     */
+    String getTaskFormByTypeAsUser(String userId, String containerId, Long taskId, String language, String formType);
+
+    /**
+     * Returns task form for given task id that belongs to given container as specified user as raw content - without filtering values by language.
+     * It returns default form type which is (FORM - build with form modeler). If there is a need to select the type use #getProcessFormByType
+     * Introduced to allow client to take advantage of bypass auth user connecting to server.
+     * @param userId userId making the request to bypass auth user
+     * @param containerId container identifier where task resides
+     * @param taskId unique task id
+     * @return  string representation of the task form without any marshalling
+     */
+    String getTaskRawFormAsUser(String userId, String containerId, Long taskId);
+
+    /**
      * Returns process image (svg) of the given process id that belongs to given container
      * @param containerId container identifier where process resides
      * @param processId  unique process id

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/UIServicesClient.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/UIServicesClient.java
@@ -127,36 +127,36 @@ public interface UIServicesClient {
      * Returns task form for given task id that belongs to given container as specified user. It returns default form type
      * which is (FORM - build with form modeler). If there is a need to select the type use #getProcessFormForUserByType
      * Introduced to allow client to take advantage of bypass auth user connecting to server.
-     * @param userId userId making the request to bypass auth user
      * @param containerId container identifier where task resides
      * @param taskId unique task id
      * @param language language that form should be filtered for
+     * @param userId userId making the request to bypass auth user
      * @return  string representation (json or xml depending on client marshaling selection) of the task form
      */
-    String getTaskFormAsUser(String userId, String containerId, Long taskId, String language);
+    String getTaskFormAsUser(String containerId, Long taskId, String language, String userId);
 
     /**
      * Returns task form for given task id that belongs to given container as specified user.
      * Introduced to allow client to take advantage of bypass auth user connecting to server.
-     * @param userId userId making the request to bypass auth user
      * @param containerId container identifier where task resides
      * @param taskId unique task id
      * @param language language that form should be filtered for
      * @param formType type of form to be returned (FORM - default (form modeler), FRM - v7 forms, FTL - freemarker template)
+     * @param userId userId making the request to bypass auth user
      * @return  string representation (json or xml depending on client marshaling selection) of the task form
      */
-    String getTaskFormByTypeAsUser(String userId, String containerId, Long taskId, String language, String formType);
+    String getTaskFormByTypeAsUser(String containerId, Long taskId, String language, String formType, String userId);
 
     /**
      * Returns task form for given task id that belongs to given container as specified user as raw content - without filtering values by language.
      * It returns default form type which is (FORM - build with form modeler). If there is a need to select the type use #getProcessFormByType
      * Introduced to allow client to take advantage of bypass auth user connecting to server.
-     * @param userId userId making the request to bypass auth user
      * @param containerId container identifier where task resides
      * @param taskId unique task id
+     * @param userId userId making the request to bypass auth user
      * @return  string representation of the task form without any marshalling
      */
-    String getTaskRawFormAsUser(String userId, String containerId, Long taskId);
+    String getTaskRawFormAsUser(String containerId, Long taskId, String userId);
 
     /**
      * Returns process image (svg) of the given process id that belongs to given container

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/UIServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/UIServicesClientImpl.java
@@ -108,27 +108,27 @@ public class UIServicesClientImpl extends AbstractKieServicesClientImpl implemen
     }
 
     @Override
-    public String getTaskFormAsUser(String userId, String containerId, Long taskId, String language) {
-        return getTaskFormByTypeAsUser(userId, containerId, taskId, language, ANY_FORM);
+    public String getTaskFormAsUser(String containerId, Long taskId, String language, String userId) {
+        return getTaskFormByTypeAsUser(containerId, taskId, language, ANY_FORM, userId);
     }
 
     @Override
     public String getTaskFormByType(String containerId, Long taskId, String language, String formType) {
-        return getTaskFormByTypeAsUser("", containerId, taskId, language, formType, true );
+        return getTaskFormByTypeAsUser(containerId, taskId, language, formType, true, null);
     }
 
     @Override
-    public String getTaskFormByTypeAsUser(String userId, String containerId, Long taskId, String language, String formType) {
-        return getTaskFormByTypeAsUser(userId, containerId, taskId, language, formType, true );
+    public String getTaskFormByTypeAsUser(String containerId, Long taskId, String language, String formType, String userId) {
+        return getTaskFormByTypeAsUser(containerId, taskId, language, formType, true, userId);
     }
 
-    private String getTaskFormByTypeAsUser(String userId, String containerId, Long taskId, String language, String formType, boolean marshallContent ) {
+    private String getTaskFormByTypeAsUser(String containerId, Long taskId, String language, String formType, boolean marshallContent, String userId) {
         if( config.isRest() ) {
             Map<String, Object> valuesMap = new HashMap<>();
             valuesMap.put(RestURI.CONTAINER_ID, containerId);
             valuesMap.put(RestURI.TASK_INSTANCE_ID, taskId);
 
-            String userQuery = userId.equals("") ? "" : getUserQueryStr(userId);
+            String userQuery = StringUtils.isEmpty(userId) ? "" : getUserQueryStr(userId);
             StringBuilder params = new StringBuilder(userQuery);
             if (params.length() == 0) {
                 params.append("?");
@@ -151,7 +151,7 @@ public class UIServicesClientImpl extends AbstractKieServicesClientImpl implemen
         } else {
             CommandScript script = new CommandScript(Collections.singletonList(
                     (KieServerCommand) new DescriptorCommand("FormService", "getFormDisplayTask",
-                            new Object[]{containerId, taskId, userId, StringUtils.defaultString(language), !StringUtils.isEmpty(language), formType})));
+                            containerId, taskId, userId, StringUtils.defaultString(language), !StringUtils.isEmpty(language), formType)));
 
             ServiceResponse<String> response = (ServiceResponse<String>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM-UI", containerId).getResponses().get(0);
 
@@ -170,17 +170,17 @@ public class UIServicesClientImpl extends AbstractKieServicesClientImpl implemen
 
     @Override
     public String getTaskFormByType(String containerId, Long taskId, String formType) {
-        return getTaskFormByTypeAsUser("", containerId, taskId, null, formType, true );
+        return getTaskFormByTypeAsUser(containerId, taskId, null, formType, true, null);
     }
 
     @Override
-    public String getTaskRawForm( String containerId, Long taskId ) {
-        return getTaskFormByTypeAsUser("", containerId, taskId, null, ANY_FORM, false );
+    public String getTaskRawForm(String containerId, Long taskId) {
+        return getTaskFormByTypeAsUser(containerId, taskId, null, ANY_FORM, false, null);
     }
 
     @Override
-    public String getTaskRawFormAsUser(String userId, String containerId, Long taskId ) {
-        return getTaskFormByTypeAsUser(userId, containerId, taskId, null, ANY_FORM, false);
+    public String getTaskRawFormAsUser(String containerId, Long taskId, String userId) {
+        return getTaskFormByTypeAsUser(containerId, taskId, null, ANY_FORM, false, userId);
     }
 
     @Override

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/UIServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/UIServicesClientImpl.java
@@ -149,9 +149,11 @@ public class UIServicesClientImpl extends AbstractKieServicesClientImpl implemen
                     build(loadBalancer.getUrl(), FORM_URI + "/" + TASK_FORM_GET_URI, valuesMap) + params.toString());
 
         } else {
-            CommandScript script = new CommandScript( Collections.singletonList(
-                    (KieServerCommand) new DescriptorCommand( "FormService", "getFormDisplayTask", new Object[]{containerId, taskId, StringUtils.defaultString( language ), !StringUtils.isEmpty( language ), formType } )) );
-            ServiceResponse<String> response = (ServiceResponse<String>) executeJmsCommand( script, DescriptorCommand.class.getName(), "BPM-UI", containerId ).getResponses().get(0);
+            CommandScript script = new CommandScript(Collections.singletonList(
+                    (KieServerCommand) new DescriptorCommand("FormService", "getFormDisplayTask",
+                            new Object[]{containerId, taskId, userId, StringUtils.defaultString(language), !StringUtils.isEmpty(language), formType})));
+
+            ServiceResponse<String> response = (ServiceResponse<String>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM-UI", containerId).getResponses().get(0);
 
             throwExceptionOnFailure(response);
             if (shouldReturnWithNullResponse(response)) {

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/UIServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/UIServicesClientImpl.java
@@ -151,7 +151,7 @@ public class UIServicesClientImpl extends AbstractKieServicesClientImpl implemen
         } else {
             CommandScript script = new CommandScript(Collections.singletonList(
                     (KieServerCommand) new DescriptorCommand("FormService", "getFormDisplayTask",
-                            containerId, taskId, userId, StringUtils.defaultString(language), !StringUtils.isEmpty(language), formType)));
+                            new Object[]{containerId, taskId, userId, StringUtils.defaultString(language), !StringUtils.isEmpty(language), formType})));
 
             ServiceResponse<String> response = (ServiceResponse<String>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM-UI", containerId).getResponses().get(0);
 

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/UIServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/UIServicesClientImpl.java
@@ -151,7 +151,8 @@ public class UIServicesClientImpl extends AbstractKieServicesClientImpl implemen
         } else {
             CommandScript script = new CommandScript(Collections.singletonList(
                     (KieServerCommand) new DescriptorCommand("FormService", "getFormDisplayTask",
-                            new Object[]{containerId, taskId, userId, StringUtils.defaultString(language), !StringUtils.isEmpty(language), formType})));
+                            new Object[]{containerId, taskId, StringUtils.defaultString(userId),
+                                StringUtils.defaultString(language), !StringUtils.isEmpty(language), formType})));
 
             ServiceResponse<String> response = (ServiceResponse<String>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM-UI", containerId).getResponses().get(0);
 

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/UIServicesClientTest.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/UIServicesClientTest.java
@@ -21,11 +21,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,7 +43,7 @@ public class UIServicesClientTest extends BaseKieServicesClientTest {
     @Before
     public void createClient() {
 
-        config.setCapabilities(List.of(KieServerConstants.CAPABILITY_BPM_UI));
+        config.setCapabilities(Arrays.asList(KieServerConstants.CAPABILITY_BPM_UI));
 
         uiClient = KieServicesFactory.newKieServicesClient(config).getServicesClient(UIServicesClient.class);
     }

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/UIServicesClientTest.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/UIServicesClientTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.server.client;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.rest.RestURI;
+import static org.kie.server.api.rest.RestURI.CONTAINER_ID;
+import static org.kie.server.api.rest.RestURI.FORM_URI;
+import static org.kie.server.api.rest.RestURI.TASK_FORM_GET_URI;
+import static org.kie.server.api.rest.RestURI.build;
+
+public class UIServicesClientTest extends BaseKieServicesClientTest {
+
+    private final String dummyFormContent = "form content";
+
+    private UIServicesClient uiClient;
+
+    @Before
+    public void createClient() {
+
+        config.setCapabilities(List.of(KieServerConstants.CAPABILITY_BPM_UI));
+
+        uiClient = KieServicesFactory.newKieServicesClient(config).getServicesClient(UIServicesClient.class);
+    }
+
+    @Test
+    public void getTaskFormAsUserWithoutBypassingAuthUser() {
+
+        String userId = "user";
+        String containerId = "test";
+        Long taskId = 1L;
+
+        String queryString = "?type=ANY&marshallContent=true&filter=false";
+
+        Map<String, Object> valuesMap = new HashMap<>();
+        valuesMap.put(CONTAINER_ID, containerId);
+        valuesMap.put(RestURI.TASK_INSTANCE_ID, taskId);
+        String url = build("", FORM_URI + "/" + TASK_FORM_GET_URI, valuesMap) + queryString;
+
+        stubFor(get(urlEqualTo(url))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(dummyFormContent)));
+
+        setBypassAuthUserConfig(Boolean.FALSE);
+        String form = uiClient.getTaskFormAsUser(userId, containerId, taskId, "");
+        assertEquals(dummyFormContent, form);
+
+    }
+
+    @Test
+    public void getTaskFormAsUserBypassingAuthUser() {
+
+        String userId = "user";
+        String containerId = "test";
+        Long taskId = 1L;
+
+        //url with user on queryString
+        String queryString = "?user=" + userId + "&type=ANY&marshallContent=true&filter=false";
+
+        Map<String, Object> valuesMap = new HashMap<>();
+        valuesMap.put(CONTAINER_ID, containerId);
+        valuesMap.put(RestURI.TASK_INSTANCE_ID, taskId);
+        String url = build("", FORM_URI + "/" + TASK_FORM_GET_URI, valuesMap) + queryString;
+
+        stubFor(get(urlEqualTo(url))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(dummyFormContent)));
+
+        setBypassAuthUserConfig(Boolean.TRUE);
+        String form = uiClient.getTaskFormAsUser(userId, containerId, taskId, "");
+        assertEquals(dummyFormContent, form);
+    }
+
+    /**
+     * Uses reflection to set the value of BYPASS_AUTH_USER config on client class
+     * @param newValue 
+     */
+    private void setBypassAuthUserConfig(Boolean newValue) {
+
+        try {
+            Field field = uiClient.getClass().getSuperclass().getDeclaredField("BYPASS_AUTH_USER");
+            field.setAccessible(true);
+            Field modifiersField = Field.class.getDeclaredField("modifiers");
+            modifiersField.setAccessible(true);
+            modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
+            field.set(uiClient, newValue);
+
+            field.setAccessible(true);
+
+        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException ex) {
+            // Tests will misbehave
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/UIServicesClientTest.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/UIServicesClientTest.java
@@ -69,7 +69,7 @@ public class UIServicesClientTest extends BaseKieServicesClientTest {
                         .withBody(dummyFormContent)));
 
         setBypassAuthUserConfig(Boolean.FALSE);
-        String form = uiClient.getTaskFormAsUser(userId, containerId, taskId, "");
+        String form = uiClient.getTaskFormAsUser(containerId, taskId, "", userId);
         assertEquals(dummyFormContent, form);
 
     }
@@ -96,7 +96,7 @@ public class UIServicesClientTest extends BaseKieServicesClientTest {
                         .withBody(dummyFormContent)));
 
         setBypassAuthUserConfig(Boolean.TRUE);
-        String form = uiClient.getTaskFormAsUser(userId, containerId, taskId, "");
+        String form = uiClient.getTaskFormAsUser(containerId, taskId, "", userId);
         assertEquals(dummyFormContent, form);
     }
 

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm-ui/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm-ui/src/build/revapi-config.json
@@ -26,7 +26,18 @@
   "ignores": {
     "revapi": {
       "_comment": "Changes between 7.26.0.Final and the current branch. These changes are desired and thus ignored.",
-      "ignore": []
+      "ignore": [
+        {
+          "code": "java.method.numberOfParametersChanged",
+          "old": "method javax.ws.rs.core.Response org.kie.server.remote.rest.jbpm.ui.FormResource::getTaskForm(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.Long, java.lang.String, boolean, java.lang.String, boolean)",
+          "new": "method javax.ws.rs.core.Response org.kie.server.remote.rest.jbpm.ui.FormResource::getTaskForm(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.Long, java.lang.String, boolean, java.lang.String, boolean, java.lang.String)",
+          "package": "org.kie.server.remote.rest.jbpm.ui",
+          "classSimpleName": "FormResource",
+          "methodName": "getTaskForm",
+          "elementKind": "method",
+          "justification": "JBPM-8931 Make form retrieval to honour bypass auth user setting. getTaskForm accepts a new optional queryParam 'user'"
+        }
+      ]
     }
   }
 }

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm-ui/src/main/java/org/kie/server/remote/rest/jbpm/ui/FormResource.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm-ui/src/main/java/org/kie/server/remote/rest/jbpm/ui/FormResource.java
@@ -155,12 +155,13 @@ public class FormResource {
             @ApiParam(value = "optional language that the form should be found for", required = false) @QueryParam("lang") @DefaultValue("en") String language, 
             @ApiParam(value = "optional filter flag if form should be filtered or returned as is", required = false) @QueryParam("filter") boolean filter,
             @ApiParam(value = "optional type of the form, defaults to ANY so system will find the most current one", required = false) @QueryParam("type") @DefaultValue("ANY") String formType, 
-            @ApiParam(value = "optional marshall content flag if the content should be transformed or not, defaults to true", required = false) @QueryParam("marshallContent") @DefaultValue("true") boolean marshallContent ) {
+            @ApiParam(value = "optional marshall content flag if the content should be transformed or not, defaults to true", required = false) @QueryParam("marshallContent") @DefaultValue("true") boolean marshallContent,
+            @ApiParam(value = "optional user id to be used instead of authenticated user - only when bypass authenticated user is enabled", required = false) @QueryParam("user") String user ) {
 
         Variant variant = getVariant(headers);
         Header conversationIdHeader = buildConversationIdHeader(containerId, context, headers);
         try {
-            String response = formServiceBase.getFormDisplayTask(containerId, taskId, language, filter, formType);
+            String response = formServiceBase.getFormDisplayTask(containerId, taskId, user, language, filter, formType);
             if ( marshallContent ) {
                 response = marshallFormContent( response, formType, variant);
             }

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/java/org/kie/server/services/jbpm/ui/FormServiceBaseTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/java/org/kie/server/services/jbpm/ui/FormServiceBaseTest.java
@@ -1,0 +1,140 @@
+package org.kie.server.services.jbpm.ui;
+
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import org.kie.server.services.jbpm.ui.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.jbpm.kie.services.impl.FormManagerService;
+import org.jbpm.services.api.DefinitionService;
+import org.jbpm.services.api.RuntimeDataService;
+import org.jbpm.services.api.UserTaskService;
+import org.jbpm.services.api.model.ProcessDefinition;
+import org.jbpm.services.task.commands.GetUserTaskCommand;
+import org.jbpm.services.task.impl.model.TaskImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.task.model.TaskData;
+import org.kie.internal.identity.IdentityProvider;
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.model.KieServerConfig;
+import org.kie.server.services.api.ContainerLocator;
+import org.kie.server.services.api.KieServerRegistry;
+import org.kie.server.services.impl.KieServerRegistryImpl;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import static org.mockito.Mockito.mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FormServiceBaseTest {
+
+    private final String dummyForm = "{\"id\": \"30f64834-1fe6-4ffb-ba48-024bc6839d5c\", \"name\": \"form-taskform.frm\", \"fields\": [{\"maxLength\": 100,\"placeHolder\": \"Resultado\",\"id\": \"field_id\",\"name\": \"field\",\"label\": \"Field\",\"code\": \"TextBox\"}]}";
+
+    private String CONTAINER_ID = "test-container";
+    private String PROCESS_ID = "test-processId";
+
+    @Mock
+    KieServerRegistry kieServerRegistry = new KieServerRegistryImpl();
+
+    @Mock
+    DefinitionService definitionService;
+
+    @Mock
+    RuntimeDataService dataService;
+
+    @Mock
+    UserTaskService userTaskService;
+
+    @Mock
+    FormManagerService formManagerService;
+
+    @Mock
+    IdentityProvider identityProvider;
+
+    @Mock
+    KieServerConfig config;
+
+    @Mock
+    TaskImpl task;
+
+    @Mock
+    TaskData taskData;
+
+    @Mock
+    ProcessDefinition processDefinition;
+
+    @Before
+    public void setupMocks() {
+        when(kieServerRegistry.getContainerId(anyString(), any(ContainerLocator.class))).thenReturn(CONTAINER_ID);
+        when(kieServerRegistry.getConfig()).thenReturn(config);
+        when(kieServerRegistry.getIdentityProvider()).thenReturn(identityProvider);
+
+        when(identityProvider.getName()).thenReturn("admin");
+
+        when(userTaskService.execute(any(), any())).thenReturn(task);
+        when(task.getName()).thenReturn("task");
+        when(task.getId()).thenReturn(1L);
+        when(task.getTaskData()).thenReturn(taskData);
+        when(task.getFormName()).thenReturn("form");
+        when(taskData.getProcessId()).thenReturn(PROCESS_ID);
+        when(taskData.getDeploymentId()).thenReturn(CONTAINER_ID);
+
+        when(dataService.getProcessesByDeploymentIdProcessId(eq(CONTAINER_ID), eq(PROCESS_ID))).thenReturn(processDefinition);
+        when(processDefinition.getName()).thenReturn("test");
+        when(formManagerService.getFormByKey(eq(CONTAINER_ID), eq("form-taskform.frm"))).thenReturn(dummyForm);
+    }
+
+    @Test
+    public void testGetFormDisplayTaskUsesRequestorIdentity() {
+        when(config.getConfigItemValue(eq(KieServerConstants.CFG_BYPASS_AUTH_USER), anyString())).thenReturn("false");
+
+        FormServiceBase formServiceBase = new FormServiceBase(definitionService, dataService, userTaskService, formManagerService, kieServerRegistry);
+
+        String userId = "john";
+        formServiceBase.getFormDisplayTask(CONTAINER_ID, 1L, userId, "en_US", true, FormServiceBase.FormType.ANY.getName());
+
+        verify(kieServerRegistry, times(1)).getIdentityProvider();
+
+        ArgumentCaptor<GetUserTaskCommand> argument = ArgumentCaptor.forClass(GetUserTaskCommand.class);
+        verify(userTaskService, times(1)).execute(eq(CONTAINER_ID), argument.capture());
+        Assert.assertEquals("admin", argument.getValue().getUserId());
+    }
+
+    @Test
+    public void testGetFormDisplayTaskBypassesAuthUser() {
+        // Set configuration to allow bypass Auth User
+        when(config.getConfigItemValue(eq(KieServerConstants.CFG_BYPASS_AUTH_USER), anyString())).thenReturn("true");
+
+        FormServiceBase formServiceBase = new FormServiceBase(definitionService, dataService, userTaskService, formManagerService, kieServerRegistry);
+
+        String userId = "john";
+        formServiceBase.getFormDisplayTask(CONTAINER_ID, 1L, userId, "en_US", true, FormServiceBase.FormType.ANY.getName());
+
+        verify(kieServerRegistry, times(0)).getIdentityProvider();
+
+        ArgumentCaptor<GetUserTaskCommand> argument = ArgumentCaptor.forClass(GetUserTaskCommand.class);
+        verify(userTaskService, times(1)).execute(eq(CONTAINER_ID), argument.capture());
+        Assert.assertEquals("john", argument.getValue().getUserId());
+    }
+
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/java/org/kie/server/services/jbpm/ui/FormServiceBaseTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/java/org/kie/server/services/jbpm/ui/FormServiceBaseTest.java
@@ -1,5 +1,3 @@
-package org.kie.server.services.jbpm.ui;
-
 /*
  * Copyright 2019 Red Hat, Inc. and/or its affiliates.
  *
@@ -14,7 +12,8 @@ package org.kie.server.services.jbpm.ui;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.kie.server.services.jbpm.ui.*;
+package org.kie.server.services.jbpm.ui;
+
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -42,7 +41,6 @@ import org.kie.server.services.api.KieServerRegistry;
 import org.kie.server.services.impl.KieServerRegistryImpl;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import static org.mockito.Mockito.mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -50,8 +48,8 @@ public class FormServiceBaseTest {
 
     private final String dummyForm = "{\"id\": \"30f64834-1fe6-4ffb-ba48-024bc6839d5c\", \"name\": \"form-taskform.frm\", \"fields\": [{\"maxLength\": 100,\"placeHolder\": \"Resultado\",\"id\": \"field_id\",\"name\": \"field\",\"label\": \"Field\",\"code\": \"TextBox\"}]}";
 
-    private String CONTAINER_ID = "test-container";
-    private String PROCESS_ID = "test-processId";
+    private final String CONTAINER_ID = "test-container";
+    private final String PROCESS_ID = "test-processId";
 
     @Mock
     KieServerRegistry kieServerRegistry = new KieServerRegistryImpl();


### PR DESCRIPTION
When using bypass auth user, FormService now can use the "user" query parameter to check permissions to see task instead of using the authenticated user.