### PR TITLE
[JBPM-9558]  KIE using XStream does not complain on unknown fields

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/Marshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/Marshaller.java
@@ -25,19 +25,23 @@ public interface Marshaller {
 
     static String MARSHALLER_PARAMETER_STRICT = "strict";
 
-    public default String marshall(Object input, Map<String, Object> parameters) {
+    default String marshall(Object input, Map<String, Object> parameters) {
         return marshall(input);
     }
 
-    public String marshall(Object input);
+    String marshall(Object input);
 
-    public <T> T unmarshall(String input, Class<T> type);
+    <T> T unmarshall(String input, Class<T> type);
 
-    public void dispose();
+    default <T> T unmarshall(String input, Class<T> type, Map<String, Object> parameters) {
+        return unmarshall(input, type);
+    }
 
-    public MarshallingFormat getFormat();
+    void dispose();
 
-    public void setClassLoader(ClassLoader classloader);
+    MarshallingFormat getFormat();
 
-    public ClassLoader getClassLoader();
+    void setClassLoader(ClassLoader classloader);
+
+    ClassLoader getClassLoader();
 }

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/CustomXstreamMarshallerBuilder.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/CustomXstreamMarshallerBuilder.java
@@ -35,7 +35,8 @@ public class CustomXstreamMarshallerBuilder extends BaseMarshallerBuilder {
             return new XStreamMarshaller(classes, classLoader) {
                 @Override
                 protected void buildMarshaller(Set<Class<?>> classes, ClassLoader classLoader) {
-                    xstream = XStreamUtils.createNonTrustingXStream(new PureJavaReflectionProvider(), new DomDriver("UTF-8", new XmlFriendlyNameCoder("_-", "_")));
+                    xstream = XStreamUtils.createNonTrustingXStream(new PureJavaReflectionProvider(), new DomDriver("UTF-8", new XmlFriendlyNameCoder("_-", "_"))
+                            , CustomElementIgnore::new);
                     xstream.addPermission(new WildcardTypePermission(new String[]{"org.kie.server.api.**"}));
                     String[] voidDeny = {"void.class", "Void.class"};
                     xstream.denyTypes(voidDeny);

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/marshal/MarshallerHelper.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/marshal/MarshallerHelper.java
@@ -105,7 +105,8 @@ public class MarshallerHelper {
             throw new IllegalArgumentException("No marshaller found for format " + format);
         }
 
-        Object instance = marshaller.unmarshall(data, unmarshalType);
+        Object instance = marshaller.unmarshall(data, unmarshalType, MarshallingFormat.buildParameters(
+                marshallingFormat));
 
         if (instance instanceof Wrapped) {
             return (T) ((Wrapped) instance).unwrap();
@@ -126,7 +127,8 @@ public class MarshallerHelper {
         	serverMarshallers.put(format, marshaller);
         }
 
-        Object instance = marshaller.unmarshall(data, unmarshalType);
+        Object instance = marshaller.unmarshall(data, unmarshalType, MarshallingFormat.buildParameters(
+                marshallingFormat));
 
         if (instance instanceof Wrapped) {
             return (T) ((Wrapped) instance).unwrap();


### PR DESCRIPTION
In order to "relax" deserialization requirements, user can specifiy as parameter of contentype, ignoreUnknown=true, which will ignore unknown fields durign xstream deserialization. 

**JIRA**: 

[link](https://issues.redhat.com/browse/JBPM-9558)

Depends on
https://github.com/kiegroup/kie-soup/pull/173
