### PR TITLE
Drools 5021 ClassCastException thrown when deserializing components of a Generic command

### DIFF
--- a/camel-container-tests/camel-container-integration-tests/pom.xml
+++ b/camel-container-tests/camel-container-integration-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>camel-container-tests</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/camel-container-tests/camel-container-tests-api/pom.xml
+++ b/camel-container-tests/camel-container-tests-api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>camel-container-tests</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/camel-container-tests/camel-container-tests-model/pom.xml
+++ b/camel-container-tests/camel-container-tests-model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>camel-container-tests</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/camel-container-tests/camel-container-tests-module/pom.xml
+++ b/camel-container-tests/camel-container-tests-module/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>camel-container-tests</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/camel-container-tests/pom.xml
+++ b/camel-container-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>droolsjbpm-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/drools-android/pom.xml
+++ b/drools-android/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>drools-android</artifactId>

--- a/drools-benchmark/pom.xml
+++ b/drools-benchmark/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>drools-benchmark</artifactId>

--- a/drools-examples-android/kiecontainer/pom.xml
+++ b/drools-examples-android/kiecontainer/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-android</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kiecontainer</artifactId>

--- a/drools-examples-android/pom.xml
+++ b/drools-examples-android/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>drools-examples-android</artifactId>

--- a/drools-examples-android/roboguice-kiecontainer-test/pom.xml
+++ b/drools-examples-android/roboguice-kiecontainer-test/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-android</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>roboguice-kiecontainer-test</artifactId>

--- a/drools-examples-android/roboguice-kiecontainer/pom.xml
+++ b/drools-examples-android/roboguice-kiecontainer/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-android</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>roboguice-kiecontainer</artifactId>

--- a/drools-examples-android/roboguice-serialized-kbase/pom.xml
+++ b/drools-examples-android/roboguice-serialized-kbase/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-android</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>roboguice-serialized-kbase</artifactId>

--- a/drools-examples-android/serialized-kbase/pom.xml
+++ b/drools-examples-android/serialized-kbase/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>drools-examples-android</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>serialized-kbase</artifactId>

--- a/drools-jboss-integration/pom.xml
+++ b/drools-jboss-integration/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <groupId>org.drools</groupId>

--- a/droolsjbpm-bpms-distribution/pom.xml
+++ b/droolsjbpm-bpms-distribution/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>droolsjbpm-bpms-distribution</artifactId>

--- a/droolsjbpm-brms-distribution/pom.xml
+++ b/droolsjbpm-brms-distribution/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>droolsjbpm-brms-distribution</artifactId>

--- a/droolsjbpm-integration-distribution/pom.xml
+++ b/droolsjbpm-integration-distribution/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>droolsjbpm-integration-distribution</artifactId>

--- a/droolsjbpm-integration-examples/pom.xml
+++ b/droolsjbpm-integration-examples/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>droolsjbpm-integration-examples</artifactId>

--- a/jbpm-process-svg/pom.xml
+++ b/jbpm-process-svg/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/jbpm-simulation/pom.xml
+++ b/jbpm-simulation/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>jbpm-simulation</artifactId>
   <name>jBPM Simulation</name>

--- a/kie-aries-blueprint/pom.xml
+++ b/kie-aries-blueprint/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/kie-camel/pom.xml
+++ b/kie-camel/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/kie-identity-session-provider/pom.xml
+++ b/kie-identity-session-provider/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   
   <groupId>org.kie</groupId>

--- a/kie-integration-test-coverage/kie-maven-plugin-separate-model-tests/kjar-with-separate-instrumentation-wrapper/pom.xml
+++ b/kie-integration-test-coverage/kie-maven-plugin-separate-model-tests/kjar-with-separate-instrumentation-wrapper/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>kie-maven-plugin-separate-model-tests-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-integration-test-coverage/kie-maven-plugin-separate-model-tests/model-wrapper/pom.xml
+++ b/kie-integration-test-coverage/kie-maven-plugin-separate-model-tests/model-wrapper/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>kie-maven-plugin-separate-model-tests-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-integration-test-coverage/kie-maven-plugin-separate-model-tests/pom.xml
+++ b/kie-integration-test-coverage/kie-maven-plugin-separate-model-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>kie-integration-test-coverage-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-integration-test-coverage/kie-maven-plugin-separate-model-tests/test-suite/pom.xml
+++ b/kie-integration-test-coverage/kie-maven-plugin-separate-model-tests/test-suite/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>kie-maven-plugin-separate-model-tests-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/pom.xml
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/kjar-with-instrumentation-wrapper/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>kie-maven-plugin-tests-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-integration-test-coverage/kie-maven-plugin-tests/pom.xml
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>kie-integration-test-coverage-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-integration-test-coverage/kie-maven-plugin-tests/test-suite/pom.xml
+++ b/kie-integration-test-coverage/kie-maven-plugin-tests/test-suite/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools.testcoverage</groupId>
     <artifactId>kie-maven-plugin-tests-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-integration-test-coverage/kie-spring-test/pom.xml
