### PR TITLE
[JBPM-9195] Case traceability from a Task Instance

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/TaskEventInstance.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/TaskEventInstance.java
@@ -50,6 +50,14 @@ public class TaskEventInstance {
 
     @XmlElement(name = "task-event-message")
     private String message;
+    
+
+    @XmlElement(name = "correlation-key")
+    private String correlationKey;
+
+    @XmlElement(name = "process-type")
+    private Integer processType;
+
 
     public TaskEventInstance() {
     }
@@ -114,6 +122,26 @@ public class TaskEventInstance {
         this.workItemId = workItemId;
     }
 
+    
+    public String getCorrelationKey() {
+        return correlationKey;
+    }
+
+    
+    public void setCorrelationKey(String correlationKey) {
+        this.correlationKey = correlationKey;
+    }
+
+    
+    public Integer getProcessType() {
+        return processType;
+    }
+
+    
+    public void setProcessType(Integer processType) {
+        this.processType = processType;
+    }
+
     public String getMessage() {
         return message;
     }
@@ -124,16 +152,8 @@ public class TaskEventInstance {
 
     @Override
     public String toString() {
-        return "TaskEventInstance{" +
-                "id=" + id +
-                ", taskId=" + taskId +
-                ", type='" + type + '\'' +
-                ", userId='" + userId + '\'' +
-                ", logTime=" + logTime +
-                ", processInstanceId=" + processInstanceId +
-                ", workItemId=" + workItemId +
-                ", message=" + message +
-                '}';
+        return "TaskEventInstance [id=" + id + ", taskId=" + taskId + ", type=" + type + ", userId=" + userId + ", logTime=" + logTime + ", processInstanceId=" + processInstanceId + ", workItemId=" + workItemId +
+               ", message=" + message + ", correlationKey=" + correlationKey + ", processType=" + processType + "]";
     }
 
     public static class Builder {
@@ -171,6 +191,16 @@ public class TaskEventInstance {
 
         public Builder workItemId(Long workItemId) {
             taskEventInstance.setWorkItemId(workItemId);
+            return this;
+        }
+
+        public Builder correlationKey(String correlationKey) {
+            taskEventInstance.setCorrelationKey(correlationKey);
+            return this;
+        }
+
+        public Builder processType (Integer processType) {
+            taskEventInstance.setProcessType(processType);
             return this;
         }
 

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/TaskInstance.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/TaskInstance.java
@@ -91,8 +91,11 @@ public class TaskInstance {
     @XmlElement(name = "task-output-data")
     private Map<String, Object> outputData;
 
-    public TaskInstance() {
-    }
+    @XmlElement(name = "correlation-key")
+    private String correlationKey;
+
+    @XmlElement(name = "process-type")
+    private Integer processType;
 
     public static Builder builder() {
         return new Builder();
@@ -306,6 +309,23 @@ public class TaskInstance {
         this.outputData = outputData;
     }
 
+    public Integer getProcessType() {
+        return processType;
+    }
+
+    public void setProcessType(Integer processType) {
+        this.processType = processType;
+    }
+
+    public String getCorrelationKey() {
+        return correlationKey;
+    }
+
+    public void setCorrelationKey(String correlationKey) {
+        this.correlationKey = correlationKey;
+    }
+
+
     @Override
     public String toString() {
         return "TaskInstance{" +
@@ -320,6 +340,8 @@ public class TaskInstance {
                 ", workItemId=" + workItemId +
                 ", slaCompliance=" + slaCompliance +
                 ", slaDueDate=" + slaDueDate  +
+                ", correlationKey=" + correlationKey +
+                ", processType=" +processType +
                 '}';
     }
 
@@ -458,6 +480,16 @@ public class TaskInstance {
 
         public Builder outputData(Map<String, Object> outputData) {
             taskInstance.setOutputData(outputData);
+            return this;
+        }
+
+        public Builder correlationKey(String correlationKey) {
+            taskInstance.setCorrelationKey(correlationKey);
+            return this;
+        }
+
+        public Builder processType(Integer processType) {
+            taskInstance.setProcessType(processType);
             return this;
         }
     }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/TaskSummary.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/TaskSummary.java
@@ -63,6 +63,10 @@ public class TaskSummary {
     private String containerId;
     @XmlElement(name = "task-parent-id")
     private Long parentId;
+    @XmlElement(name = "correlation-key")
+    private String correlationKey;
+    @XmlElement(name = "process-type")
+    private Integer processType;
 
     public static Builder builder() {
         return new Builder();
@@ -195,6 +199,22 @@ public class TaskSummary {
     public void setParentId(Long parentId) {
         this.parentId = parentId;
     }
+    
+    public Integer getProcessType() {
+        return processType;
+    }
+
+    public void setProcessType(Integer processType) {
+        this.processType = processType;
+    }
+
+    public String getCorrelationKey() {
+        return correlationKey;
+    }
+
+    public void setCorrelationKey(String correlationKey) {
+        this.correlationKey = correlationKey;
+    }
 
     @Override
     public String toString() {
@@ -209,6 +229,8 @@ public class TaskSummary {
                 ", processInstanceId=" + processInstanceId +
                 ", processId='" + processId + '\'' +
                 ", containerId='" + containerId + '\'' +
+                ", correlationKey=" + correlationKey +
+                ", processType=" +processType +
                 '}';
     }
 
@@ -313,6 +335,16 @@ public class TaskSummary {
         public Builder taskParentId(Long parentId) {
             taskSummary.setParentId(parentId);
 
+            return this;
+        }
+        
+        public Builder correlationKey(String correlationKey) {
+            taskSummary.setCorrelationKey(correlationKey);
+            return this;
+        }
+
+        public Builder processType(Integer processType) {
+            taskSummary.setProcessType(processType);
             return this;
         }
     }

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/ConvertUtils.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/ConvertUtils.java
@@ -430,6 +430,8 @@ public class ConvertUtils {
                 .slaDueDate(userTask.getSlaDueDate())
                 .formName(userTask.getFormName())
                 .subject(userTask.getSubject())
+                .processType(userTask.getProcessType())
+                .correlationKey(userTask.getCorrelationKey())
                 .build();
 
         return instance;
@@ -496,7 +498,7 @@ public class ConvertUtils {
     }
 
     public static org.kie.server.api.model.instance.TaskSummary convertToTaskSummary(TaskSummary taskSummary) {
-        org.kie.server.api.model.instance.TaskSummary task = org.kie.server.api.model.instance.TaskSummary.builder()
+        return org.kie.server.api.model.instance.TaskSummary.builder()
                 .id(taskSummary.getId())
                 .name(taskSummary.getName())
                 .description(taskSummary.getDescription())
@@ -514,8 +516,8 @@ public class ConvertUtils {
                 .status(taskSummary.getStatusId())
                 .skipable(taskSummary.isSkipable())
                 .subject(taskSummary.getSubject())
-                .build();
-        return task;
+                .correlationKey(taskSummary.getCorrelationKey())
+                .processType(taskSummary.getProcessType()).build();
     }
 
     public static QueryDefinition convertQueryDefinition(org.jbpm.services.api.query.model.QueryDefinition queryDefinition) {

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/RuntimeDataServiceBase.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/RuntimeDataServiceBase.java
@@ -596,6 +596,8 @@ public class RuntimeDataServiceBase {
                         .user(taskSummary.getUserId())
                         .workItemId(taskSummary.getWorkItemId())
                         .message(taskSummary.getMessage())
+                        .correlationKey(taskSummary.getCorrelationKey())
+                        .processType(taskSummary.getProcessType())
                         .build();
                 instances[counter] = task;
                 counter++;

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/test/java/org/kie/server/services/jbpm/ConvertUtilsTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/test/java/org/kie/server/services/jbpm/ConvertUtilsTest.java
@@ -33,7 +33,7 @@ public class ConvertUtilsTest {
         UserTaskInstanceDesc userTaskWithSla =
                 new UserTaskInstanceDesc(Long.valueOf(1), "Ready", testDate, "Task1_name", "Task1_desc", 1,
                                          "Task1_Owner", "Task1_Creator", "deployment", "Process", 1L, testDate,
-                                         testDate, 1L, "formName-1", "subject-1", testDate, ProcessInstance.SLA_PENDING);
+                                         testDate, 1L, "formName-1", "subject-1", "1", 1, testDate, ProcessInstance.SLA_PENDING);
         UserTaskInstanceDesc userTask =
                 new UserTaskInstanceDesc(Long.valueOf(1), "Ready", testDate, "Task1_name", "Task1_desc", 1,
                                          "Task1_Owner", "Task1_Creator", "deployment", "Process", 1L, testDate,
@@ -61,5 +61,7 @@ public class ConvertUtilsTest {
         assertEquals(userTask.getSlaCompliance(), taskInstance.getSlaCompliance());
         assertEquals(userTask.getSubject(), taskInstance.getSubject());
         assertEquals(userTask.getFormName(), taskInstance.getFormName());
+        assertEquals(userTask.getCorrelationKey(), taskInstance.getCorrelationKey());
+        assertEquals(userTask.getProcessType(), taskInstance.getProcessType());
     }
 }


### PR DESCRIPTION
Depends on [jbpm:1689](https://github.com/kiegroup/jbpm/pull/1680) and https://github.com/kiegroup/droolsjbpm-knowledge/pull/447

correlationKey and processType has been added to TaskInstance and
TaskSummary