### PR TITLE
Use container.profile property to activate tests for application server

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/pom.xml
@@ -305,21 +305,57 @@
     </profile>
     <profile>
       <id>tomcat9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>tomcat9</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>wildfly</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>wildfly</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>eap7</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>eap7</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>oracle-wls-12</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>oracle-wls-12</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>websphere9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>websphere9</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>springboot</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>springboot</value>
+        </property>
+      </activation>
       <properties>
         <kieserver.drools.enabled>true</kieserver.drools.enabled>
         <kieserver.dmn.enabled>true</kieserver.dmn.enabled>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-case-id-generator/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-case-id-generator/pom.xml
@@ -175,6 +175,12 @@
   <profiles>
     <profile>
       <id>tomcat9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>tomcat9</value>
+        </property>
+      </activation>
       <build>
         <pluginManagement>
           <plugins>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/pom.xml
@@ -192,6 +192,12 @@
     </profile>
     <profile>
       <id>tomcat9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>tomcat9</value>
+        </property>
+      </activation>
       <properties>
         <kie.server.controller.classifier>webc</kie.server.controller.classifier>
       </properties>
@@ -205,6 +211,12 @@
     </profile>
     <profile>
       <id>wildfly</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>wildfly</value>
+        </property>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>io.undertow</groupId>
@@ -215,6 +227,12 @@
     </profile>
     <profile>
       <id>eap7</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>eap7</value>
+        </property>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>io.undertow</groupId>
@@ -225,6 +243,12 @@
     </profile>
     <profile>
       <id>oracle-wls-12</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>oracle-wls-12</value>
+        </property>
+      </activation>
       <dependencyManagement>
         <dependencies>
          <dependency>
@@ -274,6 +298,12 @@
     </profile>
     <profile>
       <id>websphere9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>websphere9</value>
+        </property>
+      </activation>
       <dependencies>
         <dependency>
           <groupId>io.undertow</groupId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-custom-extension/kie-server-integ-tests-custom-extension-test/pom.xml
@@ -170,6 +170,12 @@
   <profiles>
     <profile>
       <id>tomcat9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>tomcat9</value>
+        </property>
+      </activation>
       <build>
         <pluginManagement>
           <plugins>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/pom.xml
@@ -237,21 +237,57 @@
     </profile>
     <profile>
       <id>tomcat9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>tomcat9</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>wildfly</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>wildfly</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>eap7</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>eap7</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>oracle-wls-12</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>oracle-wls-12</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>websphere9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>websphere9</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>springboot</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>springboot</value>
+        </property>
+      </activation>
       <properties>
         <kieserver.drools.enabled>true</kieserver.drools.enabled>
         <kieserver.dmn.enabled>true</kieserver.dmn.enabled>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
@@ -213,21 +213,57 @@
     </profile>
     <profile>
       <id>tomcat9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>tomcat9</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>wildfly</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>wildfly</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>eap7</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>eap7</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>oracle-wls-12</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>oracle-wls-12</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>websphere9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>websphere9</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>springboot</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>springboot</value>
+        </property>
+      </activation>
       <properties>
         <kieserver.drools.enabled>true</kieserver.drools.enabled>
         <kieserver.prometheus.enabled>true</kieserver.prometheus.enabled>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/pom.xml
@@ -306,9 +306,21 @@
     </profile>
     <profile>
       <id>tomcat9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>tomcat9</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>wildfly</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>wildfly</value>
+        </property>
+      </activation>
       <build>
         <pluginManagement>
           <plugins>
@@ -349,6 +361,12 @@
     </profile>
     <profile>
       <id>eap7</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>eap7</value>
+        </property>
+      </activation>
       <build>
         <pluginManagement>
           <plugins>
@@ -389,6 +407,12 @@
     </profile>
     <profile>
       <id>oracle-wls-12</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>oracle-wls-12</value>
+        </property>
+      </activation>
       <build>
         <pluginManagement>
           <plugins>
@@ -429,6 +453,12 @@
     </profile>
     <profile>
       <id>websphere9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>websphere9</value>
+        </property>
+      </activation>
       <build>
         <pluginManagement>
           <plugins>
@@ -478,6 +508,12 @@
     </profile>
     <profile>
       <id>springboot</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>springboot</value>
+        </property>
+      </activation>
       <properties>
         <kieserver.jbpm.enabled>true</kieserver.jbpm.enabled>
         <jbpm.executor.enabled>true</jbpm.executor.enabled>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/pom.xml
@@ -217,21 +217,57 @@
     </profile>
     <profile>
       <id>tomcat9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>tomcat9</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>wildfly</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>wildfly</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>eap7</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>eap7</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>oracle-wls-12</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>oracle-wls-12</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>websphere9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>websphere9</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>springboot</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>springboot</value>
+        </property>
+      </activation>
       <properties>
         <kieserver.drools.enabled>true</kieserver.drools.enabled>
         <kieserver.optaplanner.enabled>true</kieserver.optaplanner.enabled>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-policy/pom.xml
