### PR TITLE
[RHPAM-2734]: syncing SB 2.2.6 deps

### DIFF
--- a/kie-spring-boot/pom.xml
+++ b/kie-spring-boot/pom.xml
@@ -34,10 +34,9 @@
 
   <properties>
     <version.org.apache.cxf>3.2.6</version.org.apache.cxf>
-    <version.me.snowdrop.narayana>2.1.0</version.me.snowdrop.narayana>
+    <!--<version.javax.validation>2.0.1.Final</version.javax.validation> use this version property value from kie-parent-->
+    <version.me.snowdrop.narayana>2.3.0</version.me.snowdrop.narayana>
     <version.org.apache.commons-dbcp2>2.4.0</version.org.apache.commons-dbcp2>
-    
-    <version.javax.validation>2.0.1.Final</version.javax.validation>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
We upgraded to Spring Boot 2.2.6.RELEASE where dependencies in KIE-SPRING-BOOT module was left behind
https://issues.redhat.com/browse/RHPAM-2734