### PR TITLE
JBPM-9154: Fix duplicated javax.activation classes

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
@@ -220,6 +220,12 @@
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-kie-services</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.activation</groupId>
+          <artifactId>activation</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kie.soup</groupId>


### PR DESCRIPTION
Running jbpm kie-server integration tests was not possible due to duplicated classes.

For more details see: https://issues.redhat.com/browse/JBPM-9154