### PR TITLE
[JBPM-8974] Fix Swagger docs test for working at WAS also

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-standalone/src/main/ee7-resources/WEB-INF/web.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-standalone/src/main/ee7-resources/WEB-INF/web.xml
@@ -17,7 +17,7 @@
   <security-constraint>
     <web-resource-collection>
       <web-resource-name>Swagger web resources</web-resource-name>
-      <url-pattern>/rest/swagger.json</url-pattern>
+      <url-pattern>/rest/swagger.json/*</url-pattern>
       <url-pattern>/docs/*</url-pattern>
       <http-method>GET</http-method>
     </web-resource-collection>


### PR DESCRIPTION
This test was failing at Websphere due to parent path navigation provoked HTTP 404 response.
Let's fix it creating the URL ad-hoc.