### PR TITLE
PLANNER-1989 Fix task assigning test on Java 11

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-task-assigning/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-task-assigning/pom.xml
@@ -21,12 +21,6 @@
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-integ-tests-common</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>activation</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- kie server deps -->
@@ -34,12 +28,6 @@
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-api</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>activation</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.kie.server</groupId>
@@ -210,52 +198,6 @@
   </build>
 
   <profiles>
-    <profile>
-      <id>local-test-run</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.kie.server</groupId>
-          <artifactId>kie-server-services-common</artifactId>
-          <scope>test</scope>
-          <exclusions>
-            <exclusion>
-              <!-- Classes from this dependency already packaged in 'xml-apis:xml-apis' -->
-              <groupId>javax.xml.stream</groupId>
-              <artifactId>stax-api</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-        <dependency>
-          <groupId>org.kie.server</groupId>
-          <artifactId>kie-server-services-jbpm</artifactId>
-          <scope>test</scope>
-          <exclusions>
-            <exclusion>
-              <groupId>org.codehaus.woodstox</groupId>
-              <artifactId>woodstox-core-asl</artifactId>
-            </exclusion>
-          </exclusions>
-        </dependency>
-        <dependency>
-          <groupId>org.kie.server</groupId>
-          <artifactId>kie-server-rest-common</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.kie.server</groupId>
-          <artifactId>kie-server-rest-jbpm</artifactId>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-          <groupId>org.jbpm</groupId>
-          <artifactId>jbpm-case-mgmt-impl</artifactId>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
     <profile>
       <id>tomcat9</id>
     </profile>


### PR DESCRIPTION
- removes the exclusion of javax.activation:activation from the test classpath
- removes the local-test-run, as it's not used and drags in conflicting dependencies (e.g. javax.activation:activation-api)