@@ -253,21 +253,57 @@
     </profile>
     <profile>
       <id>tomcat9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>tomcat9</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>wildfly</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>wildfly</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>eap7</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>eap7</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>oracle-wls-12</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>oracle-wls-12</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>websphere9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>websphere9</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>springboot</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>springboot</value>
+        </property>
+      </activation>
       <properties>
         <kieserver.drools.enabled>true</kieserver.drools.enabled>
         <kieserver.jbpm.enabled>true</kieserver.jbpm.enabled>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-router/pom.xml
@@ -290,18 +290,48 @@
     </profile>
     <profile>
       <id>tomcat9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>tomcat9</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>wildfly</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>wildfly</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>eap7</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>eap7</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>oracle-wls-12</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>oracle-wls-12</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>websphere9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>websphere9</value>
+        </property>
+      </activation>
     </profile>
   </profiles>
 </project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-scenario-simulation/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-scenario-simulation/pom.xml
@@ -240,21 +240,57 @@
     </profile>
     <profile>
       <id>tomcat9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>tomcat9</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>wildfly</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>wildfly</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>eap7</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>eap7</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>oracle-wls-12</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>oracle-wls-12</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>websphere9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>websphere9</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>springboot</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>springboot</value>
+        </property>
+      </activation>
       <properties>
         <kieserver.drools.enabled>true</kieserver.drools.enabled>
         <kieserver.dmn.enabled>true</kieserver.dmn.enabled>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-task-assigning/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-task-assigning/pom.xml
@@ -205,21 +205,57 @@
   <profiles>
     <profile>
       <id>tomcat9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>tomcat9</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>wildfly</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>wildfly</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>eap7</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>eap7</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>oracle-wls-12</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>oracle-wls-12</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>websphere9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>websphere9</value>
+        </property>
+      </activation>
     </profile>
     <profile>
       <id>springboot</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>springboot</value>
+        </property>
+      </activation>
       <properties>
         <kieserver.jbpm.enabled>true</kieserver.jbpm.enabled>
         <kieserver.jbpmui.enabled>false</kieserver.jbpmui.enabled>

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -584,6 +584,12 @@
     </profile>
     <profile>
       <id>tomcat9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>tomcat9</value>
+        </property>
+      </activation>
       <properties>
         <org.kie.server.persistence.ds>java:comp/env/jbpmDs</org.kie.server.persistence.ds>
         <kie.server.classifier>webc</kie.server.classifier>
@@ -755,6 +761,12 @@
     </profile>
     <profile>
       <id>wildfly</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>wildfly</value>
+        </property>
+      </activation>
       <properties>
         <kie.server.remoting.url>http-remoting://${container.hostname}:${container.port}</kie.server.remoting.url>
         <kie.server.context.factory>org.wildfly.naming.client.WildFlyInitialContextFactory</kie.server.context.factory>
@@ -918,6 +930,12 @@
     </profile>
     <profile>
       <id>eap7</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>eap7</value>
+        </property>
+      </activation>
       <properties>
         <kie.server.remoting.url>http-remoting://${container.hostname}:${container.port}</kie.server.remoting.url>
         <org.kie.server.persistence.ds>java:jboss/datasources/ExampleDS</org.kie.server.persistence.ds>
@@ -1058,6 +1076,12 @@
     </profile>
     <profile>
       <id>oracle-wls-12</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>oracle-wls-12</value>
+        </property>
+      </activation>
       <properties>
         <kie.server.remoting.url>t3://${container.hostname}:${container.port}</kie.server.remoting.url>
         <kie.server.context.factory>weblogic.jndi.WLInitialContextFactory</kie.server.context.factory>
@@ -1180,6 +1204,12 @@
     </profile>
     <profile>
       <id>websphere9</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>websphere9</value>
+        </property>
+      </activation>
       <properties>
         <container.port>9080</container.port>
         <kie.server.remoting.url>iiop://${container.hostname}:2809</kie.server.remoting.url>
@@ -1325,6 +1355,12 @@
     </profile>
     <profile>
       <id>springboot</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>springboot</value>
+        </property>
+      </activation>
       <properties>
         <!-- By default disable everything, enable what is needed in child POMs-->
         <kieserver.drools.enabled>false</kieserver.drools.enabled>

--- a/process-migration-service/pom.xml
+++ b/process-migration-service/pom.xml
@@ -576,6 +576,12 @@
   <profiles>
     <profile>
       <id>wildfly</id>
+      <activation>
+        <property>
+          <name>container.profile</name>
+          <value>wildfly</value>
+        </property>
+      </activation>
       <properties>
         <cargo.container.id>wildfly18x</cargo.container.id>
         <org.kie.server.persistence.ds>java:/jdbc/jbpm</org.kie.server.persistence.ds>


### PR DESCRIPTION
By using container.profile for triggering of integration tests this repository will align with integration tests in jbpm repository.
It will also fix the current PR check issue caused by missing `wildfly` profile in Maven command.