### PR TITLE
JBPM-9286 UI error when parent process instance details have been rem…

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
@@ -210,6 +210,27 @@ public abstract class AbstractKieServicesClientImpl {
         }
     }
 
+    protected <T> T makeHttpGetRequestAndCreateCustomResponseWithHandleNotFound(String uri, Class<T> resultType) {
+        logger.debug("About to send GET request to '{}'", uri);
+        KieServerHttpRequest request = invoke(uri, new RemoteHttpOperation() {
+            @Override
+            public KieServerHttpRequest doOperation(String url) {
+                return newRequest(url).get();
+            }
+        });
+        KieServerHttpResponse response = request.response();
+
+        owner.setConversationId(response.header(KieServerConstants.KIE_CONVERSATION_ID_TYPE_HEADER));
+        if (response.code() == Response.Status.NOT_FOUND.getStatusCode()) {
+            return null;
+        }
+        if (response.code() == Response.Status.OK.getStatusCode()) {
+            return deserialize(response.body(), resultType);
+        } else {
+            throw createExceptionForUnexpectedResponseCode(request, response);
+        }
+    }
+
     protected String makeHttpGetRequestAndCreateRawResponse(String uri) {
         logger.debug("About to send GET request to '{}'", uri);
         KieServerHttpRequest request = invoke(uri, new RemoteHttpOperation() {

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/QueryServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/QueryServicesClientImpl.java
@@ -110,8 +110,7 @@ public class QueryServicesClientImpl extends AbstractKieServicesClientImpl imple
             Map<String, Object> valuesMap = new HashMap<String, Object>();
             valuesMap.put(PROCESS_ID, processId);
 
-            result = makeHttpGetRequestAndCreateCustomResponse(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_DEFINITIONS_BY_ID_GET_URI, valuesMap), ProcessDefinitionList.class);
-
+            result = makeHttpGetRequestAndCreateCustomResponseWithHandleNotFound(build(loadBalancer.getUrl(), QUERY_URI + "/" + PROCESS_DEFINITIONS_BY_ID_GET_URI, valuesMap), ProcessDefinitionList.class);
         } else {
             CommandScript script = new CommandScript(Collections.singletonList((KieServerCommand) new DescriptorCommand("QueryService", "getProcessesById", new Object[]{processId})));
             ServiceResponse<ProcessDefinitionList> response = (ServiceResponse<ProcessDefinitionList>) executeJmsCommand(script, DescriptorCommand.class.getName(), "BPM").getResponses().get(0);


### PR DESCRIPTION
…oved

**Thank you for submitting this pull request**

**JIRA**: _(JBPM-9286)_ 

[link](https://issues.redhat.com/browse/JBPM-9286)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

paste the link(s) from GitHub here

**How to retest or run**:

* a pull request please add comment: regex **[.\*[j|J]enkins,?.\*(retest|test) this.\*]**

* a full downstream build please add comment: regex **[.*\[j|J]enkins,?.\*(execute|run|trigger|start|do) fdb.\*]**

* a compile downstream build please  add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) cdb.\*]**

* a full production downstream please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) product fdb.\*]**

* an upstream build please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) upstream.\*]**

i.e for running a full downstream build =  **Jenkins do fdb**
