### PR TITLE
JBPM-8974 Added swagger /docs url-pattern to web.xml

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-standalone/src/main/ee7-resources/WEB-INF/web.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-standalone/src/main/ee7-resources/WEB-INF/web.xml
@@ -18,6 +18,7 @@
     <web-resource-collection>
       <web-resource-name>Swagger web resources</web-resource-name>
       <url-pattern>/rest/swagger.json</url-pattern>
+      <url-pattern>/docs/*</url-pattern>
       <http-method>GET</http-method>
     </web-resource-collection>
     <!-- No authentication. Swagger resources should be accessible without authentication. -->

--- a/kie-server-parent/kie-server-controller/kie-server-controller-standalone/src/main/webc-resources/WEB-INF/web.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-standalone/src/main/webc-resources/WEB-INF/web.xml
@@ -30,6 +30,7 @@
     <web-resource-collection>
       <web-resource-name>Swagger web resources</web-resource-name>
       <url-pattern>/rest/swagger.json</url-pattern>
+      <url-pattern>/docs/*</url-pattern>
       <http-method>GET</http-method>
     </web-resource-collection>
     <!-- No authentication. Swagger resources should be accessible without authentication. -->


### PR DESCRIPTION
Adding "/docs/*" url-pattern to web.xml to enabling access to swagger docs URL for jbpm controller.

Please review if it's a feasible approach.