### PR TITLE
Dynamically allocate WildFly/EAP ports for integration tests

### DIFF
--- a/camel-container-tests/camel-container-integration-tests/pom.xml
+++ b/camel-container-tests/camel-container-integration-tests/pom.xml
@@ -130,6 +130,27 @@
           </systemProperties>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>reserve-network-port</id>
+            <goals>
+              <goal>reserve-network-port</goal>
+            </goals>
+            <phase>generate-resources</phase>
+            <configuration>
+              <portNames>
+                <portName>cargo.jboss.ajp.port</portName>
+                <portName>cargo.jboss.https.port</portName>
+                <portName>cargo.jboss.management-http.port</portName>
+                <portName>cargo.jboss.management-https.port</portName>
+              </portNames>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 
@@ -214,7 +235,10 @@
                 <properties>
                   <cargo.jboss.configuration>standalone-full-camel</cargo.jboss.configuration>
                   <cargo.servlet.port>${container.port}</cargo.servlet.port>
-
+                  <cargo.jboss.ajp.port>${cargo.jboss.ajp.port}</cargo.jboss.ajp.port>
+                  <cargo.jboss.https.port>${cargo.jboss.https.port}</cargo.jboss.https.port>
+                  <cargo.jboss.management-http.port>${cargo.jboss.management-http.port}</cargo.jboss.management-http.port>
+                  <cargo.jboss.management-https.port>${cargo.jboss.management-https.port}</cargo.jboss.management-https.port>
                   <!--
                   <cargo.start.jvmargs>
                     -Xdebug
@@ -308,6 +332,10 @@
                 <properties>
                   <cargo.jboss.configuration>standalone-full</cargo.jboss.configuration>
                   <cargo.jvmargs>-Djava.net.preferIPv4Stack=true</cargo.jvmargs>
+                  <cargo.jboss.ajp.port>${cargo.jboss.ajp.port}</cargo.jboss.ajp.port>
+                  <cargo.jboss.https.port>${cargo.jboss.https.port}</cargo.jboss.https.port>
+                  <cargo.jboss.management-http.port>${cargo.jboss.management-http.port}</cargo.jboss.management-http.port>
+                  <cargo.jboss.management-https.port>${cargo.jboss.management-https.port}</cargo.jboss.management-https.port>
                 </properties>
                 <users>
                   <user>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/config/TestConfig.java
