### PR TITLE
DROOLS-5072 DMN wire DT static analysis to kie-maven-plugin

### DIFF
--- a/kie-integration-test-coverage/kie-maven-plugin-default-execmodel-tests/kjar-with-instrumentation-default-execmodel-wrapper/src/test/resources/kjar-with-instrumentation-default-execmodel/src/main/resources/META-INF/kmodule.xml
+++ b/kie-integration-test-coverage/kie-maven-plugin-default-execmodel-tests/kjar-with-instrumentation-default-execmodel-wrapper/src/test/resources/kjar-with-instrumentation-default-execmodel/src/main/resources/META-INF/kmodule.xml
@@ -3,4 +3,5 @@
   <kbase name="instrumentationKBase" default="true" packages="org.kie.integration.testcoverage.instrumentation">
     <ksession name="instrumentationSession" default="true" type="stateful" />
   </kbase>
+  <kbase name="dmnKBase" packages="org.kie.integration.testcoverage.dmn" />
 </kmodule>

--- a/kie-integration-test-coverage/kie-maven-plugin-default-execmodel-tests/kjar-with-instrumentation-default-execmodel-wrapper/src/test/resources/kjar-with-instrumentation-default-execmodel/src/main/resources/org/kie/integration/testcoverage/dmn/basic.dmn
+++ b/kie-integration-test-coverage/kie-maven-plugin-default-execmodel-tests/kjar-with-instrumentation-default-execmodel-wrapper/src/test/resources/kjar-with-instrumentation-default-execmodel/src/main/resources/org/kie/integration/testcoverage/dmn/basic.dmn
@@ -1,0 +1,45 @@
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_A212B6C9-59F6-4340-A328-AA4C020A654E" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_84121285-86DD-4BA0-9BEC-FFDCDF07D29F" name="basic" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_A212B6C9-59F6-4340-A328-AA4C020A654E">
+  <dmn:extensionElements/>
+  <dmn:inputData id="_4885B416-5A64-447E-BD94-9F860D0A3DAB" name="a number">
+    <dmn:extensionElements/>
+    <dmn:variable id="_939B2253-ABDF-4A42-AF96-B1170A5D99EC" name="a number" typeRef="number"/>
+  </dmn:inputData>
+  <dmn:decision id="_C1FFABBA-1220-440C-BFD6-6ED1A7D882C5" name="is it positive or negative?">
+    <dmn:extensionElements/>
+    <dmn:variable id="_C7E3220A-B4B1-421E-8F02-782062E8E670" name="is it positive or negative?"/>
+    <dmn:informationRequirement id="_D52C76C8-1984-4482-9A11-AC8253893B50">
+      <dmn:requiredInput href="#_4885B416-5A64-447E-BD94-9F860D0A3DAB"/>
+    </dmn:informationRequirement>
+    <dmn:decisionTable id="_F3D5D777-F4E7-42A1-8C91-1E18CA2D1ECF" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
+      <dmn:input id="_0BA60B5D-D464-4EB6-8096-3ACA7A43F664">
+        <dmn:inputExpression id="_F0C4128B-1FB2-4A84-8790-7DE79E314DD4" typeRef="number">
+          <dmn:text>a number</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:output id="_D7716AFC-DE6C-4C93-804E-44BA1A6AE80D"/>
+      <dmn:annotation name="annotation-1"/>
+      <dmn:rule id="_3ADCB78D-8628-431F-8F90-8FFFA2A365D7">
+        <dmn:inputEntry id="_9288742F-FE61-4144-A207-5EEDF99E3CE6">
+          <dmn:text>&lt;0</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_626EE9A2-283A-4AD8-91F9-4FCCC5E5BC64">
+          <dmn:text>"negative"</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text/>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id="_B45FD66A-0227-4252-8844-010DFC94470C">
+        <dmn:inputEntry id="_E1501ADD-7816-4406-BEAA-92B7F4C79D25">
+          <dmn:text>&gt;0</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_E4991060-CECB-4678-99F7-B6C883CD4A14">
+          <dmn:text>"positive"</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text>deliberately omitted =0 to trigger a warn</dmn:text>
+        </dmn:annotationEntry>
+      </dmn:rule>
+    </dmn:decisionTable>
+  </dmn:decision>
+</dmn:definitions>

