### PR TITLE
[JBPM-9121] Add missing jaxb dependency in integration test

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/secured-project/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/secured-project/pom.xml
@@ -13,6 +13,14 @@
   <version>1.0.0.Final</version>
   <name>secured-project</name>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
Required for JDK 11.

Signed-off-by: Karel Suta <ksuta@redhat.com>