### PR TITLE
[JBPM-9421] Temporary disable ScenarioSimulationIntegrationTest

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-scenario-simulation/src/test/java/org/kie/server/integrationtests/scenariosimulation/ScenarioSimulationIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-scenario-simulation/src/test/java/org/kie/server/integrationtests/scenariosimulation/ScenarioSimulationIntegrationTest.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.kie.api.KieServices;
 import org.kie.server.api.model.KieServiceResponse.ResponseType;
 import org.kie.server.api.model.ReleaseId;
@@ -31,12 +32,14 @@ import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.api.model.scenariosimulation.ScenarioSimulationResult;
 import org.kie.server.client.KieServicesClient;
 import org.kie.server.client.ScenarioSimulationServicesClient;
+import org.kie.server.integrationtests.category.UnstableOnJenkinsPrBuilder;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.basetests.RestJmsSharedBaseIntegrationTest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+@Category({UnstableOnJenkinsPrBuilder.class}) // remove once https://issues.redhat.com/browse/JBPM-9421 is fixed
 public class ScenarioSimulationIntegrationTest
         extends RestJmsSharedBaseIntegrationTest {
 


### PR DESCRIPTION
Should be enabled back once JBPM-9421 is fixed

Signed-off-by: Karel Suta <ksuta@redhat.com>

**Thank you for submitting this pull request**

**JIRA**: 

[JBPM-9421](https://issues.redhat.com/browse/JBPM-9421)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
