### PR TITLE
[7.44.x] [JBPM-9309] Skip SLA test for WebLogic

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/SLAComplianceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/SLAComplianceIntegrationTest.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -40,6 +41,7 @@ import org.kie.server.api.model.instance.NodeInstance;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.api.model.instance.TaskSummary;
 import org.kie.server.integrationtests.category.UnstableOnJenkinsPrBuilder;
+import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.KieServerSynchronization;
 
@@ -129,6 +131,8 @@ public class SLAComplianceIntegrationTest extends JbpmKieServerBaseIntegrationTe
     @Test
     @Category({UnstableOnJenkinsPrBuilder.class})
     public void testSLAonUserTaskViolated() throws Exception {
+        Assume.assumeFalse(TestConfig.isWebLogicHomeProvided()); //Skip the test for WebLogic due to deadlock issues related to https://issues.redhat.com/browse/JBPM-9309
+
         Long pid = processClient.startProcess(CONTAINER_ID, PROCESS_ID_USERTASK_WITH_SLA_ON_TASK, new HashMap<>());
         assertProcessInstance(pid, STATE_ACTIVE, SLA_NA);
 


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

Cherrypick of https://github.com/kiegroup/droolsjbpm-integration/pull/2291, affects just tests.

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[JBPM-9309](https://issues.redhat.com/browse/JBPM-9309)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
