### PR TITLE
JBPM-9231: removed exclusion for batik-ext

### DIFF
--- a/jbpm-process-svg/pom.xml
+++ b/jbpm-process-svg/pom.xml
@@ -25,10 +25,6 @@
       <artifactId>batik-anim</artifactId>
       <exclusions>
         <exclusion>
-          <groupId>org.apache.xmlgraphics</groupId>
-          <artifactId>batik-ext</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>commons-logging</groupId>
           <artifactId>commons-logging</artifactId>
         </exclusion>


### PR DESCRIPTION
https://issues.redhat.com/browse/JBPM-9231
parent PR https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1395