--- a/kie-integration-test-coverage/kie-maven-plugin-no-execmodel-tests/kjar-with-instrumentation-no-execmodel-wrapper/src/test/resources/kjar-with-instrumentation-no-execmodel/src/main/resources/META-INF/kmodule.xml
+++ b/kie-integration-test-coverage/kie-maven-plugin-no-execmodel-tests/kjar-with-instrumentation-no-execmodel-wrapper/src/test/resources/kjar-with-instrumentation-no-execmodel/src/main/resources/META-INF/kmodule.xml
@@ -3,4 +3,5 @@
   <kbase name="instrumentationKBase" default="true" packages="org.kie.integration.testcoverage.instrumentation">
     <ksession name="instrumentationSession" default="true" type="stateful" />
   </kbase>
+  <kbase name="dmnKBase" packages="org.kie.integration.testcoverage.dmn" />
 </kmodule>

--- a/kie-integration-test-coverage/kie-maven-plugin-no-execmodel-tests/kjar-with-instrumentation-no-execmodel-wrapper/src/test/resources/kjar-with-instrumentation-no-execmodel/src/main/resources/org/kie/integration/testcoverage/dmn/basic.dmn
+++ b/kie-integration-test-coverage/kie-maven-plugin-no-execmodel-tests/kjar-with-instrumentation-no-execmodel-wrapper/src/test/resources/kjar-with-instrumentation-no-execmodel/src/main/resources/org/kie/integration/testcoverage/dmn/basic.dmn
@@ -1,0 +1,45 @@
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_A212B6C9-59F6-4340-A328-AA4C020A654E" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_84121285-86DD-4BA0-9BEC-FFDCDF07D29F" name="basic" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_A212B6C9-59F6-4340-A328-AA4C020A654E">
+  <dmn:extensionElements/>
+  <dmn:inputData id="_4885B416-5A64-447E-BD94-9F860D0A3DAB" name="a number">
+    <dmn:extensionElements/>
+    <dmn:variable id="_939B2253-ABDF-4A42-AF96-B1170A5D99EC" name="a number" typeRef="number"/>
+  </dmn:inputData>
+  <dmn:decision id="_C1FFABBA-1220-440C-BFD6-6ED1A7D882C5" name="is it positive or negative?">
+    <dmn:extensionElements/>
+    <dmn:variable id="_C7E3220A-B4B1-421E-8F02-782062E8E670" name="is it positive or negative?"/>
+    <dmn:informationRequirement id="_D52C76C8-1984-4482-9A11-AC8253893B50">
+      <dmn:requiredInput href="#_4885B416-5A64-447E-BD94-9F860D0A3DAB"/>
+    </dmn:informationRequirement>
+    <dmn:decisionTable id="_F3D5D777-F4E7-42A1-8C91-1E18CA2D1ECF" hitPolicy="UNIQUE" preferredOrientation="Rule-as-Row">
+      <dmn:input id="_0BA60B5D-D464-4EB6-8096-3ACA7A43F664">
+        <dmn:inputExpression id="_F0C4128B-1FB2-4A84-8790-7DE79E314DD4" typeRef="number">
+          <dmn:text>a number</dmn:text>
+        </dmn:inputExpression>
+      </dmn:input>
+      <dmn:output id="_D7716AFC-DE6C-4C93-804E-44BA1A6AE80D"/>
+      <dmn:annotation name="annotation-1"/>
+      <dmn:rule id="_3ADCB78D-8628-431F-8F90-8FFFA2A365D7">
+        <dmn:inputEntry id="_9288742F-FE61-4144-A207-5EEDF99E3CE6">
+          <dmn:text>&lt;0</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_626EE9A2-283A-4AD8-91F9-4FCCC5E5BC64">
+          <dmn:text>"negative"</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text/>
+        </dmn:annotationEntry>
+      </dmn:rule>
+      <dmn:rule id="_B45FD66A-0227-4252-8844-010DFC94470C">
+        <dmn:inputEntry id="_E1501ADD-7816-4406-BEAA-92B7F4C79D25">
+          <dmn:text>&gt;0</dmn:text>
+        </dmn:inputEntry>
+        <dmn:outputEntry id="_E4991060-CECB-4678-99F7-B6C883CD4A14">
+          <dmn:text>"positive"</dmn:text>
+        </dmn:outputEntry>
+        <dmn:annotationEntry>
+          <dmn:text>deliberately omitted =0 to trigger a warn</dmn:text>
+        </dmn:annotationEntry>
+      </dmn:rule>
+    </dmn:decisionTable>
+  </dmn:decision>
+</dmn:definitions>

