### PR TITLE
[DROOLS-4872] "customSerializationMapper" in JSONMarshaller.configure…

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
@@ -284,6 +284,7 @@ public class JSONMarshaller implements Marshaller {
         // Extend the marshaller with optional extensions
         for (JSONMarshallerExtension extension : EXTENSIONS) {
             extension.extend(this, objectMapper, deserializeObjectMapper);
+            extension.extend(this, customSerializationMapper, customSerializationMapper);
         }
     }
 

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/json/extension/JSONMarshallerExtensionCustomPerson.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/json/extension/JSONMarshallerExtensionCustomPerson.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.api.marshalling.json.extension;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import org.kie.server.api.marshalling.json.JSONMarshaller;
+import org.kie.server.api.marshalling.json.JSONMarshallerExtension;
+import org.kie.server.api.marshalling.objects.CustomPerson;
+
+public class JSONMarshallerExtensionCustomPerson implements JSONMarshallerExtension {
+
+    private static final CustomPersonDeser DESERIALIZER = new CustomPersonDeser();
+    private static final CustomPersonSer SERIALIZER = new CustomPersonSer();
+
+    @Override
+    public void extend(JSONMarshaller marshaller, ObjectMapper serializer, ObjectMapper deserializer) {
+        registerModule(serializer);
+        registerModule(deserializer);
+    }
+
+    private void registerModule(ObjectMapper objectMapper) {
+        SimpleModule CustomPersonModule = new SimpleModule("custom-person-module", Version.unknownVersion());
+        CustomPersonModule.addDeserializer(CustomPerson.class, DESERIALIZER);
+        CustomPersonModule.addSerializer(CustomPerson.class, SERIALIZER);
+        objectMapper.registerModule(CustomPersonModule);
+    }
+
+    private static class CustomPersonDeser extends JsonDeserializer<CustomPerson> {
+
+        @Override
+        public CustomPerson deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+            // Regardless of the payload, create a CustomPerson with age=50
+            CustomPerson customPerson = new CustomPerson("John", 50);
+            return customPerson;
+        }
+    }
+
+    private static class CustomPersonSer extends JsonSerializer<CustomPerson> {
+
+        @Override
+        public void serialize(CustomPerson value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
+            // Regardless of the Object, write a constant String
+            jgen.writeRaw("{ \"name\" : \"John is CustomPerson\",  \"age\" : 20 }");
+        }
+    }
+}

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/CustomPerson.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/CustomPerson.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.api.marshalling.objects;
+
+import org.kie.api.remote.Remotable;
+
+@Remotable
+public class CustomPerson {
+
+    private String name;
+    private int age;
+
+    public CustomPerson() {}
+
+    public CustomPerson(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + age;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        CustomPerson other = (CustomPerson) obj;
+        if (age != other.age) {
+            return false;
+        }
+        if (name == null) {
+            if (other.name != null) {
+                return false;
+            }
+        } else if (!name.equals(other.name)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "CustomPerson [name=" + name + ", age=" + age + "]";
+    }
+
+}

--- a/kie-server-parent/kie-server-api/src/test/resources/META-INF/services/org.kie.server.api.marshalling.json.JSONMarshallerExtension
+++ b/kie-server-parent/kie-server-api/src/test/resources/META-INF/services/org.kie.server.api.marshalling.json.JSONMarshallerExtension
@@ -1,3 +1,4 @@
 org.kie.server.api.marshalling.json.extension.JSONMarshallerExtensionGregorianCalendar
 org.kie.server.api.marshalling.json.JSONMarshallerPMMLRequest
 org.kie.server.api.marshalling.json.JSONMarshallerPMMLParamInfo
+org.kie.server.api.marshalling.json.extension.JSONMarshallerExtensionCustomPerson


### PR DESCRIPTION
…Marshaller() doesn't respect JSONMarshallerExtensions

Regarding a unit test, I cannot reuse JSONMarshallerExtensionGregorianCalendar because I wanted to test a structured class. The implementation of JSONMarshallerExtensionCustomPerson is a bit stupid but I just make sure to test if serializer/deserializer are called.
