### PR TITLE
[7.33.x] Set correct Kie server mode in policy test suite for SpringBoot

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/pom.xml
@@ -386,6 +386,7 @@
                       <argument>-Dspring.config.location=${project.build.testOutputDirectory}/application.properties</argument>
                       <argument>-Dkie.maven.settings.custom=${kie.server.server.deployment.settings.xml}</argument>
                       <argument>-Dorg.kie.server.persistence.ds=${org.kie.server.persistence.ds}</argument>
+                      <argument>-Dorg.kie.server.mode=${org.kie.server.mode.production}</argument>
                       <!-- Policy based configuration -->
                       <argument>-Dorg.kie.server.policy.activate=${org.kie.server.policy.activate}</argument>
                       <argument>-Dpolicy.klo.interval=${policy.klo.interval}</argument>


### PR DESCRIPTION
Cherrypick of https://github.com/kiegroup/droolsjbpm-integration/pull/2031
Affects just tests.