### PR TITLE
Revert "update to latest ecj (#1967)"

### DIFF
--- a/kie-osgi/kie-karaf-features/pom.xml
+++ b/kie-osgi/kie-karaf-features/pom.xml
@@ -29,7 +29,7 @@
     <karaf.version.org.jboss.weld>${version.org.jboss.weld.weld}</karaf.version.org.jboss.weld>
     <karaf.version.org.mvel>${version.org.mvel}</karaf.version.org.mvel>
     <karaf.version.javax.enterprise.cdi>${version.javax.enterprise}</karaf.version.javax.enterprise.cdi>
-    <karaf.version.org.eclipse.jdt>${version.org.eclipse.jdt}</karaf.version.org.eclipse.jdt>
+    <karaf.version.org.eclipse.jdt.core.compiler>${version.org.eclipse.jdt.core.compiler}</karaf.version.org.eclipse.jdt.core.compiler>
 
     <!-- used by jbpm-commons -->
     <karaf.version.org.jboss.spec.javax.security.jacc>1.0.0.Final</karaf.version.org.jboss.spec.javax.security.jacc>
@@ -640,7 +640,7 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jdt</groupId>
+      <groupId>org.eclipse.jdt.core.compiler</groupId>
       <artifactId>ecj</artifactId>
       <scope>provided</scope>
     </dependency>

--- a/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features.xml
+++ b/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features.xml
@@ -15,7 +15,7 @@
     <bundle start-level='10'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-xjc/${karaf.servicemix.version.com.sun.xml.bind.jaxb}</bundle>
     <bundle start-level='10'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/${karaf.servicemix.version.com.sun.xml.bind.jaxb}</bundle>
     <bundle>mvn:org.mvel/mvel2/${version.org.mvel}</bundle>
-    <bundle>wrap:mvn:org.eclipse.jdt/ecj/${karaf.version.org.eclipse.jdt}$Bundle-SymbolicName=Eclipse-JDT-Compiler&amp;Bundle-Version=${karaf.version.org.eclipse.jdt}</bundle>
+    <bundle>wrap:mvn:org.eclipse.jdt.core.compiler/ecj/${karaf.version.org.eclipse.jdt.core.compiler}$Bundle-SymbolicName=Eclipse-JDT-Compiler&amp;Bundle-Version=${karaf.version.org.eclipse.jdt.core.compiler}</bundle>
     <bundle>wrap:mvn:org.codehaus.janino/janino/${karaf.version.org.codehaus.janino}$Bundle-SymbolicName=Codehaus-Janino&amp;Bundle-Version=${karaf.version.org.codehaus.janino}</bundle>
     <bundle>mvn:org.apache.geronimo.specs/geronimo-atinject_1.0_spec/${karaf.version.javax.inject}</bundle>
     <bundle>wrap:mvn:javax.enterprise/cdi-api/${karaf.version.javax.enterprise.cdi}</bundle>

--- a/kie-spring/pom.xml
+++ b/kie-spring/pom.xml
@@ -255,7 +255,7 @@
 
     <!-- test -->
     <dependency>
-      <groupId>org.eclipse.jdt</groupId>
+      <groupId>org.eclipse.jdt.core.compiler</groupId>
       <artifactId>ecj</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
This reverts commit 6593a05c86bab0c64f102c4532cfa8fc4e51c651.

Merge together with:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1148
- https://github.com/kiegroup/drools/pull/2699
- https://github.com/kiegroup/droolsjbpm-integration/pull/1973