### PR TITLE
[7.33.x] RHPAM-2800: fixing pom.xml validity for XSD validation (#2051)

### DIFF
--- a/camel-container-tests/camel-container-integration-tests/pom.xml
+++ b/camel-container-tests/camel-container-integration-tests/pom.xml
@@ -124,8 +124,8 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration combine.children="append">
-          <systemProperties>
+        <configuration>
+          <systemProperties combine.children="append">
             <org.apache.cxf.stax.allowInsecureParser>1</org.apache.cxf.stax.allowInsecureParser>
           </systemProperties>
         </configuration>


### PR DESCRIPTION
backport of #2051