### PR TITLE
PLANNER-1745: Eliminate deprecated OptaPlanner API, clean up test

### DIFF
--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/planner/domain/CloudBalance.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/planner/domain/CloudBalance.java
@@ -16,32 +16,31 @@
 
 package org.kie.karaf.itest.planner.domain;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamConverter;
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
+import org.optaplanner.core.api.domain.solution.PlanningScore;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
-import org.optaplanner.core.api.domain.solution.Solution;
+import org.optaplanner.core.api.domain.solution.drools.ProblemFactCollectionProperty;
 import org.optaplanner.core.api.domain.valuerange.ValueRangeProvider;
 import org.optaplanner.core.api.score.buildin.hardsoft.HardSoftScore;
-import org.optaplanner.core.impl.score.buildin.hardsoft.HardSoftScoreDefinition;
 import org.optaplanner.persistence.xstream.api.score.buildin.hardsoft.HardSoftScoreXStreamConverter;
 
 @PlanningSolution
 @XStreamAlias("CloudBalance")
-public class CloudBalance implements Solution<HardSoftScore> {
+public class CloudBalance {
 
     private List<CloudComputer> computerList;
 
     private List<CloudProcess> processList;
 
-    @XStreamConverter(value = HardSoftScoreXStreamConverter.class, types = {HardSoftScoreDefinition.class})
+    @XStreamConverter(HardSoftScoreXStreamConverter.class)
     private HardSoftScore score;
 
     @ValueRangeProvider(id = "computerRange")
+    @ProblemFactCollectionProperty
     public List<CloudComputer> getComputerList() {
         return computerList;
     }
@@ -59,18 +58,12 @@ public class CloudBalance implements Solution<HardSoftScore> {
         this.processList = processList;
     }
 
+    @PlanningScore
     public HardSoftScore getScore() {
         return score;
     }
 
     public void setScore(HardSoftScore score) {
         this.score = score;
-    }
-
-    public Collection<? extends Object> getProblemFacts() {
-        List<Object> facts = new ArrayList<Object>();
-        facts.addAll(computerList);
-        // Do not add the planning entity's (processList) because that will be done automatically
-        return facts;
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/PLANNER-1745

Follows up on #1957.

- Removed negative test that has little value and would break soon again.
- Removed deprecated API.
- Using fluent config API.
- Removed raw type usage, plus other cleanup.