### PR TITLE
[7.48.x] RHPAM-3382 It is not possible to create DMN runtime in OSGI environment

### DIFF
--- a/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features-fuse.xml
+++ b/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features-fuse.xml
@@ -37,6 +37,7 @@
 
   <feature name="kie-dmn" description="Kie DMN" version="${project.version}">
     <feature version="${project.version}">drools-module</feature>
+    <bundle>mvn:org.antlr/antlr4-runtime/${version.org.antlr4}</bundle>
     <bundle>mvn:ch.obermuhlner/big-math/${version.ch.obermuhlner}</bundle>
     <bundle>mvn:org.drools/drools-mvel-parser/${version.org.kie}</bundle>
     <bundle>mvn:org.kie/kie-dmn-model/${version.org.kie}</bundle>


### PR DESCRIPTION
cherry-pick to backport from `master` to `7.48.x` as required by https://issues.redhat.com/browse/RHPAM-3382 

**JIRA**:  https://issues.redhat.com/browse/RHPAM-3382

**referenced Pull Requests**: https://github.com/kiegroup/droolsjbpm-integration/pull/2362

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
