### PR TITLE
DROOLS-5803 Fix kie-camel dep not in MavenCentral xercesImpl 2.12.0.SP02

### DIFF
--- a/kie-camel/pom.xml
+++ b/kie-camel/pom.xml
@@ -150,10 +150,10 @@
       <artifactId>cxf-core</artifactId>
     </dependency>
 
-    <dependency>
+    <!-- <dependency>
       <groupId>xerces</groupId>
       <artifactId>xercesImpl</artifactId>
-    </dependency>
+    </dependency> -->
 
     <dependency>
       <groupId>org.apache.camel</groupId>

--- a/kie-camel/pom.xml
+++ b/kie-camel/pom.xml
@@ -150,11 +150,6 @@
       <artifactId>cxf-core</artifactId>
     </dependency>
 
-    <!-- <dependency>
-      <groupId>xerces</groupId>
-      <artifactId>xercesImpl</artifactId>
-    </dependency> -->
-
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-cxf</artifactId>
@@ -170,6 +165,10 @@
         <exclusion>
           <groupId>org.springframework</groupId>
           <artifactId>spring-jcl</artifactId>
+        </exclusion>
+        <exclusion> <!-- DROOLS-5803 -->
+          <groupId>com.sun.xml.parsers</groupId>
+          <artifactId>jaxp-ri</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/kie-camel/src/test/java/org/kie/camel/embedded/camel/component/DroolsJaxbHelperXSDInKJARTest.java
+++ b/kie-camel/src/test/java/org/kie/camel/embedded/camel/component/DroolsJaxbHelperXSDInKJARTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.kie.camel.embedded.camel.component;
+
+import java.util.List;
+
+import com.sun.tools.xjc.Language;
+import com.sun.tools.xjc.Options;
+import org.junit.Test;
+import org.kie.api.KieServices;
+import org.kie.api.builder.KieBuilder;
+import org.kie.api.builder.KieFileSystem;
+import org.kie.api.builder.Message;
+import org.kie.api.io.KieResources;
+import org.kie.api.io.ResourceType;
+import org.kie.api.runtime.KieSession;
+import org.kie.internal.builder.JaxbConfiguration;
+import org.kie.internal.builder.KnowledgeBuilderFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * DROOLS-5803 RHDM-851
+ */
+public class DroolsJaxbHelperXSDInKJARTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DroolsJaxbHelperXSDInKJARTest.class);
+
+    private static final String simpleXsdRelativePath = "person.xsd";
+
+    @Test
+    public void testInternalsDryRun() {
+        // DROOLS-5803 RHDM-851
+        System.getProperties().entrySet().forEach(e -> LOG.debug("{}", e));
+        LOG.info("{}", javax.xml.parsers.SAXParserFactory.newInstance().getClass());
+        LOG.info("{}", javax.xml.validation.SchemaFactory.newInstance(javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI).getClass());
+        LOG.info("{}", com.sun.xml.bind.v2.util.XmlFactory.createSchemaFactory(javax.xml.XMLConstants.W3C_XML_SCHEMA_NS_URI, false).getClass());
+    }
+
+    @Test
+    public void testXsdModelInKJAR() {
+        // DROOLS-5803 RHDM-851
+        KieServices ks = KieServices.Factory.get();
+        KieFileSystem kfs = ks.newKieFileSystem();
+        KieResources kieResources = ks.getResources();
+
+        Options xjcOpts = new Options();
+        xjcOpts.setSchemaLanguage(Language.XMLSCHEMA);
+        JaxbConfiguration jaxbConfiguration = KnowledgeBuilderFactory.newJaxbConfiguration(xjcOpts, "xsd");
+        kfs.write(kieResources.newClassPathResource(simpleXsdRelativePath, getClass()).setResourceType(ResourceType.XSD).setConfiguration(jaxbConfiguration));
+
+        KieBuilder kieBuilder = ks.newKieBuilder(kfs).buildAll();
+
+        List<Message> errors = kieBuilder.getResults().getMessages(Message.Level.ERROR);
+        if (!errors.isEmpty()) {
+            fail("" + errors);
+        }
+
+        KieSession ksession = ks.newKieContainer(ks.getRepository().getDefaultReleaseId()).newKieSession();
+        assertNotNull(ksession);
+    }
+
+}


