### PR TITLE
[JBPM-9237][7.39.x] Test queries with columns 'PROCESS_INST_ID', 'ACTIVITY_ID'

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/query-definition-project/src/main/resources/query-definitions.json
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/filtered-resources/kjars-sources/query-definition-project/src/main/resources/query-definitions.json
@@ -12,5 +12,17 @@
     "query-expression" : "select * from NodeInstanceLog",
     "query-target" : "CUSTOM"
 
+  },
+  {
+    "query-name": "jbpmProcessInstances",
+    "query-source": "${org.kie.server.persistence.ds}",
+    "query-expression": "select log.processInstanceId, log.processId, log.start_date, log.end_date, log.status, log.parentProcessInstanceId, log.outcome, log.duration, log.user_identity, log.processVersion, log.processName, log.correlationKey, log.externalId, log.processInstanceDescription, log.sla_due_date, log.slaCompliance, COALESCE(info.lastModificationDate, log.end_date) as lastModificationDate, (select COUNT(errInfo.id) from ExecutionErrorInfo errInfo where errInfo.PROCESS_INST_ID=log.processInstanceId and errInfo.ERROR_ACK=0) as errorCount from ProcessInstanceLog log left join ProcessInstanceInfo info on info.InstanceId=log.processInstanceId",
+    "query-target": "CUSTOM"
+  },
+  {
+    "query-name": "jbpmHumanTasksWithAdmin",
+    "query-source": "${org.kie.server.persistence.ds}",
+    "query-expression": "select t.activationTime, t.actualOwner, t.createdBy, t.createdOn, t.deploymentId, t.description, t.dueDate, t.name, t.parentId, t.priority, t.processId, t.processInstanceId, t.processSessionId, t.status, t.taskId, t.workItemId, t.lastModificationDate, pil.correlationKey, pil.processInstanceDescription ,oe.id, nil.sla_due_date, nil.slaCompliance, (select COUNT(errInfo.id) from ExecutionErrorInfo errInfo where errInfo.ACTIVITY_ID = t.taskId and errInfo.PROCESS_INST_ID = pil.processInstanceId and errInfo.ERROR_ACK = 0 and errInfo.ERROR_TYPE = 'Task') as errorCount from AuditTaskImpl t  left join ProcessInstanceLog pil on pil.processInstanceId = t.processInstanceId left join PeopleAssignments_BAs ba on t.taskId = ba.task_id left join OrganizationalEntity oe on ba.entity_id = oe.id left join NodeInstanceLog nil on nil.workItemId=t.workItemId",
+    "query-target": "FILTERED_BA_TASK"
   }
 ]

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -1050,6 +1051,32 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
         }
 
 
+    }
+    
+    @Test
+    public void testDefaultQueryJbpmProcessInstances() {
+        Map<String, Object> parameters = new HashMap<>();
+        parameters.put("stringData", "waiting for signal");
+        parameters.put("personData", createPersonInstance(USER_JOHN));
+
+        List<Long> processInstanceIds = createProcessInstances(parameters);
+
+        QueryDefinition registeredQuery = queryClient.getQuery("jbpmProcessInstances");
+        
+        try {
+            List<ProcessInstance> instances = queryClient.query(registeredQuery.getName(), QueryServicesClient.QUERY_MAP_PI, 0, 10, ProcessInstance.class);
+            assertNotNull(instances);
+        } finally {
+            abortProcessInstances(processInstanceIds);
+        }
+    }
+    
+    @Test
+    public void testDefaultQueryJbpmHumanTasksWithAdmin() {
+        QueryDefinition registeredQuery = queryClient.getQuery("jbpmHumanTasksWithAdmin");
+        
+        List<TaskInstance> tasks = queryClient.query(registeredQuery.getName(), QueryServicesClient.QUERY_MAP_TASK, 0, 10, TaskInstance.class);
+        assertNotNull(tasks);
     }
 
     protected QueryDefinition getProcessInstanceWithVariablesQueryDefinition() {


### PR DESCRIPTION
for case-sensitive dbs

Backport from [droolsjbpm-integration#2157](https://github.com/kiegroup/droolsjbpm-integration/pull/2157)