### PR TITLE
[DROOLS-5616] Be able to set with an Env Variable that KIE using XStr…

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
@@ -164,5 +164,7 @@ public class KieServerConstants {
     // System variable to store the enabled packages for the XStreamMarshaller
     public static final String SYSTEM_XSTREAM_ENABLED_PACKAGES = "org.kie.server.xstream.enabled.packages";
 
+    public static final String XSTREAM_IGNORE_UNKNOWN_ELEMENTS = "org.kie.server.xstream.ignore.unknown.elements";
+
     public static final String RESET_CONTAINER_BEFORE_UPDATE = "resetBeforeUpdate";
 }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/xstream/XStreamMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/xstream/XStreamMarshaller.java
@@ -28,6 +28,7 @@ import com.thoughtworks.xstream.XStream;
 import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider;
 import com.thoughtworks.xstream.mapper.MapperWrapper;
 import org.drools.core.runtime.help.impl.XStreamXML;
+import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.commands.CallContainerCommand;
 import org.kie.server.api.commands.CommandScript;
 import org.kie.server.api.commands.CreateContainerCommand;
@@ -85,6 +86,8 @@ public class XStreamMarshaller implements Marshaller {
     protected XStream xstream;
     protected ClassLoader classLoader;
     protected Map<String, Class> classNames = new HashMap<String, Class>();
+
+    private boolean ignoreUnknownElements = Boolean.parseBoolean(System.getProperty(KieServerConstants.XSTREAM_IGNORE_UNKNOWN_ELEMENTS, "false"));
 
     // Optional marshaller extensions to handle new types / configure custom behavior
     private static final List<XStreamMarshallerExtension> EXTENSIONS;
@@ -153,6 +156,10 @@ public class XStreamMarshaller implements Marshaller {
         this.xstream.addPermission(new KieServerTypePermission(classes));
         String classWildcards[] = {"org.kie.api.pmml.*", "org.kie.pmml.pmml_4_2.model.*"};
         this.xstream.allowTypesByWildcard(classWildcards);
+
+        if (ignoreUnknownElements) {
+            this.xstream.ignoreUnknownElements();
+        }
 
         AbstractScoreXStreamConverter.registerScoreConverters(xstream);
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
@@ -116,6 +116,7 @@
               <kie.server.testing.kjars.build.settings.xml>${kie.server.testing.kjars.build.settings.xml}</kie.server.testing.kjars.build.settings.xml>
               <org.kie.prometheus.server.ext.disabled>${org.kie.prometheus.server.ext.disabled}</org.kie.prometheus.server.ext.disabled>
               <org.kie.scenariosimulation.server.ext.disabled>${org.kie.scenariosimulation.server.ext.disabled}</org.kie.scenariosimulation.server.ext.disabled>
+              <org.kie.server.xstream.ignore.unknown.elements>true</org.kie.server.xstream.ignore.unknown.elements>
             </systemPropertyVariables>
           </configuration>
         </plugin>
@@ -158,6 +159,7 @@
               <org.drools.server.ext.disabled>${org.drools.server.ext.disabled}</org.drools.server.ext.disabled>
               <org.kie.prometheus.server.ext.disabled>${org.kie.prometheus.server.ext.disabled}</org.kie.prometheus.server.ext.disabled>
               <org.kie.scenariosimulation.server.ext.disabled>${org.kie.scenariosimulation.server.ext.disabled}</org.kie.scenariosimulation.server.ext.disabled>
+              <org.kie.server.xstream.ignore.unknown.elements>true</org.kie.server.xstream.ignore.unknown.elements>
             </systemProperties>
           </container>
         </configuration>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/unknown-field-kjar1/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/unknown-field-kjar1/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.kie.server.testing</groupId>
+    <artifactId>common-parent</artifactId>
+    <version>1.0.0.Final</version>
+  </parent>
+
+  <artifactId>unknown-field-kjar</artifactId>
+  <version>1.0.0</version>
+  <packaging>kjar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-model-compiler</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/unknown-field-kjar1/src/main/java/org/kie/server/testing/MyFact.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/unknown-field-kjar1/src/main/java/org/kie/server/testing/MyFact.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.kie.server.testing;
+
+public class MyFact {
+
+    private String field1;
+
+    public String getField1() {
+        return field1;
+    }
+
+    public void setField1(String field1) {
+        this.field1 = field1;
+    }
+
+    @Override
+    public String toString() {
+        return "MyFact ver 1 [field1=" + field1 + "]";
+    }
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/unknown-field-kjar1/src/main/resources/META-INF/kmodule.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/unknown-field-kjar1/src/main/resources/META-INF/kmodule.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kmodule xmlns="http://www.drools.org/xsd/kmodule">
+  <kbase name="kbase1" default="true" packages="kbase1">
+    <ksession name="kbase1.stateful" default="true" type="stateful"/>
+  </kbase>
+</kmodule>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/unknown-field-kjar1/src/main/resources/kbase1/Sample.drl
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/unknown-field-kjar1/src/main/resources/kbase1/Sample.drl
@@ -1,0 +1,12 @@
+package kbase1;
+
+import org.kie.server.testing.*;
+
+rule "rule-1"
+    when
+        $fact : MyFact()
+    then
+        $fact.setField1("OK");
+        System.out.println($fact.toString());
+end
+

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/unknown-field-kjar2/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/unknown-field-kjar2/pom.xml
@@ -1,0 +1,29 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.kie.server.testing</groupId>
+    <artifactId>common-parent</artifactId>
+    <version>1.0.0.Final</version>
+  </parent>
+
+  <artifactId>unknown-field-kjar</artifactId>
+  <version>2.0.0</version>
+  <packaging>kjar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-model-compiler</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/unknown-field-kjar2/src/main/java/org/kie/server/testing/MyFact.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/unknown-field-kjar2/src/main/java/org/kie/server/testing/MyFact.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.kie.server.testing;
+
+public class MyFact {
+
+    private String field1;
+
+    private String field2;
+
+    public String getField1() {
+        return field1;
+    }
+
+    public void setField1(String field1) {
+        this.field1 = field1;
+    }
+
+    public String getField2() {
+        return field2;
+    }
+
+    public void setField2(String field2) {
+        this.field2 = field2;
+    }
+
+    @Override
+    public String toString() {
+        return "MyFact ver 2 [field1=" + field1 + ", field2=" + field2 + "]";
+    }
+
+
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/unknown-field-kjar2/src/main/resources/META-INF/kmodule.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/unknown-field-kjar2/src/main/resources/META-INF/kmodule.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kmodule xmlns="http://www.drools.org/xsd/kmodule">
+  <kbase name="kbase1" default="true" packages="kbase1">
+    <ksession name="kbase1.stateful" default="true" type="stateful"/>
+  </kbase>
+</kmodule>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/unknown-field-kjar2/src/main/resources/kbase1/Sample.drl
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/unknown-field-kjar2/src/main/resources/kbase1/Sample.drl
@@ -1,0 +1,12 @@
+package kbase1;
+
+import org.kie.server.testing.*;
+
+rule "rule-1"
+    when
+        $fact : MyFact()
+    then
+        $fact.setField1("OK");
+        System.out.println($fact.toString());
+end
+

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/UnknownFieldIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/UnknownFieldIntegrationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.integrationtests.drools;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.api.command.BatchExecutionCommand;
+import org.kie.api.command.Command;
+import org.kie.api.runtime.ExecutionResults;
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.integrationtests.shared.KieServerDeployer;
+import org.kie.server.integrationtests.shared.KieServerReflections;
+
+public class UnknownFieldIntegrationTest extends DroolsKieServerBaseIntegrationTest {
+
+    private static ReleaseId releaseId1 = new ReleaseId("org.kie.server.testing", "unknown-field-kjar", "1.0.0");
+    private static ReleaseId releaseId2 = new ReleaseId("org.kie.server.testing", "unknown-field-kjar", "2.0.0");
+
+
+    private static final String CONTAINER_ID = "stateful-session";
+    private static final String KIE_SESSION = "kbase1.stateful";
+    private static final String FACT_OUT_IDENTIFIER = "fact";
+    private static final String FACT_CLASS_NAME = "org.kie.server.testing.MyFact";
+
+    private static ClassLoader secondKjarClassLoader;
+
+    @BeforeClass
+    public static void deployArtifacts() {
+        System.setProperty(KieServerConstants.XSTREAM_IGNORE_UNKNOWN_ELEMENTS, "true");
+
+        KieServerDeployer.buildAndDeployCommonMavenParent();
+        KieServerDeployer.buildAndDeployMavenProjectFromResource("/kjars-sources/unknown-field-kjar1");
+        KieServerDeployer.buildAndDeployMavenProjectFromResource("/kjars-sources/unknown-field-kjar2");
+
+        secondKjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId2).getClassLoader();
+    }
+
+    @AfterClass
+    public static void clearSystemProperty() {
+        System.clearProperty(KieServerConstants.XSTREAM_IGNORE_UNKNOWN_ELEMENTS);
+    }
+
+    @Before
+    public void cleanupContainers() {
+        disposeAllContainers();
+        createContainer(CONTAINER_ID, releaseId1);
+    }
+
+    @Override
+    protected void addExtraCustomClasses(Map<String, Class<?>> extraClasses) throws Exception {
+        extraClasses.put(FACT_CLASS_NAME, Class.forName(FACT_CLASS_NAME, true, secondKjarClassLoader)); // Use class in kjar2
+    }
+
+    @Test
+    public void testUnknownField() {
+        List<Command<?>> commands = new ArrayList<Command<?>>();
+        BatchExecutionCommand executionCommand = commandsFactory.newBatchExecution(commands, KIE_SESSION);
+
+        Object fact = createInstance(FACT_CLASS_NAME); // Use class in kjar2
+        KieServerReflections.setValue(fact, "field1", "value1");
+        KieServerReflections.setValue(fact, "field2", "value2"); // this field is unknown to kjar1
+
+        commands.add(commandsFactory.newInsert(fact, FACT_OUT_IDENTIFIER));
+        commands.add(commandsFactory.newFireAllRules());
+        ServiceResponse<ExecutionResults> reply1 = ruleClient.executeCommandsWithResults(CONTAINER_ID, executionCommand);
+
+        assertEquals(ServiceResponse.ResponseType.SUCCESS, reply1.getType());
+
+        ExecutionResults actualData = reply1.getResult();
+
+        Object outFact = actualData.getValue(FACT_OUT_IDENTIFIER);
+        assertEquals("OK", KieServerReflections.valueOf(outFact, "field1"));
+    }
+}

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -1466,6 +1466,7 @@
                       <argument>-Dorg.kie.server.bypass.auth.user=${org.kie.server.bypass.auth.user}</argument>
                       <argument>-Dorg.kie.server.policy.activate=${org.kie.server.policy.activate}</argument>
                       <argument>-Dpolicy.klo.interval=${policy.klo.interval}</argument>
+                      <argument>-Dorg.kie.server.xstream.ignore.unknown.elements=true</argument>
                       <argument>org.springframework.boot.loader.JarLauncher</argument>
                     </arguments>
                   </configuration>


### PR DESCRIPTION
…eam does not complain on unknown fields

**JIRA**: 

https://issues.redhat.com/browse/DROOLS-5616
https://issues.redhat.com/browse/RHDM-1444

<pre>
How to retest a PR or trigger a specific build:

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</pre>
