### PR TITLE
[JBPM-9264] Provide alternative to oid column in Postgres (bytea)

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/pom.xml
@@ -42,6 +42,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    
+    <dependency>
+    <groupId>org.hibernate</groupId>
+    <artifactId>hibernate-core</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.kie.server</groupId>
       <artifactId>kie-server-services-common</artifactId>

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/jpa/PostgreSQLByteaTypeContributor.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/jpa/PostgreSQLByteaTypeContributor.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/**
+ * this class allows to override the use of oid vs bytea
+ */
+package org.kie.server.services.jbpm.jpa;
+
+import org.hibernate.boot.model.TypeContributions;
+import org.hibernate.boot.model.TypeContributor;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.type.StandardBasicTypeTemplate;
+import org.hibernate.type.descriptor.java.PrimitiveByteArrayTypeDescriptor;
+import org.hibernate.type.descriptor.sql.BinaryTypeDescriptor;
+
+
+public class PostgreSQLByteaTypeContributor implements TypeContributor {
+
+    public class ByteaContributorType extends StandardBasicTypeTemplate<byte[]> {
+
+        private static final long serialVersionUID = 1619875355308645967L;
+
+        public ByteaContributorType() {
+            super(BinaryTypeDescriptor.INSTANCE, PrimitiveByteArrayTypeDescriptor.INSTANCE, "materialized_blob");
+        }
+
+    }
+
+    @Override
+    public void contribute(TypeContributions typeContributions, ServiceRegistry serviceRegistry) {
+        final Dialect dialect = serviceRegistry.getService(JdbcServices.class).getDialect();
+        if (dialect instanceof org.hibernate.dialect.PostgreSQL81Dialect && Boolean.getBoolean("org.kie.persistence.postgresql.useBytea")) {
+            typeContributions.contributeType(new ByteaContributorType());
+        }
+
+    }
+
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/resources/META-INF/services/org.hibernate.boot.model.TypeContributor
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/resources/META-INF/services/org.hibernate.boot.model.TypeContributor
@@ -1,0 +1,1 @@
+org.kie.server.services.jbpm.jpa.PostgreSQLByteaTypeContributor


### PR DESCRIPTION
added a flag and a type contributor to kie server to use bytea instead of oid
for blobs