### PR TITLE
 DROOLS-5793 kie-server marshaller simpleclass name clash with DMN symbol

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
@@ -561,6 +561,17 @@ public class JSONMarshaller implements Marshaller {
         }
     }
 
+    public static class PassThruMapStringObjectDeserializer extends JsonDeserializer<Map<String, Object>> {
+
+        @Override
+        public Map<String, Object> deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+            @SuppressWarnings("unchecked") // purpose-built (/used) JsonDeserializer
+            HashMap<String, Object> result = p.readValueAs(HashMap.class);
+            return result;
+        }
+
+    }
+
     class CustomObjectSerializer extends JsonSerializer<Object> {
 
         private ObjectMapper customObjectMapper;

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/dmn/DMNContextKS.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/dmn/DMNContextKS.java
@@ -28,9 +28,12 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
 import org.drools.core.xml.jaxb.util.JaxbUnknownAdapter;
+import org.kie.server.api.marshalling.json.JSONMarshaller;
 
 @XmlAccessorType(XmlAccessType.FIELD)
 @XmlRootElement(name = "dmn-evaluation-context")
@@ -62,6 +65,8 @@ public class DMNContextKS {
     @XmlElement(name = "dmn-context")
     @XStreamAlias("dmn-context")
     @XmlJavaTypeAdapter(JaxbUnknownAdapter.class)
+    @JsonSerialize(using = JSONMarshaller.PassThruSerializer.class)
+    @JsonDeserialize(using = JSONMarshaller.PassThruMapStringObjectDeserializer.class)
     private Map<String, Object> dmnContext = new HashMap<>();
 
     public DMNContextKS() {

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/dmn/DMNResultKS.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/dmn/DMNResultKS.java
@@ -73,7 +73,7 @@ public class DMNResultKS implements DMNResult {
     @XStreamAlias("dmn-context")
     @XmlJavaTypeAdapter(JaxbUnknownAdapter.class)
     @JsonSerialize(using = JSONMarshaller.PassThruSerializer.class)
-    @JsonDeserialize(using = JSONMarshaller.PassThruMapStringObjectDeserializer.class) // keyAs = String.class) // using = JSONMarshaller.PassThruMapStringObjectDeserializer.class)
+    @JsonDeserialize(using = JSONMarshaller.PassThruMapStringObjectDeserializer.class)
     private Map<String, Object> dmnContext = new HashMap<>();
 
     // concrete implementation of DMNMessage and DMNDecisionResult are needed in order to have proper marshalling

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/dmn/DMNResultKS.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/dmn/DMNResultKS.java
@@ -38,6 +38,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 import com.thoughtworks.xstream.annotations.XStreamImplicit;
@@ -72,6 +73,7 @@ public class DMNResultKS implements DMNResult {
     @XStreamAlias("dmn-context")
     @XmlJavaTypeAdapter(JaxbUnknownAdapter.class)
     @JsonSerialize(using = JSONMarshaller.PassThruSerializer.class)
+    @JsonDeserialize(using = JSONMarshaller.PassThruMapStringObjectDeserializer.class) // keyAs = String.class) // using = JSONMarshaller.PassThruMapStringObjectDeserializer.class)
     private Map<String, Object> dmnContext = new HashMap<>();
 
     // concrete implementation of DMNMessage and DMNDecisionResult are needed in order to have proper marshalling

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/DMNContextKSMarshallingTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/DMNContextKSMarshallingTest.java
@@ -35,6 +35,7 @@ import org.kie.server.api.model.dmn.DMNContextKS;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -188,7 +189,7 @@ public class DMNContextKSMarshallingTest {
     @Test
     public void testJsonMarshalling() {
         final String result = jsonMarshaller.marshall(BEAN);
-        assertEquals(JSON, result); // TODO: jsonpath?
+        assertThat(result).isEqualToIgnoringWhitespace(JSON);
     }
 
     @Test

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/dmn/JSONAPIRoundTripTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/dmn/JSONAPIRoundTripTest.java
@@ -55,7 +55,7 @@ public class JSONAPIRoundTripTest {
         Assertions.assertThat(applicant2).isEqualTo(applicant);
 
         DMNContext ctx = new DMNContextImpl();
-        ctx.set("Applicant", applicant);
+        ctx.set("Applicant", applicant); // VERY IMPORTANT that the map key is "Applicant" with the capital-A.
 
         DMNContextKS contextKS = new DMNContextKS("ns1", "model1", ctx.getAll());
         DMNContextKS contextKS2 = roundTrip(contextKS);

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/dmn/JSONAPIRoundTripTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/dmn/JSONAPIRoundTripTest.java
@@ -126,20 +126,26 @@ public class JSONAPIRoundTripTest {
 
         @Override
         public boolean equals(Object obj) {
-            if (this == obj)
+            if (this == obj) {
                 return true;
-            if (obj == null)
+            }
+            if (obj == null) {
                 return false;
-            if (getClass() != obj.getClass())
+            }
+            if (getClass() != obj.getClass()) {
                 return false;
+            }
             Applicant other = (Applicant) obj;
-            if (age != other.age)
+            if (age != other.age) {
                 return false;
+            }
             if (name == null) {
-                if (other.name != null)
+                if (other.name != null) {
                     return false;
-            } else if (!name.equals(other.name))
+                }
+            } else if (!name.equals(other.name)) {
                 return false;
+            }
             return true;
         }
 

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/dmn/JSONAPIRoundTripTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/dmn/JSONAPIRoundTripTest.java
@@ -55,7 +55,7 @@ public class JSONAPIRoundTripTest {
         Assertions.assertThat(applicant2).isEqualTo(applicant);
 
         DMNContext ctx = new DMNContextImpl();
-        ctx.set("Applicant", applicant); // VERY IMPORTANT that the map key is "Applicant" with the capital-A.
+        ctx.set("Applicant", applicant); // VERY IMPORTANT that the map key is "Applicant" with the capital-A to clash with Application.class simple name.
 
         DMNContextKS contextKS = new DMNContextKS("ns1", "model1", ctx.getAll());
         DMNContextKS contextKS2 = roundTrip(contextKS);

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/dmn/JSONAPIRoundTripTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/dmn/JSONAPIRoundTripTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.server.api.model.dmn;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.dmn.api.core.DMNContext;
+import org.kie.dmn.api.core.DMNDecisionResult.DecisionEvaluationStatus;
+import org.kie.dmn.core.impl.DMNContextImpl;
+import org.kie.dmn.core.impl.DMNDecisionResultImpl;
+import org.kie.dmn.core.impl.DMNResultImpl;
+import org.kie.server.api.marshalling.Marshaller;
+import org.kie.server.api.marshalling.MarshallerFactory;
+import org.kie.server.api.marshalling.MarshallingFormat;
+import org.kie.server.api.model.KieServiceResponse.ResponseType;
+import org.kie.server.api.model.ServiceResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JSONAPIRoundTripTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JSONAPIRoundTripTest.class);
+    private Marshaller marshaller;
+
+    @Before
+    public void init() {
+        Set<Class<?>> extraClasses = new HashSet<Class<?>>();
+        extraClasses.add(Applicant.class);
+        marshaller = MarshallerFactory.getMarshaller(extraClasses, MarshallingFormat.JSON, this.getClass().getClassLoader());
+    }
+
+    @Test
+    public void test() {
+        Applicant applicant = new Applicant("John Doe", 47);
+        Applicant applicant2 = roundTrip(applicant);
+        Assertions.assertThat(applicant2).isEqualTo(applicant);
+
+        DMNContext ctx = new DMNContextImpl();
+        ctx.set("Applicant", applicant);
+
+        DMNContextKS contextKS = new DMNContextKS("ns1", "model1", ctx.getAll());
+        DMNContextKS contextKS2 = roundTrip(contextKS);
+        Assertions.assertThat(contextKS2.getDmnContext()).isEqualTo(contextKS.getDmnContext());
+        Assertions.assertThat(contextKS2.toString()).isEqualTo(contextKS.toString());
+
+        DMNResultImpl dmnResults = new DMNResultImpl(null);
+        dmnResults.setContext(ctx);
+        dmnResults.addDecisionResult(new DMNDecisionResultImpl("decision", "decision", DecisionEvaluationStatus.SUCCEEDED, applicant, Collections.emptyList()));
+
+        DMNResultKS resultsKS = new DMNResultKS(dmnResults);
+        DMNResultKS resultsKS2 = roundTrip(resultsKS);
+        Assertions.assertThat(resultsKS2.getContext().getAll()).isEqualTo(resultsKS.getContext().getAll());
+
+        ServiceResponse<DMNResultKS> sr = new ServiceResponse<DMNResultKS>(ResponseType.SUCCESS, "ok", resultsKS);
+        ServiceResponse<DMNResultKS> sr2 = roundTrip(sr);
+        Assertions.assertThat(sr2.getResult().getContext().getAll()).isEqualTo(sr.getResult().getContext().getAll());
+    }
+
+    private <T> T roundTrip(T input) {
+        String asJSON = marshaller.marshall(input);
+        LOG.debug("{}", asJSON);
+        @SuppressWarnings("unchecked") // intentional due to type-erasure.
+        T unmarshall = (T) marshaller.unmarshall(asJSON, input.getClass());
+        LOG.debug("{}", unmarshall);
+        return unmarshall;
+    }
+
+    public static class Applicant {
+
+        private String name;
+        private int age;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        public void setAge(int age) {
+            this.age = age;
+        }
+
+        public Applicant() {
+
+        }
+
+        public Applicant(String name, int age) {
+            super();
+            this.name = name;
+            this.age = age;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + age;
+            result = prime * result + ((name == null) ? 0 : name.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            Applicant other = (Applicant) obj;
+            if (age != other.age)
+                return false;
+            if (name == null) {
+                if (other.name != null)
+                    return false;
+            } else if (!name.equals(other.name))
+                return false;
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "Applicant [name=" + name + ", age=" + age + "]";
+        }
+
+    }
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/json-applicant/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/json-applicant/pom.xml
@@ -1,0 +1,24 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.kie.server.testing</groupId>
+    <artifactId>common-parent</artifactId>
+    <version>1.0.0.Final</version>
+  </parent>
+
+  <artifactId>json-applicant</artifactId>
+  <version>1.0.0.Final</version>
+  <packaging>kjar</packaging>
+
+<!-- there should be no need for Kie, Kie-DMN, etc dependencies here -->
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/json-applicant/src/main/java/com/acme/Address.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/json-applicant/src/main/java/com/acme/Address.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.acme;
 
 public class Address {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/json-applicant/src/main/java/com/acme/Address.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/json-applicant/src/main/java/com/acme/Address.java
@@ -1,0 +1,31 @@
+package com.acme;
+
+public class Address {
+    private String country;
+    private String zip;
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public String getZip() {
+        return zip;
+    }
+
+    public void setZip(String zip) {
+        this.zip = zip;
+    }
+
+    public Address(){
+
+    }
+
+    public Address(String country, String zip) {
+        this.country = country;
+        this.zip = zip;
+    }
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/json-applicant/src/main/java/com/acme/Applicant.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/json-applicant/src/main/java/com/acme/Applicant.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.acme;
 
 public class Applicant {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/json-applicant/src/main/java/com/acme/Applicant.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/json-applicant/src/main/java/com/acme/Applicant.java
@@ -1,0 +1,44 @@
+package com.acme;
+
+public class Applicant {
+
+    private String name;
+    private int age;
+    private Address address;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+
+    public Applicant() {
+
+    }
+
+    public Applicant(String name, Integer age, Address address) {
+        this.name = name;
+        this.age = age;
+        this.address = address;
+    }
+
+
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/json-applicant/src/main/resources/META-INF/kmodule.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/json-applicant/src/main/resources/META-INF/kmodule.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kmodule xmlns="http://www.drools.org/xsd/kmodule">
+  <!-- This is a minimal kmodule.xml. Ref Drools documentation, see http://docs.jboss.org/drools/release/6.1.0.Final/drools-docs/html_single/index.html#d0e1112 -->
+</kmodule>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/json-applicant/src/main/resources/model1.dmn
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/json-applicant/src/main/resources/model1.dmn
@@ -1,0 +1,50 @@
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_EB0C0DE7-9BC0-4CE2-B406-5F25550B9F76" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_CD69D4CF-9E6D-43C0-B46C-3D645181A5DD" name="model1" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_EB0C0DE7-9BC0-4CE2-B406-5F25550B9F76">
+  <dmn:extensionElements/>
+  <dmn:inputData id="_5D08708A-A742-4833-A990-0187D11AF63E" name="Applicant">
+    <dmn:extensionElements/>
+    <dmn:variable id="_A3740E26-C10B-429A-9DFA-C18451BD3E1D" name="Applicant" typeRef="number"/>
+  </dmn:inputData>
+  <dmn:decision id="_7DCF0719-4E1E-41DC-BF63-E973032E4E2B" name="Decision-1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_A2CC3F7F-1506-40C0-B2FB-428E42879F61" name="Decision-1" typeRef="boolean"/>
+    <dmn:informationRequirement id="_3FA46A65-5A65-473A-9FA8-7D1A40C7DA52">
+      <dmn:requiredInput href="#_5D08708A-A742-4833-A990-0187D11AF63E"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_34998C52-CD2A-4935-8756-BB8615CFDD71">
+      <dmn:text>Applicant &gt;= 18</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_F62AFEC7-1FC6-4B21-A7A9-279BE00D7D72" name="DRG">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_34998C52-CD2A-4935-8756-BB8615CFDD71">
+            <kie:width>300</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-drg-_5D08708A-A742-4833-A990-0187D11AF63E" dmnElementRef="_5D08708A-A742-4833-A990-0187D11AF63E" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="225" y="176" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_7DCF0719-4E1E-41DC-BF63-E973032E4E2B" dmnElementRef="_7DCF0719-4E1E-41DC-BF63-E973032E4E2B" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="405" y="176" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-drg-_3FA46A65-5A65-473A-9FA8-7D1A40C7DA52" dmnElementRef="_3FA46A65-5A65-473A-9FA8-7D1A40C7DA52">
+        <di:waypoint x="325" y="201"/>
+        <di:waypoint x="405" y="201"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/json-applicant/src/main/resources/model2.dmn
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/filtered-resources/kjars-sources/json-applicant/src/main/resources/model2.dmn
@@ -1,0 +1,69 @@
+<dmn:definitions xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns="https://kiegroup.org/dmn/_8E568485-BC02-4917-830C-39D17632BD3A" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:kie="http://www.drools.org/kie/dmn/1.2" xmlns:dmndi="http://www.omg.org/spec/DMN/20180521/DMNDI/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="_411A544C-F55F-4F2F-8C5E-2D2AFCF2A3BA" name="model2" typeLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" namespace="https://kiegroup.org/dmn/_8E568485-BC02-4917-830C-39D17632BD3A">
+  <dmn:extensionElements/>
+  <dmn:itemDefinition id="_20BA4B02-96BE-45B6-BF15-985D47A55BC5" name="Applicant" isCollection="false">
+    <dmn:itemComponent id="_144175C9-8F70-4659-81F6-DED7DD4E3BC1" name="name" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_88CD703C-D910-451E-A954-1CF53076682D" name="age" isCollection="false">
+      <dmn:typeRef>number</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_5DD0FC45-114E-4D61-A3DF-C1E99F0C8621" name="address" isCollection="false">
+      <dmn:typeRef>Address</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:itemDefinition id="_03F6DB61-9667-473C-BA03-B5BE3B250F67" name="Address" isCollection="false">
+    <dmn:itemComponent id="_B758E5A5-6839-4504-8577-88E350BBB35C" name="country" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+    <dmn:itemComponent id="_76EFB13B-330C-414F-A174-5339B2799A00" name="zip" isCollection="false">
+      <dmn:typeRef>string</dmn:typeRef>
+    </dmn:itemComponent>
+  </dmn:itemDefinition>
+  <dmn:inputData id="_A7A102A9-FE6B-4FB8-8F29-6A6A80972695" name="Applicant">
+    <dmn:extensionElements/>
+    <dmn:variable id="_F0DAC9F9-A81B-4D4E-B2A0-01671276E7AF" name="Applicant" typeRef="Applicant"/>
+  </dmn:inputData>
+  <dmn:decision id="_CA6FD119-1698-4A8F-A804-4CDC653CCF07" name="Decision-1">
+    <dmn:extensionElements/>
+    <dmn:variable id="_97F63C37-67C2-4483-84FE-FCC0CC56737C" name="Decision-1" typeRef="string"/>
+    <dmn:informationRequirement id="_78EB2828-C493-4312-98B4-E65D00DD5F23">
+      <dmn:requiredInput href="#_A7A102A9-FE6B-4FB8-8F29-6A6A80972695"/>
+    </dmn:informationRequirement>
+    <dmn:literalExpression id="_C17A7D9F-9AE0-4CC4-9313-2975302BF040">
+      <dmn:text>Applicant.name + " lives in " + Applicant.address.country</dmn:text>
+    </dmn:literalExpression>
+  </dmn:decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="_015713B4-A7DD-4979-9B9C-C002A5E56D5B" name="DRG">
+      <di:extension>
+        <kie:ComponentsWidthsExtension>
+          <kie:ComponentWidths dmnElementRef="_C17A7D9F-9AE0-4CC4-9313-2975302BF040">
+            <kie:width>562</kie:width>
+          </kie:ComponentWidths>
+        </kie:ComponentsWidthsExtension>
+      </di:extension>
+      <dmndi:DMNShape id="dmnshape-drg-_A7A102A9-FE6B-4FB8-8F29-6A6A80972695" dmnElementRef="_A7A102A9-FE6B-4FB8-8F29-6A6A80972695" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="263" y="264" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="dmnshape-drg-_CA6FD119-1698-4A8F-A804-4CDC653CCF07" dmnElementRef="_CA6FD119-1698-4A8F-A804-4CDC653CCF07" isCollapsed="false">
+        <dmndi:DMNStyle>
+          <dmndi:FillColor red="255" green="255" blue="255"/>
+          <dmndi:StrokeColor red="0" green="0" blue="0"/>
+          <dmndi:FontColor red="0" green="0" blue="0"/>
+        </dmndi:DMNStyle>
+        <dc:Bounds x="443" y="264" width="100" height="50"/>
+        <dmndi:DMNLabel/>
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="dmnedge-drg-_78EB2828-C493-4312-98B4-E65D00DD5F23" dmnElementRef="_78EB2828-C493-4312-98B4-E65D00DD5F23">
+        <di:waypoint x="363" y="289"/>
+        <di:waypoint x="443" y="289"/>
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</dmn:definitions>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/java/org/kie/server/integrationtests/dmn/DMNJsonApplicantIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-dmn/src/test/java/org/kie/server/integrationtests/dmn/DMNJsonApplicantIntegrationTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.integrationtests.dmn;
+
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.dmn.api.core.DMNContext;
+import org.kie.dmn.api.core.DMNResult;
+import org.kie.server.api.model.ReleaseId;
+import org.kie.server.api.model.ServiceResponse;
+import org.kie.server.integrationtests.shared.KieServerAssert;
+import org.kie.server.integrationtests.shared.KieServerDeployer;
+import org.kie.server.integrationtests.shared.KieServerReflections;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class DMNJsonApplicantIntegrationTest extends DMNKieServerBaseIntegrationTest {
+
+    private static final ReleaseId kjar1 = new ReleaseId("org.kie.server.testing", "json-applicant", "1.0.0.Final");
+
+    private static final String CONTAINER_1_ID = "json-applicant";
+
+    private static final String APPLICANT_FQCN = "com.acme.Applicant";
+    private static final String ADDRESS_FQCN = "com.acme.Address";
+
+    @BeforeClass
+    public static void deployArtifacts() {
+        KieServerDeployer.buildAndDeployCommonMavenParent();
+        KieServerDeployer.buildAndDeployMavenProjectFromResource("/kjars-sources/json-applicant");
+
+        kieContainer = KieServices.Factory.get().newKieContainer(kjar1);
+        createContainer(CONTAINER_1_ID, kjar1);
+    }
+
+    @Override
+    protected void addExtraCustomClasses(Map<String, Class<?>> extraClasses) throws Exception {
+        extraClasses.put(APPLICANT_FQCN, Class.forName(APPLICANT_FQCN, true, kieContainer.getClassLoader()));
+        extraClasses.put(ADDRESS_FQCN, Class.forName(ADDRESS_FQCN, true, kieContainer.getClassLoader()));
+    }
+
+    @Test
+    public void test_model1() {
+        DMNContext dmnContext = dmnClient.newContext();
+        dmnContext.set("Applicant", 47);
+
+        ServiceResponse<DMNResult> evaluateAll = dmnClient.evaluateAll(CONTAINER_1_ID,
+                                                                       "https://kiegroup.org/dmn/_EB0C0DE7-9BC0-4CE2-B406-5F25550B9F76",
+                                                                       "model1",
+                                                                       dmnContext);
+        KieServerAssert.assertSuccess(evaluateAll);
+        
+        DMNResult dmnResult = evaluateAll.getResult();
+        assertThat(dmnResult.getMessages().toString(), dmnResult.hasErrors(), is(false));
+
+        DMNContext result = dmnResult.getContext();
+        assertThat(result.get("Decision-1"), is(Boolean.TRUE));
+    }
+    
+    @Test
+    public void test_model2() {
+        DMNContext dmnContext = dmnClient.newContext();
+        Object address = KieServerReflections.createInstance(ADDRESS_FQCN, kieContainer.getClassLoader(), "Italy", "12345");
+        Object applicant = KieServerReflections.createInstance(APPLICANT_FQCN, kieContainer.getClassLoader(), "John Doe", 47, address);
+        dmnContext.set("Applicant", applicant);
+
+        ServiceResponse<DMNResult> evaluateAll = dmnClient.evaluateAll(CONTAINER_1_ID,
+                                                                       "https://kiegroup.org/dmn/_8E568485-BC02-4917-830C-39D17632BD3A",
+                                                                       "model2",
+                                                                       dmnContext);
+        KieServerAssert.assertSuccess(evaluateAll);
+
+        DMNResult dmnResult = evaluateAll.getResult();
+        assertThat(dmnResult.getMessages().toString(), dmnResult.hasErrors(), is(false));
+
+        DMNContext result = dmnResult.getContext();
+        assertThat(result.get("Decision-1"), is("John Doe lives in Italy"));
+    }
+
+}


### PR DESCRIPTION
Unfortunately the **generic kie-server marshaller** for JSON doesn't conform to Jackson's directive such as

```java
@JsonDeserialize(keyAs = String.class)
Map<String, Object> field ...
```



so there is no way to circumvent the following hard-constraint code-path during deserialization: 

https://github.com/kiegroup/droolsjbpm-integration/blob/1032eeb870afeea6dd9a9211b894badb4f1874d6/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java#L747-L751



That is because for the purpose of the JSON Marshaller, a string literal in JSON for a (json map) field key could identify a class not only if it correspond to the Java's FQCN of a domain object, but also by its **simple name**,
ref a little above here: 

https://github.com/kiegroup/droolsjbpm-integration/blob/1032eeb870afeea6dd9a9211b894badb4f1874d6/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java#L728-L732



this is a problem for the scenario as described in the linked JIRA.

This PR does not solve all the analogous problems which may arise for this **generic kie-server marshaller** "feature" but at least it solves for the DMN Client API DTOs, as experience demonstrated it is very likely to occur.

**JIRA**: https://issues.redhat.com/browse/DROOLS-5793

**referenced Pull Requests**: none

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
