### PR TITLE
[JBPM-9416] node ids missing from ProcessServiceBase  causing process just being created.

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/ProcessServiceBase.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/ProcessServiceBase.java
@@ -112,7 +112,7 @@ public class ProcessServiceBase {
         ProcessStartSpec parameters = marshallerHelper.unmarshal(containerId, payload, marshallingType, ProcessStartSpec.class);
 
         logger.debug("Calling start process with id {} on container {} and parameters {}", processId, containerId, parameters.getVariables());
-        Long newProcessInstanceId = processService.startProcessFromNodeIds(containerId, processId, parameters.getVariables());
+        Long newProcessInstanceId = processService.startProcessFromNodeIds(containerId, processId, parameters.getVariables(), parameters.getNodeIds().stream().toArray(String[]::new));
 
         // return response
         return marshallerHelper.marshal(containerId, marshallingType, newProcessInstanceId);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/StartProcessServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/StartProcessServiceIntegrationTest.java
@@ -80,9 +80,14 @@ public class StartProcessServiceIntegrationTest extends JbpmKieServerBaseIntegra
 
             processInstanceId = null;
             processInstanceId = processClient.startProcessFromNodeIds(CONTAINER_ID_RESTART, PROCESS_ID_RESTART, parameters, nodeIds);
+
             assertNotNull(processInstance);
             assertEquals(org.kie.api.runtime.process.ProcessInstance.STATE_ACTIVE, processInstance.getState().intValue());
 
+            list = this.processClient.findNodeInstancesByType(CONTAINER_ID_RESTART, processInstanceId, "START", 0, 10);
+            assertNotNull(list);
+            assertThat(list.size(), is(1));
+            assertThat(list.get(0).getName(), is("Human Task"));
             processClient.abortProcessInstance(CONTAINER_ID_RESTART, processInstanceId);
         } catch (Exception e) {
             if (processInstanceId != null) {


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/JBPM-9416

missing node id list when starting from node ids without correlation key.