### PR DESCRIPTION
showing the reproducer setup in simpler terms.

```
$ mvn clean test -Dtest=DroolsJaxbHelperXSDInKJARTest

[INFO]
[INFO] --- maven-surefire-plugin:2.22.1:test (default-test) @ kie-camel
---
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running
org.kie.camel.embedded.camel.component.DroolsJaxbHelperXSDInKJARTest
15:07:05.897 [main] WARN  o.a.m.i.embedder.MavenSettings - Environment
variable M2_HOME is not set
Nov 26, 2020 3:07:07 PM com.sun.xml.bind.v2.util.XmlFactory
createSchemaFactory
SEVERE: null
org.xml.sax.SAXNotRecognizedException:
http://javax.xml.XMLConstants/feature/secure-processing
	at javax.xml.validation.SchemaFactory.setFeature(Unknown Source)
	at com.sun.xml.bind.v2.util.XmlFactory.createSchemaFactory(XmlFactory.java:110)
	at com.sun.tools.xjc.reader.xmlschema.parser.SchemaConstraintChecker.check(SchemaConstraintChecker.java:86)
	at com.sun.tools.xjc.ModelLoader.loadXMLSchema(ModelLoader.java:342)
	at com.sun.tools.xjc.ModelLoader.load(ModelLoader.java:162)
	at com.sun.tools.xjc.ModelLoader.load(ModelLoader.java:117)
	at org.drools.compiler.runtime.pipeline.impl.DroolsJaxbHelperProviderImpl.addXsdModel(DroolsJaxbHelperProviderImpl.java:138)
	at org.drools.compiler.runtime.pipeline.impl.DroolsJaxbHelperProviderImpl.addPackageFromXSD(DroolsJaxbHelperProviderImpl.java:110)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:90)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:55)
	at java.lang.reflect.Method.invoke(Method.java:508)
	at org.drools.dynamic.DynamicComponentsSupplier.addPackageFromXSD(DynamicComponentsSupplier.java:94)
	at org.drools.reflective.ComponentsFactory.addPackageFromXSD(ComponentsFactory.java:53)
	at org.drools.compiler.builder.impl.KnowledgeBuilderImpl.addPackageFromXSD(KnowledgeBuilderImpl.java:797)
	at org.drools.compiler.builder.impl.CompositeKnowledgeBuilderImpl$ResourceBuilder.lambda$static$1(CompositeKnowledgeBuilderImpl.java:288)
	at org.drools.compiler.builder.impl.CompositeKnowledgeBuilderImpl$ResourceBuilder$$Lambda$49/000000001C952860.build(Unknown
Source)
	at org.drools.compiler.builder.impl.CompositeKnowledgeBuilderImpl.buildResourceType(CompositeKnowledgeBuilderImpl.java:139)
	at org.drools.compiler.builder.impl.CompositeKnowledgeBuilderImpl.buildResources(CompositeKnowledgeBuilderImpl.java:128)
	at org.drools.compiler.builder.impl.CompositeKnowledgeBuilderImpl.build(CompositeKnowledgeBuilderImpl.java:103)
	at org.drools.compiler.builder.impl.CompositeKnowledgeBuilderImpl.build(CompositeKnowledgeBuilderImpl.java:97)
	at org.drools.compiler.kie.builder.impl.AbstractKieProject.buildKnowledgePackages(AbstractKieProject.java:268)
	at org.drools.compiler.kie.builder.impl.AbstractKieProject.buildKnowledgePackages(AbstractKieProject.java:216)
	at org.drools.compiler.kie.builder.impl.AbstractKieProject.verify(AbstractKieProject.java:80)
	at org.drools.compiler.kie.builder.impl.KieBuilderImpl.buildKieProject(KieBuilderImpl.java:279)
	at org.drools.compiler.kie.builder.impl.KieBuilderImpl.buildAll(KieBuilderImpl.java:247)
	at org.drools.compiler.kie.builder.impl.KieBuilderImpl.buildAll(KieBuilderImpl.java:194)
	at org.kie.camel.embedded.camel.component.DroolsJaxbHelperXSDInKJARTest.testXsdModelInKJAR(DroolsJaxbHelperXSDInKJARTest.java:68)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:90)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:55)
	at java.lang.reflect.Method.invoke(Method.java:508)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:273)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)

15:07:07.188 [main] INFO  o.k.c.e.c.c.DroolsJaxbHelperXSDInKJARTest -
class com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl
15:07:07.189 [main] INFO  o.k.c.e.c.c.DroolsJaxbHelperXSDInKJARTest -
class com.sun.org.apache.xerces.internal.jaxp.validation.XMLSchemaFactory
Nov 26, 2020 3:07:07 PM com.sun.xml.bind.v2.util.XmlFactory
createSchemaFactory
SEVERE: null
org.xml.sax.SAXNotRecognizedException:
http://javax.xml.XMLConstants/feature/secure-processing
	at javax.xml.validation.SchemaFactory.setFeature(Unknown Source)
	at com.sun.xml.bind.v2.util.XmlFactory.createSchemaFactory(XmlFactory.java:110)
	at org.kie.camel.embedded.camel.component.DroolsJaxbHelperXSDInKJARTest.testInternalsDryRun(DroolsJaxbHelperXSDInKJARTest.java:53)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:90)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:55)
	at java.lang.reflect.Method.invoke(Method.java:508)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:273)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)

[ (edited) ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed:
1.838 s <<< FAILURE! - in
org.kie.camel.embedded.camel.component.DroolsJaxbHelperXSDInKJARTest
[ (edited) ERROR] testXsdModelInKJAR(org.kie.camel.embedded.camel.component.DroolsJaxbHelperXSDInKJARTest)
Time elapsed: 1.777 s  <<< ERROR!
java.lang.RuntimeException: java.lang.reflect.InvocationTargetException
	at org.drools.dynamic.DynamicComponentsSupplier.addPackageFromXSD(DynamicComponentsSupplier.java:102)
	at org.drools.reflective.ComponentsFactory.addPackageFromXSD(ComponentsFactory.java:53)
	at org.drools.compiler.builder.impl.KnowledgeBuilderImpl.addPackageFromXSD(KnowledgeBuilderImpl.java:797)
	at org.drools.compiler.builder.impl.CompositeKnowledgeBuilderImpl$ResourceBuilder.lambda$static$1(CompositeKnowledgeBuilderImpl.java:288)
	at org.drools.compiler.builder.impl.CompositeKnowledgeBuilderImpl$ResourceBuilder$$Lambda$49/000000001C952860.build(Unknown
Source)
	at org.drools.compiler.builder.impl.CompositeKnowledgeBuilderImpl.buildResourceType(CompositeKnowledgeBuilderImpl.java:139)
	at org.drools.compiler.builder.impl.CompositeKnowledgeBuilderImpl.buildResources(CompositeKnowledgeBuilderImpl.java:128)
	at org.drools.compiler.builder.impl.CompositeKnowledgeBuilderImpl.build(CompositeKnowledgeBuilderImpl.java:103)
	at org.drools.compiler.builder.impl.CompositeKnowledgeBuilderImpl.build(CompositeKnowledgeBuilderImpl.java:97)
	at org.drools.compiler.kie.builder.impl.AbstractKieProject.buildKnowledgePackages(AbstractKieProject.java:268)
	at org.drools.compiler.kie.builder.impl.AbstractKieProject.buildKnowledgePackages(AbstractKieProject.java:216)
	at org.drools.compiler.kie.builder.impl.AbstractKieProject.verify(AbstractKieProject.java:80)
	at org.drools.compiler.kie.builder.impl.KieBuilderImpl.buildKieProject(KieBuilderImpl.java:279)
	at org.drools.compiler.kie.builder.impl.KieBuilderImpl.buildAll(KieBuilderImpl.java:247)
	at org.drools.compiler.kie.builder.impl.KieBuilderImpl.buildAll(KieBuilderImpl.java:194)
	at org.kie.camel.embedded.camel.component.DroolsJaxbHelperXSDInKJARTest.testXsdModelInKJAR(DroolsJaxbHelperXSDInKJARTest.java:68)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:90)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:55)
	at java.lang.reflect.Method.invoke(Method.java:508)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:273)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
Caused by: java.lang.reflect.InvocationTargetException
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:90)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:55)
	at java.lang.reflect.Method.invoke(Method.java:508)
	at org.drools.dynamic.DynamicComponentsSupplier.addPackageFromXSD(DynamicComponentsSupplier.java:94)
	... 43 more
Caused by: java.lang.IllegalStateException:
org.xml.sax.SAXNotRecognizedException:
http://javax.xml.XMLConstants/feature/secure-processing
	at com.sun.xml.bind.v2.util.XmlFactory.createSchemaFactory(XmlFactory.java:114)
	at com.sun.tools.xjc.reader.xmlschema.parser.SchemaConstraintChecker.check(SchemaConstraintChecker.java:86)
	at com.sun.tools.xjc.ModelLoader.loadXMLSchema(ModelLoader.java:342)
	at com.sun.tools.xjc.ModelLoader.load(ModelLoader.java:162)
	at com.sun.tools.xjc.ModelLoader.load(ModelLoader.java:117)
	at org.drools.compiler.runtime.pipeline.impl.DroolsJaxbHelperProviderImpl.addXsdModel(DroolsJaxbHelperProviderImpl.java:138)
	at org.drools.compiler.runtime.pipeline.impl.DroolsJaxbHelperProviderImpl.addPackageFromXSD(DroolsJaxbHelperProviderImpl.java:110)
	... 48 more
Caused by: org.xml.sax.SAXNotRecognizedException:
http://javax.xml.XMLConstants/feature/secure-processing
	at javax.xml.validation.SchemaFactory.setFeature(Unknown Source)
	at com.sun.xml.bind.v2.util.XmlFactory.createSchemaFactory(XmlFactory.java:110)
	... 54 more

[ (edited) ERROR] testInternalsDryRun(org.kie.camel.embedded.camel.component.DroolsJaxbHelperXSDInKJARTest)
Time elapsed: 0.009 s  <<< ERROR!
java.lang.IllegalStateException: org.xml.sax.SAXNotRecognizedException:
http://javax.xml.XMLConstants/feature/secure-processing
	at com.sun.xml.bind.v2.util.XmlFactory.createSchemaFactory(XmlFactory.java:114)
	at org.kie.camel.embedded.camel.component.DroolsJaxbHelperXSDInKJARTest.testInternalsDryRun(DroolsJaxbHelperXSDInKJARTest.java:53)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:90)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:55)
	at java.lang.reflect.Method.invoke(Method.java:508)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:365)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeWithRerun(JUnit4Provider.java:273)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:238)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:159)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
Caused by: org.xml.sax.SAXNotRecognizedException:
http://javax.xml.XMLConstants/feature/secure-processing
	at javax.xml.validation.SchemaFactory.setFeature(Unknown Source)
	at com.sun.xml.bind.v2.util.XmlFactory.createSchemaFactory(XmlFactory.java:110)
	... 29 more
```

**JIRA**: https://issues.redhat.com/browse/DROOLS-5803

**referenced Pull Requests**: none

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
