### PR TITLE
JBPM-9185; Exclude UserTaskServiceIntegrationTest failing on jenkins

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
@@ -299,6 +299,10 @@
               <org.kie.server.datasource.driver.class>${org.kie.server.datasource.driver.class}</org.kie.server.datasource.driver.class>
               <org.jbpm.document.storage>${org.jbpm.document.storage}</org.jbpm.document.storage>
             </systemPropertyVariables>
+            <excludes>
+              <!-- https://issues.redhat.com/browse/JBPM-9158 -->
+              <exclude>org.kie.server.integrationtests.jbpm.UserTaskServiceIntegrationTest</exclude>
+            </excludes>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
The details about failing can be found in: https://issues.redhat.com/browse/JBPM-9158