### PR TITLE
[RHPAM-2911] Null fields should not be included in JSON response

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/MarshallingFormat.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/MarshallingFormat.java
@@ -17,6 +17,7 @@
 package org.kie.server.api.marshalling;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -57,19 +58,24 @@ public enum MarshallingFormat {
         }
     }
 
+    
     public static boolean isStrictType(String type) {
-        int idx;
-        if ((idx = type.indexOf(';')) < 0 || (idx + 1) == type.length()) {
-            return false;
-        }
-        // we map parameter=1, pararmeter=2,.... into a map
-        Map<String, String> parameters = Arrays.asList(type.substring(idx + 1).split(","))
-                                               .stream()
-                                               .filter(e -> e.split("=").length > 1) // remove bad parameters
-                                               .map(e -> e.split("="))
-                                               .collect(Collectors.toMap(e -> ((String[]) e)[0].trim(), e -> ((String[]) e)[1]));
-        return Boolean.parseBoolean(parameters.get(Marshaller.MARSHALLER_PARAMETER_STRICT));
+        String strictParam  = (String)buildParameters(type).get(Marshaller.MARSHALLER_PARAMETER_STRICT);
+        return strictParam != null && Boolean.parseBoolean(strictParam);
     }
+    
+    public static Map<String,Object> buildParameters(String contentType)
+    {
+        int idx;
+        return ((idx = contentType.indexOf(';')) < 0 || (idx + 1) == contentType.length()) 
+                ? Collections.emptyMap() 
+                : Arrays.stream(contentType.substring(idx + 1).split(",")).
+                    filter(e -> e.split("=").length > 1) // remove bad parameters
+                    .map(e -> e.split("="))
+                    .collect(Collectors.toMap(e -> e[0].trim(), e ->  e[1].trim()));
+    }
+    
+
 
     public static MarshallingFormat fromType(String type) {
         if (startsWithIgnoreCase(type, "xstream") || startsWithIgnoreCase(type, "application/xstream")) {

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/marshal/MarshallerHelper.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/marshal/MarshallerHelper.java
@@ -15,7 +15,6 @@
 
 package org.kie.server.services.impl.marshal;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -30,15 +29,12 @@ import org.kie.server.services.api.KieContainerInstance;
 import org.kie.server.services.api.KieServerRegistry;
 import org.kie.server.services.impl.locator.ContainerLocatorProvider;
 
-import static org.kie.server.api.marshalling.Marshaller.MARSHALLER_PARAMETER_STRICT;
-import static org.kie.server.api.marshalling.MarshallingFormat.isStrictType;
-
 public class MarshallerHelper {
 
     private KieServerRegistry registry;
 
     private Map<MarshallingFormat, Marshaller> serverMarshallers = new ConcurrentHashMap<MarshallingFormat, Marshaller>();
-
+    
     public MarshallerHelper(KieServerRegistry registry) {
         this.registry = registry;
     }
@@ -67,8 +63,7 @@ public class MarshallerHelper {
             throw new IllegalArgumentException("No marshaller found for format " + format);
         }
 
-        return marshaller.marshall(entity, Collections.singletonMap(MARSHALLER_PARAMETER_STRICT, isStrictType(marshallingFormat)));
-
+        return marshaller.marshall(entity, MarshallingFormat.buildParameters(marshallingFormat));
     }
 
     public String marshal(String marshallingFormat, Object entity) {
@@ -84,8 +79,10 @@ public class MarshallerHelper {
         	serverMarshallers.put(format, marshaller);
         }
 
-        return marshaller.marshall(entity, Collections.singletonMap(MARSHALLER_PARAMETER_STRICT, isStrictType(marshallingFormat)));
+        return marshaller.marshall(entity, MarshallingFormat.buildParameters(marshallingFormat));
     }
+    
+    
     
     public <T> T unmarshal(String containerId, String data, String marshallingFormat, Class<T> unmarshalType) {
         return unmarshal(containerId, data, marshallingFormat, unmarshalType, ContainerLocatorProvider.get().getLocator());

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/marshal/MarshallerHelperTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/marshal/MarshallerHelperTest.java
@@ -15,9 +15,7 @@
 
 package org.kie.server.services.impl.marshal;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-
+import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -27,10 +25,9 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.json.JSONException;
 import org.junit.Test;
-import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
 import org.kie.server.api.marshalling.MarshallingFormat;
-import org.kie.server.api.model.definition.ProcessInstanceField;
 import org.kie.server.api.model.definition.ProcessInstanceQueryFilterSpec;
 import org.kie.server.api.model.definition.QueryFilterSpec;
 import org.kie.server.api.model.definition.TaskQueryFilterSpec;
@@ -42,6 +39,9 @@ import org.mockito.Mockito;
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.xmlunit.matchers.CompareMatcher;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class MarshallerHelperTest {
 
@@ -217,6 +217,22 @@ public class MarshallerHelperTest {
 		ProcessInstanceQueryFilterSpec unmarshalledPiQfs = helper.unmarshal(marshalledQFS, MarshallingFormat.JSON.toString(), ProcessInstanceQueryFilterSpec.class);
 		assertThat(expectedPiQfs, new ReflectionEquals(unmarshalledPiQfs));
 	}
+	
+	
+	
+	@Test
+    public void testJsonUnmarshallNotNull() throws JSONException {
+	    KieServerRegistry kieServerRegistryMock = Mockito.mock(KieServerRegistry.class);
+	    Set<Class<?>> extraClasses = new HashSet<>();
+	    // simulate server conditions
+        extraClasses.add(Date.class);
+        extraClasses.add(org.kie.server.api.model.type.JaxbByteArray.class);
+        Mockito.when(kieServerRegistryMock.getExtraClasses()).thenReturn(extraClasses);
+        MarshallerHelper helper = new MarshallerHelper(kieServerRegistryMock);
+        JSONAssert.assertEquals("{\"order-asc\" : false}", helper.marshal("application/json ; fields = not_null ", new QueryFilterSpecBuilder().get()), true);
+        // test reset
+        JSONAssert.assertEquals("{\"order-by\" : null, \"order-asc\" : false, \"query-params\" : null, \"result-column-mapping\" : null, \"order-by-clause\" : null}", helper.marshal("application/json", new QueryFilterSpecBuilder().get()),true);
+    }
 	
 	@Test
 	public void testJsonUnmarshallTaskQueryFilterSpec() {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/QueryServiceRestOnlyIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/rest/QueryServiceRestOnlyIntegrationTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.integrationtests.jbpm.rest;
+
+import java.util.Collections;
+
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.instance.ProcessInstance;
+import org.kie.server.api.model.instance.TaskSummary;
+import org.kie.server.api.rest.RestURI;
+import org.kie.server.integrationtests.config.TestConfig;
+import org.kie.server.integrationtests.shared.KieServerDeployer;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.kie.server.api.rest.RestURI.QUERY_URI;
+import static org.kie.server.api.rest.RestURI.TASK_GET_URI;
+import static org.kie.server.api.rest.RestURI.TASK_INSTANCE_ID;
+
+public class QueryServiceRestOnlyIntegrationTest extends RestJbpmBaseIntegrationTest {
+
+    protected static final String CONTAINER_ID = "definition-project";
+
+    @BeforeClass
+    public static void buildAndDeployArtifacts() {
+        KieServerDeployer.buildAndDeployCommonMavenParent();
+        KieServerDeployer.buildAndDeployMavenProjectFromResource("/kjars-sources/definition-project");
+        createContainer(CONTAINER_ID, new ReleaseId("org.kie.server.testing", "definition-project",
+                                                    "1.0.0.Final"));
+    }
+
+    @Test
+    public void testFindTaskById() throws Exception {
+        long processId = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK);
+        ProcessInstance desc = processClient.getProcessInstance(CONTAINER_ID, processId);
+        TaskSummary[] tasks = desc.getActiveUserTasks().getTasks();
+        assertTrue(tasks.length > 0);
+        WebTarget target = newRequest(RestURI.build(TestConfig.getKieServerHttpUrl(), QUERY_URI + "/" + TASK_GET_URI, Collections.singletonMap(TASK_INSTANCE_ID, tasks[0].getId())));
+        assertTrue(target.request(MediaType.APPLICATION_JSON_TYPE).get(String.class).contains("null"));
+        assertFalse(target.request().header("content-type", MediaType.APPLICATION_JSON + ";fields=not_null,strict=true").get(String.class).contains("null"));
+    }
+}


### PR DESCRIPTION
New fields "parameter" in content type. If value is non-null alternative
object mapper is used to prevent null serialization