### PR TITLE
Enhance maintainability at springboot kie-server-integ-tests-policy pom

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
@@ -452,14 +452,6 @@
         <!-- For including complete stack trace in the response -->
         <org.kie.server.stacktrace.included>true</org.kie.server.stacktrace.included>
       </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.bazaarvoice.maven.plugins</groupId>
-            <artifactId>process-exec-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 </project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
@@ -331,17 +331,4 @@
     </plugins>
   </build>
 
-  <profiles>
-    <profile>
-      <id>springboot</id>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.bazaarvoice.maven.plugins</groupId>
-            <artifactId>process-exec-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/pom.xml
@@ -334,14 +334,6 @@
         <kieserver.prometheus.enabled>true</kieserver.prometheus.enabled>
         <kieserver.scenariosimulation.enabled>true</kieserver.scenariosimulation.enabled>
       </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.bazaarvoice.maven.plugins</groupId>
-            <artifactId>process-exec-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 </project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
@@ -330,14 +330,6 @@
         <kieserver.prometheus.enabled>true</kieserver.prometheus.enabled>
         <kieserver.scenariosimulation.enabled>true</kieserver.scenariosimulation.enabled>
       </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.bazaarvoice.maven.plugins</groupId>
-            <artifactId>process-exec-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 </project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
@@ -570,14 +570,6 @@
         <jbpm.executor.enabled>true</jbpm.executor.enabled>
         <org.kie.server.bypass.auth.user>true</org.kie.server.bypass.auth.user>
       </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.bazaarvoice.maven.plugins</groupId>
-            <artifactId>process-exec-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 </project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
@@ -307,14 +307,6 @@
         <kieserver.optaplanner.enabled>true</kieserver.optaplanner.enabled>
         <kieserver.prometheus.enabled>true</kieserver.prometheus.enabled>
       </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.bazaarvoice.maven.plugins</groupId>
-            <artifactId>process-exec-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 </project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/pom.xml
@@ -369,42 +369,6 @@
         <org.kie.server.policy.activate>KeepLatestOnly</org.kie.server.policy.activate>
         <policy.klo.interval>5000</policy.klo.interval>
       </properties>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>com.bazaarvoice.maven.plugins</groupId>
-              <artifactId>process-exec-maven-plugin</artifactId>
-              <executions>
-                <execution>
-                  <id>start-springboot</id>
-                  <configuration>
-                    <arguments>
-                      <argument>java</argument>
-                      <argument>-cp</argument>
-                      <argument>${springboot.app.jar.name}:${springboot.jdbc.driver.jar}</argument>
-                      <argument>-Dspring.config.location=${project.build.testOutputDirectory}/application.properties</argument>
-                      <argument>-Dkie.maven.settings.custom=${kie.server.server.deployment.settings.xml}</argument>
-                      <argument>-Dorg.kie.server.persistence.ds=${org.kie.server.persistence.ds}</argument>
-                      <argument>-Dorg.kie.server.mode=${org.kie.server.mode.production}</argument>
-                      <!-- Policy based configuration -->
-                      <argument>-Dorg.kie.server.policy.activate=${org.kie.server.policy.activate}</argument>
-                      <argument>-Dpolicy.klo.interval=${policy.klo.interval}</argument>
-                      <argument>org.springframework.boot.loader.JarLauncher</argument>
-                    </arguments>
-                  </configuration>
-                </execution>
-              </executions>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-        <plugins>
-          <plugin>
-            <groupId>com.bazaarvoice.maven.plugins</groupId>
-            <artifactId>process-exec-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 </project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-scenario-simulation/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-scenario-simulation/pom.xml
@@ -337,14 +337,6 @@
         <kieserver.prometheus.enabled>true</kieserver.prometheus.enabled>
         <kieserver.scenariosimulation.enabled>true</kieserver.scenariosimulation.enabled>
       </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>com.bazaarvoice.maven.plugins</groupId>
-            <artifactId>process-exec-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
   </profiles>
 </project>

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -48,6 +48,9 @@
     <failsafe.excluded.groups/>
     <!-- Sybase driver leaks its Timestamp implementation. To correctly handle it we need to add driver as additional test classpath. -->
     <maven.jdbc.driver.jar/>
+    <!-- No policy activated by default but overwritten at kie-server-integ-tests-policy -->
+    <org.kie.server.policy.activate/>
+    <policy.klo.interval>0</policy.klo.interval>
     <!-- Set to true if you want to skip JMS tests even for containers with available JMS. -->
     <jms.skip>false</jms.skip>
     <!-- Property for configuring Maven mirror in Kie server settings.xml. Used to speed up test execution by using cache server. Empty by default. -->
@@ -1284,6 +1287,8 @@
                       <argument>-Dorg.kie.server.stacktrace.included=${org.kie.server.stacktrace.included}</argument>
                       <argument>-Dorg.jbpm.ht.admin.user=administrator</argument>
                       <argument>-Dorg.kie.server.bypass.auth.user=${org.kie.server.bypass.auth.user}</argument>
+                      <argument>-Dorg.kie.server.policy.activate=${org.kie.server.policy.activate}</argument>
+                      <argument>-Dpolicy.klo.interval=${policy.klo.interval}</argument>
                       <argument>org.springframework.boot.loader.JarLauncher</argument>
                     </arguments>
                   </configuration>
@@ -1300,6 +1305,12 @@
             </plugin>
           </plugins>
         </pluginManagement>
+        <plugins>
+          <plugin>
+            <groupId>com.bazaarvoice.maven.plugins</groupId>
+            <artifactId>process-exec-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
       </build>
     </profile>
     <!-- This profile basically disables any cargo related execution. It can be used when the tests should run on


### PR DESCRIPTION
Removed process-exec-maven-plugin overwritten at child pom, passing these properties with their default value to parent, for better maintainability.