### PR TITLE
[Do not merge] Test PR to debug downstream problem

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/main/java/org/jbpm/notification/listeners/CustomNotificationListener.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/main/java/org/jbpm/notification/listeners/CustomNotificationListener.java
@@ -33,7 +33,7 @@ public class CustomNotificationListener implements NotificationListener {
 
     @Override
     public void onNotification(NotificationEvent event, UserInfo userInfo) {
-        logger.debug("onNotification with event content {}", event.getContent());
+        logger.info("onNotification with event content {}", event.getContent());
         try {
             if ("TaskSaveContent".equals(event.getTask().getName())) {
                 userTaskService.saveContent(event.getTask().getId(), singletonMap("grade", "E"));

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/NotificationSaveContentIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/NotificationSaveContentIntegrationTest.java
@@ -51,7 +51,7 @@ public class NotificationSaveContentIntegrationTest extends JbpmKieServerBaseInt
         createContainer(CONTAINER_ID_NOTIFICATION, releaseId);
     }
 
-    @Test(timeout = 10000)
+    @Test
     public void testSaveContentOnNotification() throws Exception {
         Long processInstanceId = processClient.startProcess(CONTAINER_ID_NOTIFICATION, PROCESS_ID_NOTIFICATION);
         assertNotNull(processInstanceId);


### PR DESCRIPTION
Needed to analyze why https://github.com/kiegroup/droolsjbpm-integration/blob/master/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/NotificationSaveContentIntegrationTest.java is failing on downstream PR checks.

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
