### PR TITLE
DROOLS-5020 DMN wire Validator to kie-maven-plugin Maven build

### DIFF
--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -199,6 +199,10 @@
     </dependency>
     <dependency>
       <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-validation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
       <artifactId>kie-dmn-api</artifactId>
     </dependency>
     <dependency>

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/DMNModelMode.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/DMNModelMode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package org.kie.maven.plugin;
 
 import static java.util.Arrays.asList;

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/ExecModelMode.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/ExecModelMode.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package org.kie.maven.plugin;
 
 import java.util.List;

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateDMNModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateDMNModelMojo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package org.kie.maven.plugin;
 
 import java.io.File;

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package org.kie.maven.plugin;
 
 import java.io.File;

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/ProjectPomModel.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/ProjectPomModel.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package org.kie.maven.plugin;
 
 import java.util.Collection;

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/ValidateDMNMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/ValidateDMNMojo.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.maven.plugin;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.maven.model.Resource;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.drools.compiler.kproject.models.KieModuleModelImpl;
+import org.kie.api.builder.Message.Level;
+import org.kie.api.builder.model.KieModuleModel;
+import org.kie.dmn.api.core.DMNMessage;
+import org.kie.dmn.core.assembler.DMNAssemblerService;
+import org.kie.dmn.core.compiler.DMNProfile;
+import org.kie.dmn.feel.util.ClassLoaderUtil;
+import org.kie.dmn.model.api.DMNModelInstrumentedBase;
+import org.kie.dmn.model.api.Definitions;
+import org.kie.dmn.validation.DMNValidator;
+import org.kie.dmn.validation.DMNValidator.Validation;
+import org.kie.dmn.validation.DMNValidatorFactory;
+import org.kie.internal.utils.ChainedProperties;
+
+@Mojo(name = "validateDMN",
+      requiresDependencyResolution = ResolutionScope.NONE,
+      requiresProject = true,
+      defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
+public class ValidateDMNMojo extends AbstractKieMojo {
+
+    @Parameter(required = true, defaultValue = "${project.build.resources}")
+    private List<Resource> resources;
+
+    @Parameter
+    private Map<String, String> properties;
+
+    @Parameter(required = true, defaultValue = "${project}")
+    private MavenProject project;
+
+    @Parameter(property = "validateDMN", defaultValue = "VALIDATE_SCHEMA,VALIDATE_MODEL")
+    private String validateDMN;
+    private List<Validation> actualFlags = new ArrayList<>();
+
+    private DMNValidator validator;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        try {
+            for (String p : validateDMN.split(",")) {
+                actualFlags.add(Validation.valueOf(p));
+            }
+        } catch (IllegalArgumentException e) {
+            // do nothing.
+        }
+        // for this phase, keep only the following flags (the rest requires the BuildMojo).
+        actualFlags.retainAll(Arrays.asList(Validation.VALIDATE_SCHEMA, Validation.VALIDATE_MODEL));
+        if (actualFlags.isEmpty()) {
+            getLog().info("No VALIDATE_SCHEMA or VALIDATE_MODEL flags set, skipping.");
+            return;
+        }
+
+        List<Path> resourcesPaths = resources.stream().map(r -> new File(r.getDirectory()).toPath()).collect(Collectors.toList());
+        List<Path> dmnModelPaths = new ArrayList<>();
+        for (Path p : resourcesPaths) {
+            getLog().info("Looking for DMN models in path: " + p);
+            try (Stream<Path> walk = Files.walk(p)) {
+                walk.filter(f -> f.toString().endsWith(".dmn"))
+                    .forEach(dmnModelPaths::add);
+            } catch (Exception e) {
+                throw new MojoExecutionException("Failed executing ValidateDMNMojo", e);
+            }
+        }
+
+        if (dmnModelPaths.isEmpty()) {
+            getLog().info("No DMN Models found.");
+            return;
+        }
+
+        getLog().info("Initializing DMNValidator...");
+        ClassLoader classLoader = ClassLoaderUtil.findDefaultClassLoader();
+        ChainedProperties chainedProperties = ChainedProperties.getChainedProperties(classLoader);
+        List<KieModuleModel> kieModules = new ArrayList<>();
+        for (Path p : resourcesPaths) {
+            try (Stream<Path> walk = Files.walk(p)) {
+                List<Path> collect = walk.filter(f -> f.toString().endsWith("kmodule.xml")).collect(Collectors.toList());
+                for (Path k : collect) {
+                    kieModules.add(KieModuleModelImpl.fromXML(k.toFile()));
+                }
+            } catch (Exception e) {
+                throw new MojoExecutionException("Failed executing ValidateDMNMojo", e);
+            }
+        }
+        for (KieModuleModel kmm : kieModules) {
+            Properties ps = new Properties();
+            ps.putAll(kmm.getConfigurationProperties());
+            chainedProperties.addProperties(ps);
+        }
+        List<DMNProfile> dmnProfiles = new ArrayList<>();
+        dmnProfiles.addAll(DMNAssemblerService.getDefaultDMNProfiles(chainedProperties));
+        try {
+            Map<String, String> dmnProfileProperties = new HashMap<>();
+            chainedProperties.mapStartsWith(dmnProfileProperties, DMNAssemblerService.DMN_PROFILE_PREFIX, false);
+            for (Map.Entry<String, String> dmnProfileProperty : dmnProfileProperties.entrySet()) {
+                DMNProfile dmnProfile = (DMNProfile) classLoader.loadClass(dmnProfileProperty.getValue()).newInstance();
+                dmnProfiles.add(dmnProfile);
+            }
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            throw new MojoExecutionException("Failed DMNValidator initialization.", e);
+        }
+        validator = DMNValidatorFactory.newValidator(dmnProfiles);
+        getLog().info("DMNValidator initialized.");
+
+        dmnModelPaths.forEach(x -> getLog().info("Will validate DMN model: " + x.toString()));
+        List<DMNMessage> validation = validator.validateUsing(actualFlags.toArray(new Validation[]{}))
+                                               .theseModels(dmnModelPaths.stream().map(Path::toFile).collect(Collectors.toList()).toArray(new File[]{}));
+        for (DMNMessage msg : validation) {
+            Consumer<CharSequence> logFn = null;
+            switch (msg.getLevel()) {
+                case ERROR:
+                    logFn = getLog()::error;
+                    break;
+                case WARNING:
+                    logFn = getLog()::warn;
+                    break;
+                case INFO:
+                default:
+                    logFn = getLog()::info;
+                    break;
+            }
+            StringBuilder sb = new StringBuilder();
+            if (msg.getSourceReference() instanceof DMNModelInstrumentedBase) {
+                DMNModelInstrumentedBase ib = (DMNModelInstrumentedBase) msg.getSourceReference();
+                while (ib.getParent() != null) {
+                    ib = ib.getParent();
+                }
+                if (ib instanceof Definitions) {
+                    sb.append(((Definitions) ib).getName() + ": ");
+                }
+            }
+            sb.append(msg.getText());
+            logFn.accept(sb.toString());
+        }
+        if (validation.stream().anyMatch(m -> m.getLevel() == Level.ERROR)) {
+            throw new MojoFailureException("There are DMN Validation Error(s).");
+        }
+    }
+}
+

