### PR TITLE
BXMSPROD-741: Remove Node and npm versions

### DIFF
--- a/process-migration-service/pom.xml
+++ b/process-migration-service/pom.xml
@@ -20,8 +20,6 @@
     <version.org.jboss.weld.weld-api>2.4.SP2</version.org.jboss.weld.weld-api>
     <!-- Frontend properties -->
     <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
-    <node.version>v11.6.0</node.version>
-    <npm.version>6.9.0</npm.version>
     <!-- Following properties are used only for testing -->
     <!-- This property needs to be overridden when running tests against different version of the WAR (e.g. running
          SNAPSHOT tests against Beta3 WAR) so the tests actually know what exact version of server is being tested -->
@@ -275,10 +273,6 @@
             <goals>
               <goal>install-node-and-npm</goal>
             </goals>
-            <configuration>
-              <nodeVersion>${node.version}</nodeVersion>
-              <npmVersion>${npm.version}</npmVersion>
-            </configuration>
           </execution>
           <execution>
             <id>npm install lock-treatment-tool and run-node</id>


### PR DESCRIPTION
They are now managed by kie-parent.

PR group:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1273
- https://github.com/kiegroup/appformer/pull/943
- https://github.com/kiegroup/droolsjbpm-integration/pull/2064
- https://github.com/kiegroup/kie-wb-common/pull/3269
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/296
- https://github.com/kiegroup/optaweb-employee-rostering/pull/425