### PR TITLE
(GSS) [7.44.x] [JBPM-9423] Duplicate container-info entries in kie-server-router.json file if we create containers with unique container-alias

### DIFF
--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/Configuration.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/Configuration.java
@@ -57,7 +57,9 @@ public class Configuration {
             hosts = new ArrayList<>();
             hostsPerContainer.put(containerId, hosts);
         }
-        hosts.add(serverUrl);
+        if(!hosts.contains(serverUrl)) {
+            hosts.add(serverUrl);
+        }
 
         this.listeners.forEach(l -> l.onContainerAdded(containerId, serverUrl));
     }
@@ -68,7 +70,9 @@ public class Configuration {
             hosts = new ArrayList<>();
             hostsPerServer.put(serverId, hosts);
         }
-        hosts.add(serverUrl);
+        if(!hosts.contains(serverUrl)) {
+            hosts.add(serverUrl);
+        }
 
         this.listeners.forEach(l -> l.onServerAdded(serverId, serverUrl));
     }
@@ -79,14 +83,18 @@ public class Configuration {
             containersByAlias = new ArrayList<>();
             containerInfosPerContainer.put(containerInfo.getAlias(), containersByAlias);
         }
-        containersByAlias.add(containerInfo);
+        if(!containersByAlias.contains(containerInfo)) {
+            containersByAlias.add(containerInfo);
+        }
 
         List<ContainerInfo> containersById = containerInfosPerContainer.get(containerInfo.getContainerId());
         if (containersById == null) {
             containersById = new ArrayList<>();
             containerInfosPerContainer.put(containerInfo.getContainerId(), containersById);
         }
-        containersById.add(containerInfo);
+        if(!containersById.contains(containerInfo)) {
+            containersById.add(containerInfo);
+        }
     }
     
     public void removeContainerHost(String containerId, String serverUrl) {

--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/ContainerInfo.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/ContainerInfo.java
@@ -51,6 +51,10 @@ public class ContainerInfo {
         this.releaseId = releaseId;
     }
 
+    public String getKey() {
+        return alias + "-" + containerId + "-" + releaseId;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/repository/ConfigurationMarshaller.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/repository/ConfigurationMarshaller.java
@@ -62,13 +62,12 @@ public class ConfigurationMarshaller {
         }
         Set<String> processed = new HashSet<>();
         for (Entry<String, List<ContainerInfo>> entry : containerInfo.entrySet()) {
-            if (processed.contains(entry.getKey())) {
-                continue;
-            }
             entry.getValue().forEach(ci -> {
+                if(processed.contains(ci.getKey())) {
+                    return;
+                }
                 JSONObject jsonCI = new JSONObject();
-                processed.add(ci.getAlias());
-                processed.add(ci.getContainerId());
+                processed.add(ci.getKey());
                 try {
                     jsonCI.put("alias", ci.getAlias());
                     jsonCI.put("containerId", ci.getContainerId());

--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/test/java/org/kie/server/router/ConfigurationTest.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/test/java/org/kie/server/router/ConfigurationTest.java
@@ -16,6 +16,7 @@
 package org.kie.server.router;
 
 import org.junit.Test;
+import org.kie.server.router.repository.ConfigurationMarshaller;
 import org.kie.server.router.spi.ConfigRepository;
 
 import static org.junit.Assert.assertEquals;
@@ -25,6 +26,55 @@ import org.assertj.core.api.Assertions;
 
 public class ConfigurationTest {
 
+    @Test
+    public void testAddDuplicateContainer() throws Exception {
+
+        Configuration configuration = new Configuration();
+        
+        String containerId = "itorders_1.01";
+        String serverUrl = "http://localhost:8090/kie-server/services/rest/server";
+        String alias = "itorders_1.01";
+        String serverId = "default-kieServer";
+        String releaseId = "1.0";
+        
+        
+        ContainerInfo containerInfo = new ContainerInfo(containerId, alias, releaseId);
+        configuration.addContainerHost(containerId, serverUrl);
+        configuration.addContainerHost(alias, serverUrl);
+        configuration.addServerHost(serverId, serverUrl);
+        configuration.addContainerInfo(containerInfo);
+        
+        
+        serverUrl = "http://localhost:8190/kie-server/services/rest/server";
+      
+        containerInfo = new ContainerInfo(containerId, alias, releaseId);
+        configuration.addContainerHost(containerId, serverUrl);
+        configuration.addContainerHost(alias, serverUrl);
+        configuration.addServerHost(serverId, serverUrl);
+        configuration.addContainerInfo(containerInfo);
+
+        serverUrl = "http://localhost:8290/kie-server/services/rest/server";
+        
+        containerInfo = new ContainerInfo(containerId, alias, releaseId);
+        configuration.addContainerHost(containerId, serverUrl);
+        configuration.addContainerHost(alias, serverUrl);
+        configuration.addServerHost(serverId, serverUrl);
+        configuration.addContainerInfo(containerInfo);
+
+        alias = "itorders_1.0.1";
+        containerInfo = new ContainerInfo(containerId, alias, releaseId);
+        configuration.addContainerHost(containerId, serverUrl);
+        configuration.addContainerHost(alias, serverUrl);
+        configuration.addServerHost(serverId, serverUrl);
+        configuration.addContainerInfo(containerInfo);
+
+        assertEquals(2, configuration.getHostsPerContainer().size());
+        assertEquals(1, configuration.getHostsPerServer().size());
+
+        assertEquals(3, configuration.getHostsPerContainer().get("itorders_1.01").size());
+        assertEquals(1, configuration.getHostsPerContainer().get("itorders_1.0.1").size());
+        assertEquals(3, configuration.getHostsPerServer().get("default-kieServer").size());
+    }
 
     @Test
     public void testRemoveServerWhenUnavailable() {
@@ -115,8 +165,8 @@ public class ConfigurationTest {
         assertEquals(2, config.getHostsPerContainer().size());
         assertEquals(1, config.getHostsPerServer().size());
 
-        assertEquals(2, config.getHostsPerContainer().get("container1").size());        
-        assertEquals(2, config.getHostsPerServer().get("server1").size());
+        assertEquals(1, config.getHostsPerContainer().get("container1").size());        
+        assertEquals(1, config.getHostsPerServer().get("server1").size());
 
         config.removeContainerHost("container1", "http://localhost:8080/server");
         config.removeContainerHost("container", "http://localhost:8080/server");
@@ -127,8 +177,8 @@ public class ConfigurationTest {
         assertEquals(2, config.getHostsPerContainer().size());
         assertEquals(1, config.getHostsPerServer().size());
 
-        assertEquals(1, config.getHostsPerContainer().get("container1").size());       
-        assertEquals(1, config.getHostsPerServer().get("server1").size());
+        assertEquals(0, config.getHostsPerContainer().get("container1").size());       
+        assertEquals(0, config.getHostsPerServer().get("server1").size());
     }
     
     @Test


### PR DESCRIPTION
correcting marshalling and computation of the host, servers and containers in the router configuration

Jira [link](https://issues.redhat.com/browse/JBPM-9423)

cherry pick from 
https://github.com/kiegroup/droolsjbpm-integration/commit/59f3ef91ad04957debc69758ccb82ba79a8212c0