### PR TITLE
PLANNER-1938 Increase timeout for task assigning test

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-task-assigning/src/test/java/org/kie/server/integrationtests/taskassigning/TaskAssigningIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-task-assigning/src/test/java/org/kie/server/integrationtests/taskassigning/TaskAssigningIntegrationTest.java
@@ -46,6 +46,7 @@ public class TaskAssigningIntegrationTest extends KieServerBaseIntegrationTest {
     private static final ReleaseId TEST_KJAR = new ReleaseId("org.kie.server.testing", "task-assigning", "1.0.0.Final");
     private static final String CONTAINER_ID = "task-assigning";
     private static final String PROCESS_ID = "org.kie.server.CreditDispute";
+    private static final int ASSIGNMENT_TIMEOUT_SECONDS = 600;
 
     private final KieServicesClient kieServicesClient = createDefaultClient();
     private final ProcessServicesClient processClient = kieServicesClient.getServicesClient(ProcessServicesClient.class);
@@ -86,7 +87,7 @@ public class TaskAssigningIntegrationTest extends KieServerBaseIntegrationTest {
     }
 
     private void doNextTaskByUser(String userId) {
-        List<TaskSummary> tasks = waitForTasks(() -> taskClient.findTasks(userId, 0, 1), 10);
+        List<TaskSummary> tasks = waitForTasks(() -> taskClient.findTasks(userId, 0, 1), ASSIGNMENT_TIMEOUT_SECONDS);
         assertThat(tasks).hasSize(1);
         final long resolveDisputeTaskId = tasks.get(0).getId();
         taskClient.startTask(CONTAINER_ID, resolveDisputeTaskId, userId);


### PR DESCRIPTION
As the change of dependencies is going to be bigger than I originally thought, let's merge the timeout increase first.