### PR TITLE
PLANNER-1317: Fix parent of optaplanner-workbench-models

### DIFF
--- a/optaplanner-workbench-models/pom.xml
+++ b/optaplanner-workbench-models/pom.xml
@@ -4,11 +4,12 @@
 
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.optaplanner</groupId>
-    <artifactId>optaplanner-integration</artifactId>
+    <groupId>org.drools</groupId>
+    <artifactId>droolsjbpm-integration</artifactId>
     <version>7.32.0-SNAPSHOT</version>
   </parent>
 
+  <groupId>org.optaplanner</groupId>
   <artifactId>optaplanner-workbench-models</artifactId>
   <packaging>pom</packaging>
 


### PR DESCRIPTION
Fixes build order so that `optaplanner-workbench-models-datamodel-api` is built before `kie-maven-plugin`.