### PR TITLE
Use provided scope for kjar dependencies for Kie server tests

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/definition-project/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/definition-project/pom.xml
@@ -22,8 +22,7 @@
       <groupId>org.kie</groupId>
       <artifactId>kie-api</artifactId>
       <version>${version.org.kie}</version>
-      <scope>system</scope>
-      <systemPath>${kie.api.path}</systemPath>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.xml.bind</groupId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/query-definition-project/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/query-definition-project/pom.xml
@@ -23,15 +23,13 @@
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-services-api</artifactId>
       <version>${version.org.kie}</version>
-      <scope>system</scope>
-      <systemPath>${jbpm.services.api.path}</systemPath>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.kie.soup</groupId>
       <artifactId>kie-soup-dataset-api</artifactId>
       <version>${version.org.kie}</version>
-      <scope>system</scope>
-      <systemPath>${kie.soup.dataset.api.path}</systemPath>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.xml.bind</groupId>


### PR DESCRIPTION
System scope was used in a try to speed up test execution, however without significant effect.
Provided scope is aligned with purpose of kjar dependencies.

Changes in https://github.com/kiegroup/droolsjbpm-integration/pull/2105 made build if these kjars failing unless artefacts with system scope were available in local repository. With this fix these artefacts are properly downloaded when kjar is built.