+++ b/kie-integration-test-coverage/kie-spring-test/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <artifactId>kie-integration-test-coverage-parent</artifactId>
     <groupId>org.drools.testcoverage</groupId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-integration-test-coverage/pom.xml
+++ b/kie-integration-test-coverage/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>droolsjbpm-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-maven-plugin/pom.xml
+++ b/kie-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/kie-osgi/kie-karaf-features/pom.xml
+++ b/kie-osgi/kie-karaf-features/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-osgi</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-karaf-features</artifactId>

--- a/kie-osgi/kie-karaf-itests-domain-model/pom.xml
+++ b/kie-osgi/kie-karaf-itests-domain-model/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-osgi</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-karaf-itests-domain-model</artifactId>

--- a/kie-osgi/kie-karaf-itests/pom.xml
+++ b/kie-osgi/kie-karaf-itests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-osgi</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-karaf-itests</artifactId>

--- a/kie-osgi/kie-osgi-integration/pom.xml
+++ b/kie-osgi/kie-osgi-integration/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-osgi</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-osgi-integration</artifactId>

--- a/kie-osgi/pom.xml
+++ b/kie-osgi/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/kie-performance-kit/pom.xml
+++ b/kie-performance-kit/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/kie-plugins-testing/pom.xml
+++ b/kie-plugins-testing/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/kie-security/pom.xml
+++ b/kie-security/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>droolsjbpm-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-server-parent/kie-server-api/pom.xml
+++ b/kie-server-parent/kie-server-api/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-api</artifactId>

--- a/kie-server-parent/kie-server-common/pom.xml
+++ b/kie-server-parent/kie-server-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-common</artifactId>

--- a/kie-server-parent/kie-server-controller-plugin/pom.xml
+++ b/kie-server-parent/kie-server-controller-plugin/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-controller-plugin</artifactId>
   <packaging>maven-plugin</packaging>

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-controller</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-controller-api</artifactId>

--- a/kie-server-parent/kie-server-controller/kie-server-controller-client/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-client/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-server-controller</artifactId>
     <groupId>org.kie.server</groupId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-controller-client</artifactId>

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-controller</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-controller-impl</artifactId>

--- a/kie-server-parent/kie-server-controller/kie-server-controller-openshift/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-openshift/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>kie-server-controller</artifactId>
     <groupId>org.kie.server</groupId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-controller-openshift</artifactId>

--- a/kie-server-parent/kie-server-controller/kie-server-controller-rest/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-rest/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-controller</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-controller-rest</artifactId>

--- a/kie-server-parent/kie-server-controller/kie-server-controller-standalone-impl/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-standalone-impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-server-controller</artifactId>
     <groupId>org.kie.server</groupId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-server-parent/kie-server-controller/kie-server-controller-standalone/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-standalone/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-controller</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-controller-standalone</artifactId>
   <packaging>pom</packaging>

--- a/kie-server-parent/kie-server-controller/kie-server-controller-websocket-client/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-websocket-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-controller</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-controller-websocket-client</artifactId>
   <name>KIE :: Execution Server :: Controller :: Websocket Client Implementation</name>

--- a/kie-server-parent/kie-server-controller/kie-server-controller-websocket-common/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-websocket-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-controller</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-controller-websocket-common</artifactId>
   <name>KIE :: Execution Server :: Controller :: Websocket Common Implementation</name>

--- a/kie-server-parent/kie-server-controller/kie-server-controller-websocket/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-websocket/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-controller</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-controller-websocket</artifactId>
   <name>KIE :: Execution Server :: Controller :: Websocket Implementation</name>

--- a/kie-server-parent/kie-server-controller/pom.xml
+++ b/kie-server-parent/kie-server-controller/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-controller</artifactId>

--- a/kie-server-parent/kie-server-maven-plugin/pom.xml
+++ b/kie-server-parent/kie-server-maven-plugin/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.kie.server</groupId>
         <artifactId>kie-server-parent</artifactId>
-        <version>7.29.0-SNAPSHOT</version>
+        <version>7.29.0.Final</version>
     </parent>
     <artifactId>kie-server-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>

