### PR TITLE
Supply valid EAP URL parameter for Cargo

### DIFF
--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -71,7 +71,7 @@
          and for free (e.g. from http://jbossas.jboss.org/downloads.html) and the zip location needs to be specified
          here or via system property when running the build (don't forget to use the `file://` prefix when
          referencing the zip from local filesystem). -->
-    <eap7.download.url>valid-url-for-eap-7-needs-to-be-specified-here-or-via-cmd-line</eap7.download.url>
+    <eap7.download.url>http://valid-url-for-eap-7-needs-to-be-specified-here-or-via-cmd-line.com</eap7.download.url>
 
     <!-- Integration tests and Cargo are skipped by default. They are activated when specific container profile is used. -->
     <skipITs>true</skipITs>


### PR DESCRIPTION
Allows running Kie server on EAP7 with custom-container profile activated.

@MarianMacik Please review.