### PR TITLE
DROOLS-5578: Kie Server uses obselete/to be deleted Java APIs

### DIFF
--- a/drools-ha/ha-core-infra/src/main/java/org/kie/hacep/core/infra/election/LeaderElectionImpl.java
+++ b/drools-ha/ha-core-infra/src/main/java/org/kie/hacep/core/infra/election/LeaderElectionImpl.java
@@ -16,6 +16,7 @@
 package org.kie.hacep.core.infra.election;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -195,7 +196,7 @@ public class LeaderElectionImpl implements LeaderElection {
                         logPrefix(),
                         new BigDecimal(delay).divide(BigDecimal.valueOf(1000),
                                                      2,
-                                                     BigDecimal.ROUND_HALF_UP));
+                                                     RoundingMode.HALF_UP));
         }
         try {
             Thread.sleep(delay);

--- a/jbpm-simulation/src/main/java/org/jbpm/simulation/converter/SimulationFilterPathFormatConverter.java
+++ b/jbpm-simulation/src/main/java/org/jbpm/simulation/converter/SimulationFilterPathFormatConverter.java
@@ -82,7 +82,7 @@ public class SimulationFilterPathFormatConverter implements
                             }
                         }
                         BigDecimal bd = new BigDecimal(probability);
-                        bd = bd.setScale(5, RoundingMode.ROUND_HALF_UP);
+                        bd = bd.setScale(5, RoundingMode.HALF_UP);
                         probability = bd.doubleValue();
                         if (probability != 100) {
                             throw new IllegalArgumentException("Process is not valid for simulation - use validation to find errors");

--- a/jbpm-simulation/src/main/java/org/jbpm/simulation/converter/SimulationFilterPathFormatConverter.java
+++ b/jbpm-simulation/src/main/java/org/jbpm/simulation/converter/SimulationFilterPathFormatConverter.java
@@ -16,6 +16,7 @@
 package org.jbpm.simulation.converter;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -81,7 +82,7 @@ public class SimulationFilterPathFormatConverter implements
                             }
                         }
                         BigDecimal bd = new BigDecimal(probability);
-                        bd = bd.setScale(5, BigDecimal.ROUND_HALF_UP);
+                        bd = bd.setScale(5, RoundingMode.ROUND_HALF_UP);
                         probability = bd.doubleValue();
                         if (probability != 100) {
                             throw new IllegalArgumentException("Process is not valid for simulation - use validation to find errors");

--- a/jbpm-simulation/src/main/java/org/jbpm/simulation/impl/JBPMBAMSimulationDataProvider.java
+++ b/jbpm-simulation/src/main/java/org/jbpm/simulation/impl/JBPMBAMSimulationDataProvider.java
@@ -161,7 +161,7 @@ public class JBPMBAMSimulationDataProvider implements SimulationDataProvider {
                 long minExec = exitStat.getMinTimeStamp() - enterStat.getMinTimeStamp();
                 long maxExec = exitStat.getMaxTimeStamp() - enterStat.getMaxTimeStamp();
             
-                nodeProperties.put("duration", new Double(StatUtils.mean(new double[]{minExec, maxExec})).longValue());
+                nodeProperties.put("duration", Double.valueOf(StatUtils.mean(new double[]{minExec, maxExec})).longValue());
                 nodeProperties.put("max-exec", maxExec);
                 nodeProperties.put("min-exec", minExec);
                 nodeProperties.put("range", (maxExec - minExec)/2);


### PR DESCRIPTION
[Kie Server uses obselete/to be deleted Java APIs](https://issues.redhat.com/browse/DROOLS-5578)
Automated fix to Java9
https://j2eeguys.com/updater/index.html

regex **[.\*[j|J]enkins,?.\*(retest|test) this.\*]**