--- a/kie-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/kie-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -8,7 +8,7 @@
             <implementation>org.apache.maven.lifecycle.mapping.DefaultLifecycleMapping</implementation>
             <configuration>
                 <phases>
-                    <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources</process-resources>
+                    <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources,org.kie:kie-maven-plugin:validateDMN</process-resources>
                     <compile>org.apache.maven.plugins:maven-compiler-plugin:compile,org.kie:kie-maven-plugin:generateModel,org.kie:kie-maven-plugin:generateDMNModel,org.apache.maven.plugins:maven-compiler-plugin:compile,org.kie:kie-maven-plugin:build</compile>
                     <!-- proces-classes does not have a default plug-in binding for JAR/KJAR, accordingly to https://maven.apache.org/ref/3-LATEST/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging
                          so can directly declare the inject reactive bytecode goal -->

--- a/kie-maven-plugin/src/test/java/org/kie/maven/plugin/ValidateDMNMojoFlagsTest.java
+++ b/kie-maven-plugin/src/test/java/org/kie/maven/plugin/ValidateDMNMojoFlagsTest.java
@@ -1,0 +1,48 @@
+package org.kie.maven.plugin;
+
+import java.util.List;
+
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.validation.DMNValidator.Validation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ValidateDMNMojoFlagsTest {
+
+    public static final Logger LOG = LoggerFactory.getLogger(ValidateDMNMojoFlagsTest.class);
+
+    private ValidateDMNMojo mojo;
+
+    @Before
+    public void init() {
+        mojo = new ValidateDMNMojo();
+        mojo.setLog(new SystemStreamLog());
+    }
+
+    @Test
+    public void testFlagsOK() {
+        List<Validation> result = mojo.computeFlagsFromCSVString("VALIDATE_SCHEMA,VALIDATE_MODEL");
+        assertThat(result).isNotNull()
+                          .hasSize(2)
+                          .contains(Validation.VALIDATE_SCHEMA, Validation.VALIDATE_MODEL);
+    }
+
+    @Test
+    public void testFlagsDisable() {
+        List<Validation> result = mojo.computeFlagsFromCSVString("disabled");
+        assertThat(result).isNotNull()
+                          .hasSize(0);
+    }
+
+    @Test
+    public void testFlagsUnknown() {
+        List<Validation> result = mojo.computeFlagsFromCSVString("VALIDATE_SCHEMA,boh");
+        assertThat(result).isNotNull()
+                          .hasSize(0);
+    }
+
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/decision-services/src/main/resources/ImportDecisionService20180718.dmn
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/decision-services/src/main/resources/ImportDecisionService20180718.dmn
@@ -1,67 +1,64 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<dmn11:definitions xmlns="http://www.trisotech.com/dmn/definitions/_0ff3708a-c861-4a96-b85c-7b882f18b7a1" xmlns:feel="http://www.omg.org/spec/FEEL/20140401" xmlns:include1="http://www.trisotech.com/dmn/definitions/_6eef3a7c-bb0d-40bb-858d-f9067789c18a" xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:trisofeed="http://trisotech.com/feed" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" exporter="DMN Modeler" exporterVersion="6.1.2" id="_0ff3708a-c861-4a96-b85c-7b882f18b7a1" name="Import Decision Service 20180718" namespace="http://www.trisotech.com/dmn/definitions/_0ff3708a-c861-4a96-b85c-7b882f18b7a1" triso:logoChoice="Default" xmlns:dmn11="http://www.omg.org/spec/DMN/20151101/dmn.xsd">
-  <dmn11:extensionElements>
-    <drools:decisionServices xmlns:drools="http://www.drools.org/kie/dmn/1.1">
-      <dmn11:decisionService id="_41e62189-d469-456c-ab1b-a23180e1b05a" name="Import L1 DS">
-        <dmn11:outputDecision href="#_ea2ccf66-6ede-4365-b0f1-1000216241af"/>
-        <dmn11:encapsulatedDecision href="#_d85b923e-b757-41f4-9bec-b47a2887c5d5"/>
-        <dmn11:encapsulatedDecision href="#_40256338-f153-468e-a8dd-05342a8674b4"/>
-        <dmn11:inputData href="#_48d1a207-aabf-469a-a481-8f255b762cf5"/>
-      </dmn11:decisionService>
-    </drools:decisionServices>
-  </dmn11:extensionElements>
-  <dmn11:import xmlns:drools="http://www.drools.org/kie/dmn/1.1" drools:modelName="Decision Service 20180718" drools:name="import1" importType="http://www.omg.org/spec/DMN/20180521/MODEL/" namespace="http://www.trisotech.com/dmn/definitions/_6eef3a7c-bb0d-40bb-858d-f9067789c18a" triso:fileId="eyJmIjp7InNrdSI6IjBkN2Q0NzdmLTVlNDQtNGI1ZS1iNmZlLTIxZjVmM2FlZGE5NCIsIm5hbWUiOiJEZWNpc2lvbiBTZXJ2aWNlIDIwMTgwNzE4In19" triso:fileName="Matteo Mortari/Decision Service 20180718"/>
-  <dmn11:decision id="_d85b923e-b757-41f4-9bec-b47a2887c5d5" name="invoke imported DS">
-    <dmn11:variable id="_adf487ac-5576-4b7b-9cd4-61b95a66c1ad" name="invoke imported DS"/>
-    <dmn11:informationRequirement>
-      <dmn11:requiredInput href="#_48d1a207-aabf-469a-a481-8f255b762cf5"/>
-    </dmn11:informationRequirement>
-    <dmn11:knowledgeRequirement>
-      <dmn11:requiredKnowledge href="http://www.trisotech.com/dmn/definitions/_6eef3a7c-bb0d-40bb-858d-f9067789c18a#_cf49add9-84a4-40ac-8306-1eea599ff43c"/>
-    </dmn11:knowledgeRequirement>
-    <dmn11:invocation id="_bbe48e01-6b02-4fe7-ab9f-6f00e1b6c286">
-      <dmn11:literalExpression id="literal__bbe48e01-6b02-4fe7-ab9f-6f00e1b6c286">
-        <dmn11:text>import1.DS given inputdata</dmn11:text>
-      </dmn11:literalExpression>
-      <dmn11:binding>
-        <dmn11:parameter id="_41c6511b-4ad8-428b-8151-69d0faa3633e" name="Person name"/>
-        <dmn11:literalExpression id="_7f0c4bac-36d9-4cbd-aa94-b7c803e38e42">
-          <dmn11:text>L1 person name</dmn11:text>
-        </dmn11:literalExpression>
-      </dmn11:binding>
-      <dmn11:binding>
-        <dmn11:parameter id="_49ebab71-c36e-4637-a66c-d3346d63935a" name="Person age"/>
-        <dmn11:literalExpression id="_efc44fbc-e1c4-4337-8475-083feae34229">
-          <dmn11:text>47</dmn11:text>
-        </dmn11:literalExpression>
-      </dmn11:binding>
-    </dmn11:invocation>
-  </dmn11:decision>
-  <dmn11:decision id="_ea2ccf66-6ede-4365-b0f1-1000216241af" name="final Import L1 decision">
-    <dmn11:variable id="_ec8c4501-ac42-441b-b4e2-063264696401" name="final Import L1 decision"/>
-    <dmn11:informationRequirement>
-      <dmn11:requiredDecision href="#_d85b923e-b757-41f4-9bec-b47a2887c5d5"/>
-    </dmn11:informationRequirement>
-    <dmn11:informationRequirement>
-      <dmn11:requiredDecision href="#_40256338-f153-468e-a8dd-05342a8674b4"/>
-    </dmn11:informationRequirement>
-    <dmn11:literalExpression id="_ebe53fe1-8a4e-4e16-a076-4257ca8f47c0">
-      <dmn11:text>Prefixing + " the result of invoking the imported DS is: " + invoke imported DS</dmn11:text>
-    </dmn11:literalExpression>
-  </dmn11:decision>
-  <dmn11:decision id="_40256338-f153-468e-a8dd-05342a8674b4" name="Prefixing">
-    <dmn11:variable id="_8721d53b-a6b5-4ea0-b394-e7396539bddc" name="Prefixing"/>
-    <dmn11:informationRequirement>
-      <dmn11:requiredInput href="#_48d1a207-aabf-469a-a481-8f255b762cf5"/>
-    </dmn11:informationRequirement>
-    <dmn11:knowledgeRequirement>
-      <dmn11:requiredKnowledge href="http://www.trisotech.com/dmn/definitions/_6eef3a7c-bb0d-40bb-858d-f9067789c18a#_ef12690d-0e40-4bd6-ac6a-dacab2141f0c"/>
-    </dmn11:knowledgeRequirement>
-    <dmn11:literalExpression id="_8a0a2202-fe5f-46aa-8326-42cf6284a530">
-      <dmn11:text>import1.what to say to greet a person(L1 person name)</dmn11:text>
-    </dmn11:literalExpression>
-  </dmn11:decision>
-  <dmn11:inputData id="_48d1a207-aabf-469a-a481-8f255b762cf5" name="L1 person name">
-    <dmn11:variable id="_8531455c-6d5f-4525-8976-eb34f98e5a22" name="L1 person name" typeRef="feel:string"/>
-  </dmn11:inputData>
-</dmn11:definitions>
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:include1="http://www.trisotech.com/dmn/definitions/_6eef3a7c-bb0d-40bb-858d-f9067789c18a"       xmlns:triso="http://www.trisotech.com/2015/triso/modeling"  xmlns:trisodmn="http://www.trisotech.com/2016/triso/dmn"  xmlns:tc="http://www.omg.org/spec/DMN/20160719/testcase"  xmlns:drools="http://www.drools.org/kie/dmn/1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"  xmlns:rss="http://purl.org/rss/2.0/"  xmlns:openapi="https://openapis.org/omg/extension/1.0"  xmlns:xsd="http://www.w3.org/2001/XMLSchema"  xmlns="http://www.trisotech.com/dmn/definitions/_0ff3708a-c861-4a96-b85c-7b882f18b7a1" id="_0ff3708a-c861-4a96-b85c-7b882f18b7a1" name="Import Decision Service 20180718" namespace="http://www.trisotech.com/dmn/definitions/_0ff3708a-c861-4a96-b85c-7b882f18b7a1" exporter="Decision Modeler" exporterVersion="6.9.0" triso:logoChoice="Default">
+  <dmn:import namespace="http://www.trisotech.com/dmn/definitions/_6eef3a7c-bb0d-40bb-858d-f9067789c18a" name="import1" triso:fileId="eyJmIjp7InNrdSI6IjBkN2Q0NzdmLTVlNDQtNGI1ZS1iNmZlLTIxZjVmM2FlZGE5NCIsIm5hbWUiOiJEZWNpc2lvbiBTZXJ2aWNlIDIwMTgwNzE4IiwicGF0aCI6Ii8iLCJtaW1ldHlwZSI6ImFwcGxpY2F0aW9uL3ZuZC50cmlzby1kbW4ranNvbiJ9LCJyIjp7Im5hbWUiOiJNYXR0ZW8gTW9ydGFyaSIsImFwaWtleSI6IjI5MjAwM2Y2OTg0MGU3MTIiLCJ1cmwiOiJodHRwczovL3JlZGhhdC50cmlzb3RlY2guY29tL3B1YmxpY2FwaSIsInJlcG9zaXRvcnlJZCI6InxwZXJzb25hbHwifSwidCI6InB1YmxpY2FwaSJ9" triso:fileName="Matteo Mortari/Decision Service 20180718" importType="http://www.omg.org/spec/DMN/20180521/MODEL/" drools:modelName="Decision Service 20180718"/>
+  <dmn:decisionService id="_41e62189-d469-456c-ab1b-a23180e1b05a" name="Import L1 DS">
+      <dmn:variable name="Import L1 DS" id="_ff65129c-bf0c-4111-97b8-354646c5f399" typeRef="Any"/>
+      <dmn:outputDecision href="#_ea2ccf66-6ede-4365-b0f1-1000216241af"/>
+      <dmn:encapsulatedDecision href="#_d85b923e-b757-41f4-9bec-b47a2887c5d5"/>
+      <dmn:encapsulatedDecision href="#_40256338-f153-468e-a8dd-05342a8674b4"/>
+      <dmn:inputData href="#_48d1a207-aabf-469a-a481-8f255b762cf5"/>
+  </dmn:decisionService>
+  <dmn:decision id="_d85b923e-b757-41f4-9bec-b47a2887c5d5" name="invoke imported DS">
+    <dmn:variable id="_adf487ac-5576-4b7b-9cd4-61b95a66c1ad" name="invoke imported DS"/>
+    <dmn:informationRequirement>
+      <dmn:requiredInput href="#_48d1a207-aabf-469a-a481-8f255b762cf5"/>
+    </dmn:informationRequirement>
+    <dmn:knowledgeRequirement>
+      <dmn:requiredKnowledge href="http://www.trisotech.com/dmn/definitions/_6eef3a7c-bb0d-40bb-858d-f9067789c18a#_cf49add9-84a4-40ac-8306-1eea599ff43c"/>
+    </dmn:knowledgeRequirement>
+    <dmn:invocation id="_bbe48e01-6b02-4fe7-ab9f-6f00e1b6c286">
+      <dmn:literalExpression id="literal__bbe48e01-6b02-4fe7-ab9f-6f00e1b6c286">
+        <dmn:text>import1.DS given inputdata</dmn:text>
+      </dmn:literalExpression>
+      <dmn:binding>
+        <dmn:parameter id="_41c6511b-4ad8-428b-8151-69d0faa3633e" name="Person name"/>
+        <dmn:literalExpression id="_7f0c4bac-36d9-4cbd-aa94-b7c803e38e42">
+          <dmn:text>L1 person name</dmn:text>
+        </dmn:literalExpression>
+      </dmn:binding>
+      <dmn:binding>
+        <dmn:parameter id="_49ebab71-c36e-4637-a66c-d3346d63935a" name="Person age"/>
+        <dmn:literalExpression id="_efc44fbc-e1c4-4337-8475-083feae34229">
+          <dmn:text>47</dmn:text>
+        </dmn:literalExpression>
+      </dmn:binding>
+    </dmn:invocation>
+  </dmn:decision>
+  <dmn:decision id="_ea2ccf66-6ede-4365-b0f1-1000216241af" name="final Import L1 decision">
+    <dmn:variable id="_ec8c4501-ac42-441b-b4e2-063264696401" name="final Import L1 decision"/>
+    <dmn:informationRequirement>
+      <dmn:requiredDecision href="#_d85b923e-b757-41f4-9bec-b47a2887c5d5"/>
+    </dmn:informationRequirement>
+    <dmn:informationRequirement>
+      <dmn:requiredDecision href="#_40256338-f153-468e-a8dd-05342a8674b4"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_ebe53fe1-8a4e-4e16-a076-4257ca8f47c0">
+      <dmn:text>Prefixing + " the result of invoking the imported DS is: " + invoke imported DS</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:decision id="_40256338-f153-468e-a8dd-05342a8674b4" name="Prefixing">
+    <dmn:variable id="_8721d53b-a6b5-4ea0-b394-e7396539bddc" name="Prefixing"/>
+    <dmn:informationRequirement>
+      <dmn:requiredInput href="#_48d1a207-aabf-469a-a481-8f255b762cf5"/>
+    </dmn:informationRequirement>
+    <dmn:knowledgeRequirement>
+      <dmn:requiredKnowledge href="http://www.trisotech.com/dmn/definitions/_6eef3a7c-bb0d-40bb-858d-f9067789c18a#_ef12690d-0e40-4bd6-ac6a-dacab2141f0c"/>
+    </dmn:knowledgeRequirement>
+    <dmn:literalExpression id="_8a0a2202-fe5f-46aa-8326-42cf6284a530">
+      <dmn:text>import1.what to say to greet a person(L1 person name)</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmn:inputData id="_48d1a207-aabf-469a-a481-8f255b762cf5" name="L1 person name">
+    <dmn:variable id="_8531455c-6d5f-4525-8976-eb34f98e5a22" name="L1 person name" typeRef="feel:string"/>
+  </dmn:inputData>
+</dmn:definitions>


### PR DESCRIPTION
please note tests are provided by takari framework here: https://github.com/kiegroup/droolsjbpm-integration/tree/master/kie-plugins-testing/src/test/projects/kjar-7-with-dmn

@etirelli @baldimir @hellowdan 
/cc @DuncanDoyle 

If I introduce an Error which is subject of the model analysis:
![image](https://user-images.githubusercontent.com/1699252/74659262-4bfb6e00-5194-11ea-915c-4283880da021.png)

Then, if I really want to try anyway, by disabling the kie-maven-plugin flag:
![image](https://user-images.githubusercontent.com/1699252/74659342-6d5c5a00-5194-11ea-9207-6ba578d46e7a.png)

I will get the same trouble now because the DMN compilation would, naturally, fail:
![image](https://user-images.githubusercontent.com/1699252/74659403-90870980-5194-11ea-8842-febcb36f7f17.png)

Once review approved, I will write the doc N&N