### PR TITLE
Fix Springboot Swagger tests

### DIFF
--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/pom.xml
@@ -24,6 +24,31 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
+    <!-- extra dependencies for swagger -->
+    <dependency>
+      <groupId>org.webjars</groupId>
+      <artifactId>swagger-ui</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-rs-service-description-swagger</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.cxf</groupId>
+          <artifactId>cxf-rt-rs-service-description-swagger-ui</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-jaxrs</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.ws.rs</groupId>
+          <artifactId>jsr311-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-client</artifactId>

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/src/main/java/org/kie/server/springboot/samples/IntegrationTestsWebSecurityConfig.java
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/src/main/java/org/kie/server/springboot/samples/IntegrationTestsWebSecurityConfig.java
@@ -38,6 +38,7 @@ public class IntegrationTestsWebSecurityConfig extends WebSecurityConfigurerAdap
         http
         .csrf().disable()
         .authorizeRequests().antMatchers("/**/server/readycheck").permitAll() // Allow health check without authentication
+        .regexMatchers(".*swagger.json", ".*swagger-ui.js", ".*/css/.*css", ".*/lib/.*js", ".*/images/.*png").permitAll() //Allow also Swagger elements
         .anyRequest().authenticated()
         .and()
         .httpBasic();

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/src/main/resources/application.properties
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/src/main/resources/application.properties
@@ -14,7 +14,7 @@ jbpm.executor.enabled=false
 #jbpm.executor.threadPoolSize=1
 #jbpm.executor.timeUnit=SECONDS
 
-kieserver.swagger.enabled=false
+kieserver.swagger.enabled=true
 kieserver.location=http://${server.address}:${server.port}${cxf.path}/server
 #kieserver.controllers=
 

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/src/main/resources/swagger.properties
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/src/main/resources/swagger.properties
@@ -1,0 +1,4 @@
+title = KIE Server
+description = This sample project demonstrates how to use KIE Server services in SpringBoot
+version = 1.0.0
+contact = The jBPM team

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/pom.xml
@@ -16,21 +16,6 @@
     <start-class>org.kie.server.springboot.samples.KieServerApplication</start-class>
   </properties>
   
-  <dependencyManagement>
-    <dependencies>      
-      <dependency>
-        <groupId>org.webjars</groupId>
-        <artifactId>swagger-ui</artifactId>
-        <version>2.1.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.cxf</groupId>
-        <artifactId>cxf-rt-rs-service-description-swagger</artifactId>
-        <version>${version.org.apache.cxf}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.kie</groupId>

--- a/kie-spring-boot/kie-spring-boot-samples/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-samples/pom.xml
@@ -39,6 +39,22 @@
     <module>kie-server-spring-boot-integ-tests-sample</module>
   </modules>
 
+  <dependencyManagement>
+    <dependencies>
+     <dependency>
+        <groupId>org.apache.cxf</groupId>
+        <artifactId>cxf-rt-rs-service-description-swagger</artifactId>
+        <version>${version.org.apache.cxf}</version>
+      </dependency>
+      <!-- Notice that higher versions like 1.5.20 contain a bug (No message body writer has been found) so downgraded to 1.5.15 -->
+      <dependency>
+        <groupId>io.swagger</groupId>
+        <artifactId>swagger-jaxrs</artifactId>
+        <version>1.5.15</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Depends on [droolsjbpm-build-bootstrap#1199](https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1199)

After enabling Swagger capability for integration testing of kie server at Springboot, some modifications are needed:
- Swagger UI is exposed in a different endpoint:  
   `[context]/api-docs?url=[context]/swagger.json`
so it's needed to make the test compatible for both endpoints

- Swagger cxf libraries have to be added to the _kie-server-spring-boot-integ-tests-sample_ project  as well as the Swagger UI. 

_Notice that due to a bug at **swagger-jaxrs** in latest versions (No message body writer has been found, when retrieving json files), this dependency must to be downgraded to **1.5.15**, as [current documentation recommends](https://github.com/kiegroup/kie-docs/blob/master/doc-content/enterprise-only/springboot/bus-app-swagger_proc.adoc). This has also been modified at kie-server-spring-boot-sample module._

- WebSecurityConfig for _kie-server-spring-boot-integ-tests-sample_ project has to permit all Swagger elements without authentication

- Added _swagger.properties_ containing the same _title_ that it's expected in the tests



