### PR TITLE
[BAQE-1367] administrator user should be lowercase to match keycloak

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
@@ -45,7 +45,7 @@ public abstract class JbpmKieServerBaseIntegrationTest extends RestJmsSharedBase
 
     protected static final String USER_YODA = "yoda";
     protected static final String USER_JOHN = "john";
-    protected static final String USER_ADMINISTRATOR = "Administrator";
+    protected static final String USER_ADMINISTRATOR = "administrator";
     protected static final String USER_MARY = "mary";
 
     protected static final String PROCESS_ID_USERTASK = "definition-project.usertask";

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/JbpmKieServerBaseIntegrationTest.java
@@ -45,7 +45,7 @@ public abstract class JbpmKieServerBaseIntegrationTest extends RestJmsSharedBase
 
     protected static final String USER_YODA = "yoda";
     protected static final String USER_JOHN = "john";
-    protected static final String USER_ADMINISTRATOR = "Administrator";
+    protected static final String USER_ADMINISTRATOR = "administrator";
     protected static final String USER_MARY = "mary";
 
     protected static final String PERSON_CLASS_NAME = "org.jbpm.data.Person";

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskServiceIntegrationTest.java
@@ -566,7 +566,7 @@ public class UserTaskServiceIntegrationTest extends JbpmKieServerBaseIntegration
 
             assertNotNull(taskInstance.getBusinessAdmins());
             assertEquals(2, taskInstance.getBusinessAdmins().size());
-            assertTrue(taskInstance.getBusinessAdmins().contains("Administrator"));
+            assertTrue(taskInstance.getBusinessAdmins().contains(USER_ADMINISTRATOR));
             assertTrue(taskInstance.getBusinessAdmins().contains("Administrators"));
 
             assertNotNull(taskInstance.getInputData());

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/resources/userinfo.properties
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/resources/userinfo.properties
@@ -1,4 +1,4 @@
-Administrator=Administrator@domain.com:en-UK:Administrator
+Administrator=administrator@domain.com:en-UK:administrator
 john=john@domain.com:en-UK:john
 yoda=yoda@domain.com:en-UK:yoda
 Administrators=administrators@domain.com:en-UK:Administrators:[Administrator]

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -259,6 +259,7 @@
                 <org.kie.server.persistence.ds>${org.kie.server.persistence.ds}</org.kie.server.persistence.ds>
                 <org.kie.server.persistence.dialect>${org.kie.server.persistence.dialect}</org.kie.server.persistence.dialect>
                 <org.kie.server.mode>${org.kie.server.mode.production}</org.kie.server.mode>
+                <org.jbpm.ht.admin.user>administrator</org.jbpm.ht.admin.user>
               </systemProperties>
             </container>
             <deployables>
@@ -287,7 +288,7 @@
                   </roles>
                 </user>
                 <user>
-                  <name>Administrator</name>
+                  <name>administrator</name>
                   <password>usetheforce123@</password>
                   <roles>
                     <role>kie-server</role>


### PR DESCRIPTION
provision tests

Needed after [droolsjbpm-integration#2048](https://github.com/kiegroup/droolsjbpm-integration/pull/2048) due to in Keycloak we have "administrator" user in lowercase as Keycloak doesn't allow using capital letters.