### PR TITLE
BXMSPROD-598 filterWebInfLib property added to thorntail maven plugin

### DIFF
--- a/process-migration-service/pom.xml
+++ b/process-migration-service/pom.xml
@@ -263,6 +263,9 @@
         <groupId>io.thorntail</groupId>
         <artifactId>thorntail-maven-plugin</artifactId>
         <version>${version.thorntail}</version>
+        <configuration>
+          <filterWebInfLib>uberjar-only</filterWebInfLib>
+        </configuration>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
BXMSPROD-598
It depends on https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1156
filterWebInfLib property added with the value 'uberjar-only' to thorntail maven plugin to the business-monitoring-webapp and business-central-webapp