### PR TITLE
[JBPM-9330] Change log level for endpoint failure

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
@@ -810,7 +810,7 @@ public abstract class AbstractKieServicesClientImpl {
                 return operation.doOperation(url);
             } catch (KieServerHttpRequestException e) {
                 if (e.getCause() instanceof IOException) {
-                    logger.debug("Marking endpoint '{}' as failed due to {}", url, e.getCause().getMessage());
+                    logger.warn("Marking endpoint '{}' as failed due to {}", url, e.getCause().getMessage());
                     String failedBaseUrl = loadBalancer.markAsFailed(url);
                     nextUrl = loadBalancer.getUrl();
                     url = url.replace(failedBaseUrl, nextUrl);


### PR DESCRIPTION
When an endpoint fails, reason for failure is logged as debug level,
changing it to warn

**JIRA**:

[JBPM-9330](https://issues.redhat.com/browse/JBPM-9330)

