### PR TITLE
[7.39.x] Fix DMNLocalDateIntegrationTest execution on Java 11

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/common-parent/pom.xml
@@ -15,6 +15,16 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.jboss.spec.javax.xml.bind</groupId>
+        <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+        <version>${version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.3_spec}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <pluginManagement>
       <plugins>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/local-date-unary-check/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/local-date-unary-check/pom.xml
@@ -22,6 +22,11 @@
       <version>${version.org.kie}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.3_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
 </dependencies>
 
   <build>


### PR DESCRIPTION
Cherrypick of https://github.com/kiegroup/droolsjbpm-integration/pull/2135
Affects just tests.