### PR TITLE
[7.44.x] [JBPM-9415] ClassNotFoundException in kie-server-integ-tests-all test…

### DIFF
--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-integ-tests-sample/pom.xml
@@ -32,12 +32,6 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-rs-service-description-swagger</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.cxf</groupId>
-          <artifactId>cxf-rt-rs-service-description-swagger-ui</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.swagger</groupId>


### PR DESCRIPTION
…s running on SpringBoot

Change affects just tests.

Cherrypick of https://github.com/kiegroup/droolsjbpm-integration/pull/2268

Signed-off-by: Karel Suta <ksuta@redhat.com>

**Thank you for submitting this pull request**

**JIRA**: 

[JBPM-9415](https://issues.redhat.com/browse/JBPM-9415)

**referenced Pull Requests**: 

* https://github.com/kiegroup/droolsjbpm-integration/pull/2268

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