@@ -77,6 +77,8 @@ public class TestConfig {
     private static final StringTestParameter CARGO_REMOTE_PASSWORD = new StringTestParameter("cargo.remote.password");
     private static final StringTestParameter KIE_SERVER_WAR_PATH = new StringTestParameter("kie.server.war.path");
 
+    private static final StringTestParameter JBOSS_MANAGEMENT_PORT = new StringTestParameter("cargo.jboss.management-http.port");
+
     private static final StringTestParameter WEBLOGIC_HOME = new StringTestParameter("weblogic.home");
 
     private static final StringTestParameter JMS_SKIP = new StringTestParameter("jms.skip");
@@ -399,6 +401,20 @@ public class TestConfig {
      */
     public static String getContainerPort() {
         return TestConfig.CONTAINER_PORT.getParameterValue();
+    }
+
+    /**
+     * @return JBoss management port.
+     */
+    public static String getJbossManagementPort() {
+        return TestConfig.JBOSS_MANAGEMENT_PORT.getParameterValue();
+    }
+
+    /**
+     * @return True if JBoss management port is provided.
+     */
+    public static boolean isJbossManagementPortProvided() {
+        return TestConfig.JBOSS_MANAGEMENT_PORT.isParameterConfigured();
     }
 
     /**

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/controller/ContainerRemoteController.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/controller/ContainerRemoteController.java
@@ -23,6 +23,7 @@ import org.codehaus.cargo.container.configuration.ConfigurationType;
 import org.codehaus.cargo.container.deployable.DeployableType;
 import org.codehaus.cargo.container.deployable.WAR;
 import org.codehaus.cargo.container.deployer.Deployer;
+import org.codehaus.cargo.container.jboss.JBossPropertySet;
 import org.codehaus.cargo.container.property.RemotePropertySet;
 import org.codehaus.cargo.container.property.ServletPropertySet;
 import org.codehaus.cargo.container.weblogic.WebLogicPropertySet;
@@ -47,6 +48,9 @@ public class ContainerRemoteController {
 
         configuration.setProperty(ServletPropertySet.PORT, containerPort);
 
+        if(TestConfig.isJbossManagementPortProvided()) {
+            configuration.setProperty(JBossPropertySet.JBOSS_MANAGEMENT_HTTP_PORT, TestConfig.getJbossManagementPort());
+        }
         if(TestConfig.isCargoRemoteUsernameProvided()) {
             configuration.setProperty(RemotePropertySet.USERNAME, TestConfig.getCargoRemoteUsername());
         }

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -407,6 +407,10 @@
             <configuration>
               <portNames>
                 <portName>container.port</portName>
+                <portName>cargo.jboss.ajp.port</portName>
+                <portName>cargo.jboss.https.port</portName>
+                <portName>cargo.jboss.management-http.port</portName>
+                <portName>cargo.jboss.management-https.port</portName>
               </portNames>
             </configuration>
           </execution>
@@ -813,6 +817,10 @@
                        cargo.resource.id=mail|
                        cargo.resource.parameters=mail.smtp.host=localhost;mail.smtp.port=2525;mail.smtp.from=kie-server-test@domain.com
                     </cargo.resource.resource.mail>
+                    <cargo.jboss.ajp.port>${cargo.jboss.ajp.port}</cargo.jboss.ajp.port>
+                    <cargo.jboss.https.port>${cargo.jboss.https.port}</cargo.jboss.https.port>
+                    <cargo.jboss.management-http.port>${cargo.jboss.management-http.port}</cargo.jboss.management-http.port>
+                    <cargo.jboss.management-https.port>${cargo.jboss.management-https.port}</cargo.jboss.management-https.port>
                   </properties>
                   <datasources>
                     <datasource>
@@ -835,6 +843,7 @@
                   <!-- Reuse yoda user for deploying and undeploying Kie server from within the test -->
                   <cargo.remote.username>yoda</cargo.remote.username>
                   <cargo.remote.password>usetheforce123@</cargo.remote.password>
+                  <cargo.jboss.management-http.port>${cargo.jboss.management-http.port}</cargo.jboss.management-http.port>
                 </systemPropertyVariables>
               </configuration>
             </plugin>
@@ -974,6 +983,10 @@
                        cargo.resource.id=mail|
                        cargo.resource.parameters=mail.smtp.host=localhost;mail.smtp.port=2525;mail.smtp.from=kie-server-test@domain.com
                     </cargo.resource.resource.mail>
+                    <cargo.jboss.ajp.port>${cargo.jboss.ajp.port}</cargo.jboss.ajp.port>
+                    <cargo.jboss.https.port>${cargo.jboss.https.port}</cargo.jboss.https.port>
+                    <cargo.jboss.management-http.port>${cargo.jboss.management-http.port}</cargo.jboss.management-http.port>
+                    <cargo.jboss.management-https.port>${cargo.jboss.management-https.port}</cargo.jboss.management-https.port>
                   </properties>
                 </configuration>
               </configuration>
@@ -986,6 +999,7 @@
                   <!-- Reuse yoda user for deploying and undeploying Kie server from within the test -->
                   <cargo.remote.username>yoda</cargo.remote.username>
                   <cargo.remote.password>usetheforce123@</cargo.remote.password>
+                  <cargo.jboss.management-http.port>${cargo.jboss.management-http.port}</cargo.jboss.management-http.port>
                 </systemPropertyVariables>
               </configuration>
             </plugin>

--- a/process-migration-service/pom.xml
+++ b/process-migration-service/pom.xml
@@ -26,7 +26,9 @@
          SNAPSHOT tests against Beta3 WAR) so the tests actually know what exact version of server is being tested -->
     <kie.server.version>${project.version}</kie.server.version>
     <container.hostname>localhost</container.hostname>
-    <container.port>19090</container.port>
+    <!-- <container.port/> can't define the default port value, because the build-helper-maven-plugin:reserve-network-port
+         is not able to override the value of the property. The port number would then always be the same
+         (the default one, unless changed from outside) -->
     <kie.server.context>kie-server</kie.server.context>
     <cargo.container.id>valid-id-needs-to-be-specified-in-appropriate-container-profile</cargo.container.id>
     <kie.server.classifier>ee8</kie.server.classifier>
@@ -429,6 +431,28 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>reserve-network-port</id>
+            <goals>
+              <goal>reserve-network-port</goal>
+            </goals>
+            <phase>generate-resources</phase>
+            <configuration>
+              <portNames>
+                <portName>container.port</portName>
+                <portName>cargo.jboss.ajp.port</portName>
+                <portName>cargo.jboss.https.port</portName>
+                <portName>cargo.jboss.management-http.port</portName>
+                <portName>cargo.jboss.management-https.port</portName>
+              </portNames>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.cargo</groupId>
         <artifactId>cargo-maven2-plugin</artifactId>
         <configuration>
@@ -604,6 +628,10 @@
                   <cargo.jboss.management-http.port>19991</cargo.jboss.management-http.port>
                   <cargo.jboss.configuration>standalone-full</cargo.jboss.configuration>
                   <cargo.jvmargs>-Xmx1024m</cargo.jvmargs>
+                  <cargo.jboss.ajp.port>${cargo.jboss.ajp.port}</cargo.jboss.ajp.port>
+                  <cargo.jboss.https.port>${cargo.jboss.https.port}</cargo.jboss.https.port>
+                  <cargo.jboss.management-http.port>${cargo.jboss.management-http.port}</cargo.jboss.management-http.port>
+                  <cargo.jboss.management-https.port>${cargo.jboss.management-https.port}</cargo.jboss.management-https.port>
                 </properties>
                 <datasources>
                   <datasource>


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

paste the link(s) from GitHub here

**How to retest or run**:

* a pull request please add comment: regex **[.\*[j|J]enkins,?.\*(retest|test) this.\*]**

* a full downstream build please add comment: regex **[.*\[j|J]enkins,?.\*(execute|run|trigger|start|do) fdb.\*]**

* a compile downstream build please  add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) cdb.\*]**

* a full production downstream please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) product fdb.\*]**

* an upstream build please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) upstream.\*]**

i.e for running a full downstream build =  **Jenkins do fdb**
