### PR TITLE
[7.44.x] Mark unstable tests to be skipped by PR check

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerStartupIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerStartupIntegrationTest.java
@@ -22,6 +22,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.kie.server.api.model.KieContainerResource;
 import org.kie.server.api.model.KieContainerResourceList;
 import org.kie.server.api.model.KieContainerStatus;
@@ -36,6 +37,7 @@ import org.kie.server.controller.api.model.spec.ContainerConfig;
 import org.kie.server.controller.api.model.spec.ContainerSpec;
 import org.kie.server.controller.api.model.spec.ServerTemplate;
 import org.kie.server.controller.api.model.spec.ServerTemplateList;
+import org.kie.server.integrationtests.category.UnstableOnJenkinsPrBuilder;
 import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
@@ -183,6 +185,7 @@ public class KieControllerStartupIntegrationTest extends KieControllerManagement
     }
 
     @Test
+    @Category({UnstableOnJenkinsPrBuilder.class})
     public void testContainerDisposedAfterStartup() throws Exception {
         // Getting info from currently started kie server.
         ServiceResponse<KieServerInfo> kieServerInfo = client.getServerInfo();

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/NotificationSaveContentIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/NotificationSaveContentIntegrationTest.java
@@ -25,6 +25,7 @@ import org.kie.api.KieServices;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.integrationtests.category.JEEOnly;
+import org.kie.server.integrationtests.category.UnstableOnJenkinsPrBuilder;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.KieServerSynchronization;
 
@@ -34,7 +35,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.kie.api.task.model.Status.Reserved;
 
-@Category(JEEOnly.class)
+@Category({JEEOnly.class,UnstableOnJenkinsPrBuilder.class}) // https://issues.redhat.com/browse/JBPM-9383
 public class NotificationSaveContentIntegrationTest extends JbpmKieServerBaseIntegrationTest {
 
     private static ReleaseId releaseId = new ReleaseId("org.kie.server.testing", CONTAINER_ID_NOTIFICATION,


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

Cherrypick of https://github.com/kiegroup/droolsjbpm-integration/pull/2256

**Thank you for submitting this pull request**

**JIRA**: 

[JBPM-9383](https://issues.redhat.com/browse/JBPM-9383)

**referenced Pull Requests**: 

* https://github.com/kiegroup/droolsjbpm-integration/pull/2256

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
