### PR TITLE
Kie-camel tests no longer depends on exact order of rules evaluation

### DIFF
--- a/kie-camel/pom.xml
+++ b/kie-camel/pom.xml
@@ -208,6 +208,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/kie-camel/src/test/java/org/kie/camel/embedded/camel/component/BatchTest.java
+++ b/kie-camel/src/test/java/org/kie/camel/embedded/camel/component/BatchTest.java
@@ -569,8 +569,6 @@ public abstract class BatchTest extends CamelTestSupport {
 
         String outXml = execContent("testInsertElements.in.1");
 
-        assertXMLEqual(getContent("testInsertElements.expected.1"), outXml);
-
         ExecutionResults result = unmarshalOutXml(outXml, ExecutionResults.class);
 
         List list = (List)result.getValue("list1");
@@ -622,8 +620,6 @@ public abstract class BatchTest extends CamelTestSupport {
         list.add(ksession.getObject(((InternalFactHandle)factHandles.get(1))));
         assertTrue(list.contains(new Cheese("stilton", 35)));
         assertTrue(list.contains(new Cheese("stilton", 30)));
-
-        assertXMLEqual(getContent("testInsertElementsWithReturnObjects.expected.1", factHandles.get(0).toExternalForm(), factHandles.get(1).toExternalForm()), outXml);
     }
 
     @Test
@@ -816,8 +812,6 @@ public abstract class BatchTest extends CamelTestSupport {
         String outXml = execContent("testManualFireAllRules.in.1");
 
         ExecutionResults result = unmarshalOutXml(outXml, ExecutionResults.class);
-
-        assertXMLEqual(getContent("testManualFireAllRules.expected.1", ((FactHandle)result.getFactHandle("outBrie")).toExternalForm()), outXml);
 
         // brie should not have been added to the list
         List list = (List)result.getValue("list1");

--- a/kie-camel/src/test/java/org/kie/camel/embedded/camel/component/CamelEndpointWithJaxWrapperCollectionTest.java
+++ b/kie-camel/src/test/java/org/kie/camel/embedded/camel/component/CamelEndpointWithJaxWrapperCollectionTest.java
@@ -18,6 +18,7 @@ package org.kie.camel.embedded.camel.component;
 
 import java.io.ByteArrayInputStream;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.naming.Context;
@@ -29,6 +30,7 @@ import com.sun.tools.xjc.Language;
 import com.sun.tools.xjc.Options;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.dataformat.JaxbDataFormat;
+import org.assertj.core.api.Assertions;
 import org.drools.core.command.runtime.BatchExecutionCommandImpl;
 import org.drools.core.command.runtime.GetGlobalCommand;
 import org.drools.core.command.runtime.SetGlobalCommand;
@@ -85,9 +87,10 @@ public class CamelEndpointWithJaxWrapperCollectionTest extends KieCamelTestSuppo
         assertNotNull(resp);
 
         assertEquals(resp.size(), 2);
-        assertEquals("baunax", resp.get(0).getName());
-        assertEquals("Hadrian", resp.get(1).getName());
-
+        final List<String> expectedNames = new ArrayList<>();
+        expectedNames.add(resp.get(0).getName());
+        expectedNames.add(resp.get(1).getName());
+        Assertions.assertThat(expectedNames).contains("baunax", "Hadrian");
     }
 
     @Override

--- a/kie-camel/src/test/java/org/kie/camel/embedded/camel/component/XStreamBatchExecutionTest.java
+++ b/kie-camel/src/test/java/org/kie/camel/embedded/camel/component/XStreamBatchExecutionTest.java
@@ -681,47 +681,6 @@ public class XStreamBatchExecutionTest extends CamelTestSupport {
 
         Collection<? extends FactHandle> factHandles = ksession.getFactHandles();
 
-        String expectedXml = "";
-        expectedXml += "<execution-results>\n";
-        expectedXml += "  <result identifier='list'>\n";
-        expectedXml += "    <list>\n";
-        expectedXml += "      <org.kie.camel.embedded.camel.testdomain.Cheese>\n";
-        expectedXml += "        <type>stilton</type>\n";
-        expectedXml += "        <price>35</price>\n";
-        expectedXml += "        <oldPrice>0</oldPrice>\n";
-        expectedXml += "      </org.kie.camel.embedded.camel.testdomain.Cheese>\n";
-        expectedXml += "      <org.kie.camel.embedded.camel.testdomain.Cheese>\n";
-        expectedXml += "        <type>stilton</type>\n";
-        expectedXml += "        <price>30</price>\n";
-        expectedXml += "        <oldPrice>0</oldPrice>\n";
-        expectedXml += "      </org.kie.camel.embedded.camel.testdomain.Cheese>\n";
-        expectedXml += "    </list>\n";
-        expectedXml += "  </result>\n";
-
-        expectedXml += "  <result identifier=\"myfacts\">\n";
-        expectedXml += "  <list>\n";
-        expectedXml += "    <org.kie.camel.embedded.camel.testdomain.Cheese reference=\"../../../result/list/org.kie.camel.embedded.camel.testdomain.Cheese[2]\"/>\n";
-        expectedXml += "    <org.kie.camel.embedded.camel.testdomain.Cheese reference=\"../../../result/list/org.kie.camel.embedded.camel.testdomain.Cheese\"/>\n";
-        expectedXml += "  </list>\n";
-        expectedXml += "  </result>\n";
-        expectedXml += "  <fact-handles identifier=\"myfacts\">\n";
-        for (FactHandle factHandle : factHandles) {
-            if (((Cheese)ksession.getObject(factHandle)).getPrice() == 30) {
-                expectedXml += "  <fact-handle external-form=\"" + factHandle.toExternalForm() + "\"/>\n";
-            }
-        }
-
-        for (FactHandle factHandle : factHandles) {
-            if (((Cheese)ksession.getObject(factHandle)).getPrice() == 35) {
-                expectedXml += "  <fact-handle external-form=\"" + factHandle.toExternalForm() + "\"/>\n";
-            }
-        }
-        expectedXml += "  </fact-handles>\n";
-
-        expectedXml += "</execution-results>\n";
-
-        assertXMLEqual(expectedXml, outXml);
-
         ExecutionResults result = (ExecutionResults) BatchExecutionHelper.newXStreamMarshaller().fromXML(outXml);
 
         List list = (List)result.getValue("list");


### PR DESCRIPTION
This fix is related to DROOLS-2965 where order was reversed. It is no longer
possible to compare exact content of XMLs. Only unmarshalled values are compared.