### PR TITLE
[BAQE-1367] administrator user should be lowercase to match keycloak

### DIFF
--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -1280,6 +1280,7 @@
                       <argument>-Dkie.server.base.http.url=${kie.server.base.http.url}</argument>
                       <argument>-Dorg.kie.server.mode=${org.kie.server.mode.production}</argument>
                       <argument>-Dorg.kie.server.stacktrace.included=${org.kie.server.stacktrace.included}</argument>
+                      <argument>-Dorg.jbpm.ht.admin.user=administrator</argument>
                       <argument>org.springframework.boot.loader.JarLauncher</argument>
                     </arguments>
                   </configuration>

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/src/main/java/org/kie/server/springboot/samples/IntegrationTestsWebSecurityConfig.java
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/src/main/java/org/kie/server/springboot/samples/IntegrationTestsWebSecurityConfig.java
@@ -63,7 +63,7 @@ public class IntegrationTestsWebSecurityConfig extends WebSecurityConfigurerAdap
         // Configuration is the same as in the kie-server-tests module
         auth.inMemoryAuthentication().withUser("yoda").password(encoder.encode("usetheforce123@")).roles("kie-server", "guest")
         .and()        
-        .withUser("Administrator").password(encoder.encode("usetheforce123@")).roles("kie-server", "guest", "Administrators")
+        .withUser("administrator").password(encoder.encode("usetheforce123@")).roles("kie-server", "guest", "Administrators")
         .and()        
         .withUser("john").password(encoder.encode("usetheforce123@")).roles("kie-server", "guest", "engineering", "HR", "IT", "Accounting")
         .and()        


### PR DESCRIPTION
Fixing SpringBoot test configuration.

Signed-off-by: Karel Suta <ksuta@redhat.com>