### PR TITLE
[7.44.x] Use different port for embedded Kie server in WebSocketKieControllerS…

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerExecutor.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/KieServerExecutor.java
@@ -39,10 +39,19 @@ public class KieServerExecutor {
     // Need to hold kie server instance because we need to manually handle startup/shutdown behavior defined in
     // context listener org.kie.server.services.Bootstrap. Embedded server doesn't support ServletContextListeners.
     private KieServerImpl kieServer;
+    private int kieServerAllocatedPort;
 
     private String serverActivePolicies = "KeepLatestOnly";
 
     private static SimpleDateFormat serverIdSuffixDateFormat = new SimpleDateFormat("yyyy-MM-DD-HHmmss_SSS");
+
+    public KieServerExecutor() {
+        this(TestConfig.getKieServerAllocatedPort());
+    }
+
+    public KieServerExecutor(int kieServerAllocatedPort) {
+        this.kieServerAllocatedPort = kieServerAllocatedPort;
+    }
 
     public void startKieServer() {
         startKieServer(false);
@@ -58,7 +67,7 @@ public class KieServerExecutor {
         
 
         server = new TJWSEmbeddedJaxrsServer();
-        server.setPort(TestConfig.getKieServerAllocatedPort());
+        server.setPort(kieServerAllocatedPort);
         server.start();
 
         addServerSingletonResources();
@@ -77,7 +86,7 @@ public class KieServerExecutor {
         System.setProperty(KieServerConstants.KIE_SERVER_CONTROLLER, TestConfig.getControllerHttpUrl());
         System.setProperty(KieServerConstants.CFG_KIE_CONTROLLER_USER, TestConfig.getUsername());
         System.setProperty(KieServerConstants.CFG_KIE_CONTROLLER_PASSWORD, TestConfig.getPassword());
-        System.setProperty(KieServerConstants.KIE_SERVER_LOCATION, TestConfig.getEmbeddedKieServerHttpUrl());
+        System.setProperty(KieServerConstants.KIE_SERVER_LOCATION, "http://localhost:" + kieServerAllocatedPort + "/server");
         System.setProperty(KieServerConstants.KIE_SERVER_STATE_REPO, "./target");
         System.setProperty(KieServerConstants.CFG_SYNC_DEPLOYMENT, Boolean.toString(syncWithController));
         System.setProperty(KieServerConstants.KIE_SERVER_MODE, KieServerMode.PRODUCTION.name());


### PR DESCRIPTION
…tartupIntegrationTest

Signed-off-by: Karel Suta <ksuta@redhat.com>

**Thank you for submitting this pull request**

**referenced Pull Requests**:

* https://github.com/kiegroup/droolsjbpm-integration/pull/2312

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