--- a/kie-server-parent/kie-server-remote/kie-server-client/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-remote</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-client</artifactId>

--- a/kie-server-parent/kie-server-remote/kie-server-jms/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-jms/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-remote</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-jms</artifactId>

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-case-mgmt/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-case-mgmt/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-server-rest</artifactId>
     <groupId>org.kie.server</groupId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-common/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-rest</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-dmn/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-dmn/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-rest</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-rest-dmn</artifactId>
   

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-drools/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-drools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-rest</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm-ui/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm-ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-server-rest</artifactId>
     <groupId>org.kie.server</groupId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-rest</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-optaplanner/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-optaplanner/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-rest</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-prometheus/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-prometheus/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-rest</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-swagger/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-swagger/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-rest</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-server-parent/kie-server-remote/kie-server-rest/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-remote</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-rest</artifactId>

--- a/kie-server-parent/kie-server-remote/pom.xml
+++ b/kie-server-parent/kie-server-remote/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-remote</artifactId>

--- a/kie-server-parent/kie-server-router/kie-server-router-client/pom.xml
+++ b/kie-server-parent/kie-server-router/kie-server-router-client/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-router</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-router-client</artifactId>
   <packaging>jar</packaging>

--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/pom.xml
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-router</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-router-proxy</artifactId>
   <packaging>jar</packaging>

--- a/kie-server-parent/kie-server-router/pom.xml
+++ b/kie-server-parent/kie-server-router/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-router</artifactId>

--- a/kie-server-parent/kie-server-services/kie-server-services-case-mgmt/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-case-mgmt/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-server-services</artifactId>
     <groupId>org.kie.server</groupId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-services</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-services-common</artifactId>

--- a/kie-server-parent/kie-server-services/kie-server-services-dmn/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-dmn/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-services</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-services-dmn</artifactId>
   

--- a/kie-server-parent/kie-server-services/kie-server-services-drools/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-drools/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-services</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>kie-server-services</artifactId>
     <groupId>org.kie.server</groupId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-services</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-services-jbpm</artifactId>

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-services</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-services-openshift</artifactId>

--- a/kie-server-parent/kie-server-services/kie-server-services-optaplanner/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-optaplanner/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-services</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/kie-server-parent/kie-server-services/kie-server-services-prometheus/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-prometheus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-services</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-services-prometheus</artifactId>

--- a/kie-server-parent/kie-server-services/kie-server-services-swagger/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-swagger/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-services</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-services-swagger</artifactId>

--- a/kie-server-parent/kie-server-services/pom.xml
+++ b/kie-server-parent/kie-server-services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-services</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-tests</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-integ-tests-all</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-case-id-generator/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-case-id-generator/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-tests</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-integ-tests-case-id-generator</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-tests</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-integ-tests-common</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-tests</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-integ-tests-controller</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-client/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-client/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-integ-tests-custom-extension</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-integ-tests-custom-extension-client</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-prometheus/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-prometheus/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-integ-tests-custom-extension</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-integ-tests-custom-extension-prometheus</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-rest/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-rest/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-integ-tests-custom-extension</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-integ-tests-custom-extension-rest</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-services/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-services/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-integ-tests-custom-extension</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-integ-tests-custom-extension-services</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-integ-tests-custom-extension</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-integ-tests-custom-extension-test</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-tests</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-integ-tests-custom-extension</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-tests</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-integ-tests-dmn</artifactId>
   

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-tests</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-integ-tests-drools</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-tests</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-integ-tests-jbpm</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-tests</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-integ-tests-optaplanner</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-tests</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-integ-tests-policy</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-tests</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-integ-tests-router</artifactId>

--- a/kie-server-parent/kie-server-tests/kie-server-test-web-service/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-test-web-service/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-tests</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-test-web-service</artifactId>
   <packaging>war</packaging>

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-tests</artifactId>

--- a/kie-server-parent/kie-server-wars/kie-server-distribution/pom.xml
+++ b/kie-server-parent/kie-server-wars/kie-server-distribution/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-wars</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-distribution</artifactId>

--- a/kie-server-parent/kie-server-wars/kie-server/pom.xml
+++ b/kie-server-parent/kie-server-wars/kie-server/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-wars</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server</artifactId>

--- a/kie-server-parent/kie-server-wars/pom.xml
+++ b/kie-server-parent/kie-server-wars/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie.server</groupId>
     <artifactId>kie-server-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-server-wars</artifactId>

