### PR TITLE
kie-performance-kit: Use the default test package if the provided one…

### DIFF
--- a/kie-performance-kit/src/main/java/org/kie/perf/TestConfig.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/TestConfig.java
@@ -86,7 +86,10 @@ public class TestConfig {
         }
         properties.put("startScriptLocation", startScriptLocation);
 
-        testPackage = System.getProperty("org.kie.perf.suite.test-package", DEFAULT_TEST_PACKAGE);
+        testPackage = System.getProperty("org.kie.perf.suite.test-package");
+        if (testPackage == null || testPackage.isEmpty()) {
+            testPackage = DEFAULT_TEST_PACKAGE;
+        }
         properties.put("org.kie.perf.suite.test-package", testPackage);
 
         runType = RunType.valueOf(System.getProperty("runType").toUpperCase());


### PR DESCRIPTION
… is null or empty

Unfortunately, even the [empty property](https://github.com/kiegroup/kie-benchmarks/blob/master/jbpm-benchmarks/kieserver-performance-tests/pom.xml#L25) is a property so kie-performance-kit saw it as a set property. I made it more robust by ignoring even the empty string. jBPM performance tests were fine as they don't define the Maven property at all.