--- a/kie-maven-plugin-example/src/main/resources/org/acme/test_generateModel_kjararchetype/test.dmn
+++ b/kie-maven-plugin-example/src/main/resources/org/acme/test_generateModel_kjararchetype/test.dmn
@@ -46,7 +46,7 @@
       <semantic:informationRequirement>
          <semantic:requiredInput href="#_a69e86bf-4e59-444f-abf8-09d38f762bab"/>
       </semantic:informationRequirement>
-      <semantic:decisionTable hitPolicy="UNIQUE"
+      <semantic:decisionTable hitPolicy="PRIORITY"
                               id="_b950dde1-532a-4bfb-9bdd-1e3768b15fac"
                               outputLabel="Exemptions">
          <semantic:input id="_e2659f15-f658-41dc-ae2d-7e50abd1f555">
@@ -59,7 +59,11 @@
                <semantic:text>Account holder.employed</semantic:text>
             </semantic:inputExpression>
          </semantic:input>
-         <semantic:output id="_15bb42a9-4650-40b1-b7c0-1dde877b4d3f"/>
+         <semantic:output id="_15bb42a9-4650-40b1-b7c0-1dde877b4d3f">
+           <semantic:outputValues id="manual1">
+             <semantic:text>"Exempted","Standard"</semantic:text>
+           </semantic:outputValues>
+         </semantic:output>
          <semantic:rule id="_a8532882-b9d8-4b02-aba1-dc46325e1f13">
             <semantic:inputEntry id="_45266326-5e3d-4b5d-b7d9-00b65e184761">
                <semantic:text>-</semantic:text>

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/AbstractDMNValidationAwareMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/AbstractDMNValidationAwareMojo.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.maven.plugin;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.apache.maven.model.Resource;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.drools.compiler.kie.builder.impl.InternalKieModule;
+import org.drools.compiler.kproject.models.KieModuleModelImpl;
+import org.drools.core.definitions.InternalKnowledgePackage;
+import org.kie.api.builder.Message.Level;
+import org.kie.api.builder.model.KieModuleModel;
+import org.kie.api.definition.KiePackage;
+import org.kie.api.internal.io.ResourceTypePackage;
+import org.kie.api.io.ResourceType;
+import org.kie.dmn.api.core.DMNMessage;
+import org.kie.dmn.api.core.DMNModel;
+import org.kie.dmn.core.assembler.DMNAssemblerService;
+import org.kie.dmn.core.compiler.DMNProfile;
+import org.kie.dmn.feel.util.ClassLoaderUtil;
+import org.kie.dmn.validation.DMNValidator.Validation;
+import org.kie.dmn.validation.dtanalysis.InternalDMNDTAnalyser;
+import org.kie.dmn.validation.dtanalysis.InternalDMNDTAnalyserFactory;
+import org.kie.dmn.validation.dtanalysis.model.DTAnalysis;
+import org.kie.internal.utils.ChainedProperties;
+
+public abstract class AbstractDMNValidationAwareMojo extends AbstractKieMojo {
+
+    @Parameter(required = true, defaultValue = "${project.build.resources}")
+    private List<Resource> resources;
+
+    @Parameter(property = "validateDMN", defaultValue = "VALIDATE_SCHEMA,VALIDATE_MODEL")
+    private String validateDMN;
+
+    protected String getValidateDMN() {
+        return validateDMN;
+    }
+
+    protected void logValidationMessages(List<DMNMessage> validation, Function<DMNMessage, String> prefixer) {
+        for (DMNMessage msg : validation) {
+            Consumer<CharSequence> logFn = null;
+            switch (msg.getLevel()) {
+                case ERROR:
+                    logFn = getLog()::error;
+                    break;
+                case WARNING:
+                    logFn = getLog()::warn;
+                    break;
+                case INFO:
+                default:
+                    logFn = getLog()::info;
+                    break;
+            }
+            StringBuilder sb = new StringBuilder();
+            sb.append(prefixer.apply(msg));
+            sb.append(msg.getText());
+            logFn.accept(sb.toString());
+        }
+    }
+
+    public List<Validation> computeFlagsFromCSVString(String csvString) {
+        List<Validation> flags = new ArrayList<>();
+        boolean resetFlag = false;
+        for (String p : csvString.split(",")) {
+            try {
+                flags.add(Validation.valueOf(p));
+            } catch (IllegalArgumentException e) {
+                getLog().info("validateDMN configured with flag: '" + p + "' determines this Mojo will not be executed (reset all flags).");
+                resetFlag = true;
+            }
+        }
+        if (resetFlag) {
+            flags.clear();
+        }
+        return flags;
+    }
+
+    protected boolean shallPerformDMNDTAnalysis() {
+        return computeFlagsFromCSVString(getValidateDMN()).contains(Validation.ANALYZE_DECISION_TABLE);
+    }
+
+    public void performDMNDTAnalysis(InternalKieModule kieModule) throws MojoExecutionException, MojoFailureException {
+        Collection<DMNModel> dmnModels = extractDMNModelsFromKieModule(kieModule);
+        getLog().info("Initializing DMN DT Validator...");
+        InternalDMNDTAnalyser analyser = InternalDMNDTAnalyserFactory.newDMNDTAnalyser(computeDMNProfiles());
+        getLog().info("DMN DT Validator initialized.");
+        for (DMNModel model : dmnModels) {
+            getLog().info("Analysing decision tables in DMN Model '" + model.getName() + "' ...");
+            List<DTAnalysis> results = analyser.analyse(model, new HashSet<>(Arrays.asList(Validation.ANALYZE_DECISION_TABLE)));
+            if (results.isEmpty()) {
+                getLog().info(" no decision tables found.");
+            } else {
+                for (DTAnalysis r : results) {
+                    getLog().info(" analysis for decision table '" + r.nameOrIDOfTable() + "':");
+                    List<DMNMessage> messages = r.asDMNMessages();
+                    logValidationMessages(messages, (u) -> "  ");
+                    if (messages.stream().anyMatch(m -> m.getLevel() == Level.ERROR)) {
+                        throw new MojoFailureException("There are DMN Validation Error(s).");
+                    }
+                }
+            }
+        }
+    }
+
+    private Collection<DMNModel> extractDMNModelsFromKieModule(InternalKieModule kieModule) {
+        Collection<KiePackage> kpkgs = kieModule.getKieModuleModel().getKieBaseModels().keySet().stream()
+                                                .flatMap(name -> kieModule.getKnowledgePackagesForKieBase(name).stream())
+                                                .collect(Collectors.toList());
+        Set<DMNModel> models = new HashSet<>();
+        for (KiePackage kp : kpkgs) {
+            InternalKnowledgePackage ikpkg = (InternalKnowledgePackage) kp;
+            ResourceTypePackage<DMNModel> rtp = (ResourceTypePackage<DMNModel>) ikpkg.getResourceTypePackages().get(ResourceType.DMN);
+            if (rtp == null) {
+                continue;
+            }
+            for (DMNModel dmnModel : rtp) {
+                models.add(dmnModel);
+            }
+        }
+        Map<org.kie.api.io.Resource, DMNModel> removeDups = new HashMap<>();
+        for (DMNModel m : models) {
+            removeDups.put(m.getResource(), m);
+        }
+        return removeDups.values();
+    }
+
+    protected List<Path> resourcesPaths() {
+        List<Path> resourcesPaths = resources.stream().map(r -> new File(r.getDirectory()).toPath()).collect(Collectors.toList());
+        if (getLog().isDebugEnabled()) {
+            getLog().debug("resourcesPaths: " + resourcesPaths.stream().map(Path::toString).collect(Collectors.joining(",\n")));
+        }
+        return resourcesPaths;
+    }
+
+    protected List<DMNProfile> computeDMNProfiles() throws MojoExecutionException {
+        ClassLoader classLoader = ClassLoaderUtil.findDefaultClassLoader();
+        ChainedProperties chainedProperties = ChainedProperties.getChainedProperties(classLoader);
+        List<KieModuleModel> kieModules = new ArrayList<>();
+        for (Path p : resourcesPaths()) {
+            try (Stream<Path> walk = Files.walk(p)) {
+                List<Path> collect = walk.filter(f -> f.toString().endsWith("kmodule.xml")).collect(Collectors.toList());
+                for (Path k : collect) {
+                    kieModules.add(KieModuleModelImpl.fromXML(k.toFile()));
+                }
+            } catch (Exception e) {
+                throw new MojoExecutionException("Failed executing AbstractDMNValidationAwareMojo while computing DMNProfile(s)", e);
+            }
+        }
+        for (KieModuleModel kmm : kieModules) {
+            Properties ps = new Properties();
+            ps.putAll(kmm.getConfigurationProperties());
+            chainedProperties.addProperties(ps);
+        }
+        List<DMNProfile> dmnProfiles = new ArrayList<>();
+        dmnProfiles.addAll(DMNAssemblerService.getDefaultDMNProfiles(chainedProperties));
+        try {
+            Map<String, String> dmnProfileProperties = new HashMap<>();
+            chainedProperties.mapStartsWith(dmnProfileProperties, DMNAssemblerService.DMN_PROFILE_PREFIX, false);
+            for (Map.Entry<String, String> dmnProfileProperty : dmnProfileProperties.entrySet()) {
+                DMNProfile dmnProfile = (DMNProfile) classLoader.loadClass(dmnProfileProperty.getValue()).newInstance();
+                dmnProfiles.add(dmnProfile);
+            }
+        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+            throw new MojoExecutionException("Failed executing AbstractDMNValidationAwareMojo while computing DMNProfile(s)", e);
+        }
+        return dmnProfiles;
+    }
+}

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/BuildMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/BuildMojo.java
@@ -68,7 +68,7 @@ import static org.kie.maven.plugin.ExecModelMode.modelParameterEnabled;
         requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME,
         requiresProject = true,
         defaultPhase = LifecyclePhase.COMPILE)
