### PR TITLE
PLANNER-1739: Quick fix for OptaPlanner test broken by PLANNER-241

### DIFF
--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/planner/PlannerCloudBalanceIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/planner/PlannerCloudBalanceIntegrationTest.java
@@ -64,7 +64,7 @@ public class PlannerCloudBalanceIntegrationTest extends AbstractKarafIntegration
 
     @Test(expected=IllegalStateException.class)
     public void invalidSolutionPlannerTest() {
-        solveSolution(cloudBalanceGeneratorForFuse(0, 0, 0));
+        solveSolution(cloudBalanceGeneratorForFuse(0, 1, 0));
     }
 
     @Test


### PR DESCRIPTION
OptaPlanner no longer throws exception if the entity collection is empty. That caused the test to fail because no exception was thrown. But it still throws exception if the value provider returns an empty collection. We can exploit this behavior to keep the negative test.

I personally don't see much value in this test but it is possible that it covers exception propagation in the Fuse environment. Jiri is on a leave this week so we cannot ask him so I'm proposing a fix that keeps the test in place and makes it pass. We can discuss with Jiri and decide to remove the test later.