--- a/kie-server-parent/pom.xml
+++ b/kie-server-parent/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <groupId>org.kie.server</groupId>

--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/jbpm-spring-boot-autoconfiguration/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/jbpm-spring-boot-autoconfiguration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot-autoconfiguration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>jbpm-spring-boot-autoconfiguration</artifactId>
   <name>KIE :: Spring :: Boot :: jBPM Auto Configuration</name>

--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/jbpm-spring-boot-data-sources/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/jbpm-spring-boot-data-sources/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot-autoconfiguration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>jbpm-spring-boot-data-sources</artifactId>
 

--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration-drools/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration-drools/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot-autoconfiguration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-spring-boot-autoconfiguration-drools</artifactId>
   <name>KIE :: Spring :: Boot :: KIE Server Auto Configuration :: Drools</name>

--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration-jbpm/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration-jbpm/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot-autoconfiguration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-spring-boot-autoconfiguration-jbpm</artifactId>
   <name>KIE :: Spring :: Boot :: KIE Server Auto Configuration :: jBPM</name>

--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration-optaplanner/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration-optaplanner/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot-autoconfiguration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-spring-boot-autoconfiguration-optaplanner</artifactId>
   <name>KIE :: Spring :: Boot :: KIE Server Auto Configuration :: OptaPlanner</name>

--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot-autoconfiguration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-spring-boot-autoconfiguration</artifactId>
   <name>KIE :: Spring :: Boot :: KIE Server Auto Configuration</name>

--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-spring-boot-autoconfiguration</artifactId>
   <name>KIE :: Spring :: Boot :: Auto Configuration</name>

--- a/kie-spring-boot/kie-spring-boot-samples/jbpm-spring-boot-sample-basic/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-samples/jbpm-spring-boot-sample-basic/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot-samples</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>jbpm-spring-boot-sample-basic</artifactId>

--- a/kie-spring-boot/kie-spring-boot-samples/keycloak-kie-server-spring-boot-sample/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-samples/keycloak-kie-server-spring-boot-sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot-samples</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>keycloak-kie-server-spring-boot-sample</artifactId>
 

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot-samples</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-spring-boot-integ-tests-sample</artifactId>
 

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot-samples</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-spring-boot-sample</artifactId>
 

--- a/kie-spring-boot/kie-spring-boot-samples/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-samples/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-spring-boot-samples</artifactId>

--- a/kie-spring-boot/kie-spring-boot-starters/jbpm-spring-boot-starter-basic/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-starters/jbpm-spring-boot-starter-basic/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot-starters</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>jbpm-spring-boot-starter-basic</artifactId>

--- a/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter-drools/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter-drools/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot-starters</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-spring-boot-starter-drools</artifactId>
   

--- a/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter-jbpm/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter-jbpm/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot-starters</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-spring-boot-starter-jbpm</artifactId>
 

--- a/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter-optaplanner/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter-optaplanner/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot-starters</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-spring-boot-starter-optaplanner</artifactId>
   

--- a/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot-starters</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
   <artifactId>kie-server-spring-boot-starter</artifactId>
 

--- a/kie-spring-boot/kie-spring-boot-starters/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-starters/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-spring-boot</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>kie-spring-boot-starters</artifactId>

--- a/kie-spring-boot/pom.xml
+++ b/kie-spring-boot/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>droolsjbpm-integration</artifactId>
     <groupId>org.drools</groupId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/kie-spring/pom.xml
+++ b/kie-spring/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/kie-swagger-ui/pom.xml
+++ b/kie-swagger-ui/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/kie-takari-plugin/pom.xml
+++ b/kie-takari-plugin/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <groupId>org.kie</groupId>

--- a/kie-tomcat-integration/pom.xml
+++ b/kie-tomcat-integration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-parent</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
     <!-- relativePath causes out-of-date problems on hudson slaves -->
     <!--<relativePath>../droolsjbpm-build-bootstrap/pom.xml</relativePath>-->
   </parent>

--- a/process-migration-service/pom.xml
+++ b/process-migration-service/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.29.0-SNAPSHOT</version>
+    <version>7.29.0.Final</version>
   </parent>
 
   <artifactId>process-migration-service</artifactId>


### PR DESCRIPTION
The fix that was tested was as described in [DROOLS-5021](https://issues.redhat.com/browse/DROOLS-5021?focusedCommentId=14001519&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14001519url).
It's passing the provided test cases, and doesn't seem to have broken any additional Unit or Integration tests (there were several tests failing out of the box for me).
