### PR TITLE
[JBPM-9147] getTaskById does not return formName

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/ConvertUtils.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/ConvertUtils.java
@@ -427,6 +427,7 @@ public class ConvertUtils {
                 .workItemId(userTask.getWorkItemId())
                 .slaCompliance(userTask.getSlaCompliance())
                 .slaDueDate(userTask.getSlaDueDate())
+                .formName(userTask.getFormName())
                 .build();
 
         return instance;


### PR DESCRIPTION
Added test to retrieve formName from kie-server.
**formName** was missing on _ConvertUtils.convertToTask_ method.

Related to [jbpm#1647](https://github.com/kiegroup/jbpm/pull/1647)