### PR TITLE
JBPM-9431: Unable to add deployment unit while creating very first container (#2295)

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerInstanceManager.java
@@ -497,6 +497,7 @@ public class KieServerInstanceManager {
 
             Container container = new Container();
             container.setContainerSpecId(containerSpec.getId());
+            container.setResolvedReleasedId(containerSpec.getReleasedId());
             container.setServerTemplateId(serverTemplate.getId());
             container.setServerInstanceId(instanceUrl.getServerInstanceId());
             container.setUrl(instanceUrl.getUrl() + "/containers/" + containerSpec.getId());


### PR DESCRIPTION
* Backport of https://github.com/kiegroup/droolsjbpm-integration/pull/2295

(cherry picked from commit 121c1d2d336e20e00a5f68241a77231cde32887d)

**JIRA**: 
 * [RHPAM-3254](https://issues.redhat.com/browse/RHPAM-3254)
 * [JBPM-9431](https://issues.redhat.com/browse/JBPM-9431)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
