### PR TITLE
JBPM-9410 - No Model definition in KIE Server Swagger API - revapi fix

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-case-mgmt/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-case-mgmt/pom.xml
@@ -71,9 +71,6 @@
       <plugin>
         <groupId>org.revapi</groupId>
         <artifactId>revapi-maven-plugin</artifactId>
-        <configuration>
-          <failSeverity>breaking</failSeverity>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-case-mgmt/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-case-mgmt/src/build/revapi-config.json
@@ -28,7 +28,36 @@
     "ignores": {
         "revapi": {
             "_comment": "Changes between 7.44.0.Final and the current branch. These changes are desired and thus ignored.",
-            "ignore": []
+            "ignore": [
+                {
+                    "code": "java.annotation.attributeRemoved",
+                    "annotationType": "io.swagger.annotations.ApiOperation",
+                    "attribute": "response",
+                    "elementKind": "method",
+                    "justification": "[JBPM-9410] No Model definition in KIE Server Swagger API"
+                },
+                {
+                    "code": "java.annotation.attributeRemoved",
+                    "annotationType": "io.swagger.annotations.ApiOperation",
+                    "attribute": "code",
+                    "elementKind": "method",
+                    "justification": "[JBPM-9410] No Model definition in KIE Server Swagger API"
+                },
+                {
+                    "code": "java.annotation.attributeValueChanged",
+                    "annotationType": "io.swagger.annotations.ApiResponses",
+                    "attribute": "value",
+                    "elementKind": "method",
+                    "justification": "[JBPM-9410] No Model definition in KIE Server Swagger API"
+                },
+                {
+                    "code": "java.annotation.attributeAdded",
+                    "annotationType": "io.swagger.annotations.ApiOperation",
+                    "attribute": "response",
+                    "elementKind": "method",
+                    "justification": "[JBPM-9410] No Model definition in KIE Server Swagger API"
+                }
+            ]
         }
     }
 }

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/pom.xml
@@ -174,9 +174,6 @@
       <plugin>
         <groupId>org.revapi</groupId>
         <artifactId>revapi-maven-plugin</artifactId>
-        <configuration>
-          <failSeverity>breaking</failSeverity>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/build/revapi-config.json
@@ -28,7 +28,43 @@
     "ignores": {
         "revapi": {
             "_comment": "Changes between 7.44.0.Final and the current branch. These changes are desired and thus ignored.",
-            "ignore": []
+            "ignore": [
+                {
+                    "code": "java.annotation.attributeValueChanged",
+                    "annotationType": "io.swagger.annotations.ApiResponses",
+                    "attribute": "value",
+                    "elementKind": "method",
+                    "justification": "[JBPM-9410] No Model definition in KIE Server Swagger API"
+                },
+                {
+                    "code": "java.annotation.attributeRemoved",
+                    "annotationType": "io.swagger.annotations.ApiOperation",
+                    "attribute": "code",
+                    "elementKind": "method",
+                    "justification": "[JBPM-9410] No Model definition in KIE Server Swagger API"
+                },
+                {
+                    "code": "java.annotation.attributeRemoved",
+                    "annotationType": "io.swagger.annotations.ApiOperation",
+                    "attribute": "response",
+                    "elementKind": "method",
+                    "justification": "[JBPM-9410] No Model definition in KIE Server Swagger API"
+                },
+                {
+                    "code": "java.annotation.attributeRemoved",
+                    "annotationType": "io.swagger.annotations.ApiOperation",
+                    "attribute": "responseContainer",
+                    "elementKind": "method",
+                    "justification": "[JBPM-9410] No Model definition in KIE Server Swagger API"
+                },
+                {
+                    "code": "java.annotation.attributeAdded",
+                    "annotationType": "io.swagger.annotations.ApiOperation",
+                    "attribute": "response",
+                    "elementKind": "method",
+                    "justification": "[JBPM-9410] No Model definition in KIE Server Swagger API"
+                }
+            ]
         }
     }
 }


### PR DESCRIPTION
**JIRA**: [JBPM-9410](https://issues.redhat.com/browse/JBPM-9410)

Follow-up of #2263 

We don't need to ignore every potentially breaking change. Revapi ignores work like filters and the less specific the filter is, the more it will ignore. So there is no need to ignore them one by one :) If we left the current configuration (only breaking changes are failing the build), we would miss any potential changes in future regarding endpoints, i.e. JAX-RS annotations configuration.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