-public class BuildMojo extends AbstractKieMojo {
+public class BuildMojo extends AbstractDMNValidationAwareMojo {
 
     @Parameter(defaultValue = "${session}", required = true, readonly = true)
     private MavenSession mavenSession;
@@ -114,7 +114,7 @@ public class BuildMojo extends AbstractKieMojo {
         }
     }
 
-    private void buildDrl() throws MojoFailureException {
+    private void buildDrl() throws MojoFailureException, MojoExecutionException {
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
         try {
             Set<URL> urls = new HashSet<>();
@@ -168,6 +168,10 @@ public class BuildMojo extends AbstractKieMojo {
                 throw new MojoFailureException("Build failed!");
             } else {
                 writeClassFiles( kModule );
+            }
+
+            if (shallPerformDMNDTAnalysis()) {
+                performDMNDTAnalysis(kModule);
             }
         } finally {
             Thread.currentThread().setContextClassLoader(contextClassLoader);

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
@@ -69,7 +69,7 @@ import static org.kie.maven.plugin.ExecModelMode.modelParameterEnabled;
         requiresDependencyResolution = ResolutionScope.NONE,
         requiresProject = true,
         defaultPhase = LifecyclePhase.COMPILE)
-public class GenerateModelMojo extends AbstractKieMojo {
+public class GenerateModelMojo extends AbstractDMNValidationAwareMojo {
 
     public static PathMatcher drlFileMatcher = FileSystems.getDefault().getPathMatcher("glob:**.drl");
 
@@ -111,7 +111,7 @@ public class GenerateModelMojo extends AbstractKieMojo {
 
     }
 
-    private void generateModel() throws MojoExecutionException {
+    private void generateModel() throws MojoExecutionException, MojoFailureException {
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
         try {
             Set<URL> urls = new HashSet<>();
@@ -200,6 +200,10 @@ public class GenerateModelMojo extends AbstractKieMojo {
             } catch (IOException e) {
                 e.printStackTrace();
                 throw new MojoExecutionException("Unable to write file", e);
+            }
+
+            if (shallPerformDMNDTAnalysis()) {
+                performDMNDTAnalysis(kieModule);
             }
 
             if (ExecModelMode.shouldDeleteFile(generateModel)) {

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/ValidateDMNMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/ValidateDMNMojo.java
@@ -20,15 +20,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -36,28 +32,20 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-import org.drools.compiler.kproject.models.KieModuleModelImpl;
 import org.kie.api.builder.Message.Level;
-import org.kie.api.builder.model.KieModuleModel;
 import org.kie.dmn.api.core.DMNMessage;
-import org.kie.dmn.core.assembler.DMNAssemblerService;
 import org.kie.dmn.core.compiler.DMNProfile;
-import org.kie.dmn.feel.util.ClassLoaderUtil;
 import org.kie.dmn.model.api.DMNModelInstrumentedBase;
 import org.kie.dmn.model.api.Definitions;
 import org.kie.dmn.validation.DMNValidator;
 import org.kie.dmn.validation.DMNValidator.Validation;
 import org.kie.dmn.validation.DMNValidatorFactory;
-import org.kie.internal.utils.ChainedProperties;
 
 @Mojo(name = "validateDMN",
       requiresDependencyResolution = ResolutionScope.NONE,
       requiresProject = true,
       defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
-public class ValidateDMNMojo extends AbstractKieMojo {
-
-    @Parameter(required = true, defaultValue = "${project.build.resources}")
-    private List<Resource> resources;
+public class ValidateDMNMojo extends AbstractDMNValidationAwareMojo {
 
     @Parameter
     private Map<String, String> properties;
@@ -65,26 +53,18 @@ public class ValidateDMNMojo extends AbstractKieMojo {
     @Parameter(required = true, defaultValue = "${project}")
     private MavenProject project;
 
-    @Parameter(property = "validateDMN", defaultValue = "VALIDATE_SCHEMA,VALIDATE_MODEL")
-    private String validateDMN;
     private List<Validation> actualFlags = new ArrayList<>();
 
-    private List<Path> resourcesPaths;
     private DMNValidator validator;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        actualFlags.addAll(computeFlagsFromCSVString(validateDMN));
+        actualFlags.addAll(computeFlagsFromCSVString(getValidateDMN()));
         // for this phase, keep only the following flags (the rest requires the BuildMojo).
         actualFlags.retainAll(Arrays.asList(Validation.VALIDATE_SCHEMA, Validation.VALIDATE_MODEL));
         if (actualFlags.isEmpty()) {
             getLog().info("No VALIDATE_SCHEMA or VALIDATE_MODEL flags set, skipping.");
             return;
-        }
-
-        resourcesPaths = resources.stream().map(r -> new File(r.getDirectory()).toPath()).collect(Collectors.toList());
-        if (getLog().isDebugEnabled()) {
-            getLog().debug("resourcesPaths: " + resourcesPaths.stream().map(Path::toString).collect(Collectors.joining(",\n")));
         }
 
         List<Path> dmnModelPaths = computeDmnModelPaths();
@@ -100,62 +80,28 @@ public class ValidateDMNMojo extends AbstractKieMojo {
         dmnModelPaths.forEach(x -> getLog().info("Will validate DMN model: " + x.toString()));
         List<DMNMessage> validation = validator.validateUsing(actualFlags.toArray(new Validation[]{}))
                                                .theseModels(dmnModelPaths.stream().map(Path::toFile).collect(Collectors.toList()).toArray(new File[]{}));
-        logValidationMessages(validation);
+        logValidationMessages(validation, this::validateMsgPrefixer);
         if (validation.stream().anyMatch(m -> m.getLevel() == Level.ERROR)) {
             throw new MojoFailureException("There are DMN Validation Error(s).");
         }
     }
 
-    private void logValidationMessages(List<DMNMessage> validation) {
-        for (DMNMessage msg : validation) {
-            Consumer<CharSequence> logFn = null;
-            switch (msg.getLevel()) {
-                case ERROR:
-                    logFn = getLog()::error;
-                    break;
-                case WARNING:
-                    logFn = getLog()::warn;
-                    break;
-                case INFO:
-                default:
-                    logFn = getLog()::info;
-                    break;
+    private String validateMsgPrefixer(DMNMessage msg) {
+        if (msg.getSourceReference() instanceof DMNModelInstrumentedBase) {
+            DMNModelInstrumentedBase ib = (DMNModelInstrumentedBase) msg.getSourceReference();
+            while (ib.getParent() != null) {
+                ib = ib.getParent();
             }
-            StringBuilder sb = new StringBuilder();
-            if (msg.getSourceReference() instanceof DMNModelInstrumentedBase) {
-                DMNModelInstrumentedBase ib = (DMNModelInstrumentedBase) msg.getSourceReference();
-                while (ib.getParent() != null) {
-                    ib = ib.getParent();
-                }
-                if (ib instanceof Definitions) {
-                    sb.append(((Definitions) ib).getName() + ": ");
-                }
-            }
-            sb.append(msg.getText());
-            logFn.accept(sb.toString());
-        }
-    }
-
-    public List<Validation> computeFlagsFromCSVString(String csvString) {
-        List<Validation> flags = new ArrayList<>();
-        boolean resetFlag = false;
-        for (String p : csvString.split(",")) {
-            try {
-                flags.add(Validation.valueOf(p));
-            } catch (IllegalArgumentException e) {
-                getLog().info("validateDMN configured with flag: '" + p + "' determines this Mojo will not be executed (reset all flags).");
-                resetFlag = true;
+            if (ib instanceof Definitions) {
+                return (((Definitions) ib).getName() + ": ");
             }
         }
-        if (resetFlag) {
-            flags.clear();
-        }
-        return flags;
+        return "";
     }
 
     private List<Path> computeDmnModelPaths() throws MojoExecutionException {
         List<Path> dmnModelPaths = new ArrayList<>();
-        for (Path p : resourcesPaths) {
+        for (Path p : resourcesPaths()) {
             getLog().info("Looking for DMN models in path: " + p);
             try (Stream<Path> walk = Files.walk(p)) {
                 walk.filter(f -> f.toString().endsWith(".dmn"))
@@ -168,36 +114,7 @@ public class ValidateDMNMojo extends AbstractKieMojo {
     }
 
     private void initializeDMNValidator() throws MojoExecutionException {
-        ClassLoader classLoader = ClassLoaderUtil.findDefaultClassLoader();
-        ChainedProperties chainedProperties = ChainedProperties.getChainedProperties(classLoader);
-        List<KieModuleModel> kieModules = new ArrayList<>();
-        for (Path p : resourcesPaths) {
-            try (Stream<Path> walk = Files.walk(p)) {
-                List<Path> collect = walk.filter(f -> f.toString().endsWith("kmodule.xml")).collect(Collectors.toList());
-                for (Path k : collect) {
-                    kieModules.add(KieModuleModelImpl.fromXML(k.toFile()));
-                }
-            } catch (Exception e) {
-                throw new MojoExecutionException("Failed executing ValidateDMNMojo", e);
-            }
-        }
-        for (KieModuleModel kmm : kieModules) {
-            Properties ps = new Properties();
-            ps.putAll(kmm.getConfigurationProperties());
-            chainedProperties.addProperties(ps);
-        }
-        List<DMNProfile> dmnProfiles = new ArrayList<>();
-        dmnProfiles.addAll(DMNAssemblerService.getDefaultDMNProfiles(chainedProperties));
-        try {
-            Map<String, String> dmnProfileProperties = new HashMap<>();
-            chainedProperties.mapStartsWith(dmnProfileProperties, DMNAssemblerService.DMN_PROFILE_PREFIX, false);
-            for (Map.Entry<String, String> dmnProfileProperty : dmnProfileProperties.entrySet()) {
-                DMNProfile dmnProfile = (DMNProfile) classLoader.loadClass(dmnProfileProperty.getValue()).newInstance();
-                dmnProfiles.add(dmnProfile);
-            }
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
-            throw new MojoExecutionException("Failed DMNValidator initialization.", e);
-        }
+        List<DMNProfile> dmnProfiles = computeDMNProfiles();
         validator = DMNValidatorFactory.newValidator(dmnProfiles);
     }
 }

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/ValidateDMNMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/ValidateDMNMojo.java
@@ -80,7 +80,7 @@ public class ValidateDMNMojo extends AbstractDMNValidationAwareMojo {
         dmnModelPaths.forEach(x -> getLog().info("Will validate DMN model: " + x.toString()));
         List<DMNMessage> validation = validator.validateUsing(actualFlags.toArray(new Validation[]{}))
                                                .theseModels(dmnModelPaths.stream().map(Path::toFile).collect(Collectors.toList()).toArray(new File[]{}));
-        logValidationMessages(validation, this::validateMsgPrefixer);
+        logValidationMessages(validation, this::validateMsgPrefixer, DMNMessage::getText);
         if (validation.stream().anyMatch(m -> m.getLevel() == Level.ERROR)) {
             throw new MojoFailureException("There are DMN Validation Error(s).");
         }

--- a/kie-maven-plugin/src/test/java/org/kie/maven/plugin/ValidateDMNMojoFlagsTest.java
+++ b/kie-maven-plugin/src/test/java/org/kie/maven/plugin/ValidateDMNMojoFlagsTest.java
@@ -15,7 +15,7 @@ public class ValidateDMNMojoFlagsTest {
 
     public static final Logger LOG = LoggerFactory.getLogger(ValidateDMNMojoFlagsTest.class);
 
-    private ValidateDMNMojo mojo;
+    private AbstractDMNValidationAwareMojo mojo;
 
     @Before
     public void init() {


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-5072

**referenced Pull Requests**: on drools.git:

* https://github.com/kiegroup/drools/pull/3134

# Details 

@mariofusco @lucamolteni : the DMN Validator, Decision Table static analysis (DT Analysis) requires the DMN model to be in their compiled form, before performing the static analysis on the decision table. To avoid compiling the DMN Models twice, I bind to the 2 main entry point which are building the ~`KieModule` of the KJAR project, that is:

- GenerateModelMojo (exec model, the default)
- BuildMojo (no exec model, classic DRL)

after the KJAR project is compiled by the KieBuilder `buildAll` as before, I launch the analysis of the decision table.

# Demo

if the decision table static analysis have some error, it trigger the Maven Failure as expected by all the other plugin (including semantic DMN validation):

![image](https://user-images.githubusercontent.com/1699252/94818535-8271ba80-03fe-11eb-9338-18a38ff43102.png)

in this case the decision table as it was already merged on master, was semantically incorrect, hence the modification in this PR (change of hitpolicy from UNIQUE to PRIORITY)

![image](https://user-images.githubusercontent.com/1699252/94818626-9d442f00-03fe-11eb-963e-51f869e6606a.png)

And so the full report is available to the end user by means of build log, as expected.

To support non-regression tests, I've added a basic DMN model to the `kie-integration-test-coverage` module:

![image](https://user-images.githubusercontent.com/1699252/94822378-ded6d900-0402-11eb-89d5-1cfedc249f5d.png)

so a simple DMN model with 1 Decision Table with 1 Gap (missing to cover for value `=0`).

Without exec model the check is performed by the BuildMojo:

![image](https://user-images.githubusercontent.com/1699252/94818813-cfee2780-03fe-11eb-9649-3ecf8fa466aa.png)

With the default exec model the check is performed by the GenerateModelMojo:

![image](https://user-images.githubusercontent.com/1699252/94818881-e4322480-03fe-11eb-95e8-f5c7a80d93ff.png)


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
