### PR TITLE
RHPAM-2800: fixing pom.xml validity for XSD validation

### DIFF
--- a/camel-container-tests/camel-container-integration-tests/pom.xml
+++ b/camel-container-tests/camel-container-integration-tests/pom.xml
@@ -124,8 +124,8 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration combine.children="append">
-          <systemProperties>
+        <configuration>
+          <systemProperties combine.children="append">
             <org.apache.cxf.stax.allowInsecureParser>1</org.apache.cxf.stax.allowInsecureParser>
           </systemProperties>
         </configuration>


### PR DESCRIPTION
https://issues.redhat.com/browse/RHPAM-2800
 according to http://maven.apache.org/pom.html#Plugins