### PR TITLE
[JBPM-9611] Command resource returns HTTP OK response status code even for failure scenarios

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-client/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/build/revapi-config.json
@@ -41,7 +41,17 @@
     "ignores": {
         "revapi": {
             "_comment": "Changes between 7.48.0.Final and the current branch. These changes are desired and thus ignored.",
-            "ignore": []
+            "ignore": [
+            {
+              "code": "java.method.addedToInterface",
+              "new": "method org.kie.server.api.model.ServiceResponse<org.kie.api.runtime.ExecutionResults> org.kie.server.client.RuleServicesClient::executeCommandsWithResults(java.lang.String, org.kie.api.command.Command<?>, javax.ws.rs.core.Response.Status)",
+              "package": "org.kie.server.client",
+              "classSimpleName": "RuleServicesClient",
+              "methodName": "executeCommandsWithResults",
+              "elementKind": "method",
+              "justification": "https://issues.redhat.com/browse/JBPM-9611"
+            }
+            ]
         }
     }
 }

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesClient.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/KieServicesClient.java
@@ -15,6 +15,8 @@
 
 package org.kie.server.client;
 
+import javax.ws.rs.core.Response.Status;
+
 import org.kie.api.command.Command;
 import org.kie.server.api.commands.CommandScript;
 import org.kie.server.api.model.KieContainerResource;
@@ -80,7 +82,19 @@ public interface KieServicesClient {
      * @deprecated
      */
     @Deprecated
-    ServiceResponse<String> executeCommands(String id, Command<?> cmd);
+    default ServiceResponse<String> executeCommands(String id, Command<?> cmd) {
+        return executeCommands(id, cmd, Status.OK);
+    }
+
+    /**
+     * This method is deprecated on KieServicesClient as it was moved to RuleServicesClient
+     * @see RuleServicesClient#executeCommands(String, Command)
+     * @deprecated
+     */
+    @Deprecated
+    default ServiceResponse<String> executeCommands(String id, Command<?> cmd, Status response) {
+        throw new UnsupportedOperationException();
+    }
 
     /**
      * Sets the classloader for user class unmarshalling

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/RuleServicesClient.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/RuleServicesClient.java
@@ -15,6 +15,8 @@
 
 package org.kie.server.client;
 
+import javax.ws.rs.core.Response.Status;
+
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
 import org.kie.server.api.model.ServiceResponse;
@@ -36,7 +38,11 @@ public interface RuleServicesClient {
 
     ServiceResponse<ExecutionResults> executeCommandsWithResults(String id, String payload);
 
-    ServiceResponse<ExecutionResults> executeCommandsWithResults(String id, Command<?> cmd);
+    default ServiceResponse<ExecutionResults> executeCommandsWithResults(String id, Command<?> cmd) {
+        return executeCommandsWithResults(id, cmd, Status.OK);
+    }
+
+    ServiceResponse<ExecutionResults> executeCommandsWithResults(String id, Command<?> cmd, Status status);
 
     void setResponseHandler(ResponseHandler responseHandler);
 }

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/AbstractKieServicesClientImpl.java
@@ -36,6 +36,7 @@ import javax.jms.Session;
 import javax.jms.TextMessage;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.commands.CommandScript;
@@ -285,12 +286,28 @@ public abstract class AbstractKieServicesClientImpl {
         return makeHttpPostRequestAndCreateServiceResponse( uri, serialize( bodyObject ), resultType, headers );
     }
 
+    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(String uri,
+                                                                                 Object bodyObject,
+                                                                                 Class<T> resultType,
+                                                                                 Map<String, String> headers,
+                                                                                 Status status) {
+        return makeHttpPostRequestAndCreateServiceResponse(uri, serialize(bodyObject), resultType, headers, status);
+    }
+
     protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(String uri, String body, Class<T> resultType) {
         return  makeHttpPostRequestAndCreateServiceResponse( uri, body, resultType, new HashMap<String, String>() );
     }
 
     @SuppressWarnings("unchecked")
     protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(String uri, String body, Class<T> resultType, Map<String, String> headers) {
+        return makeHttpPostRequestAndCreateServiceResponse(uri, body, resultType, headers, Status.OK);
+    }
+
+    protected <T> ServiceResponse<T> makeHttpPostRequestAndCreateServiceResponse(String uri,
+                                                                                 String body,
+                                                                                 Class<T> resultType,
+                                                                                 Map<String, String> headers,
+                                                                                 Status status) {
         logger.debug("About to send POST request to '{}' with payload '{}'", uri, body);
         KieServerHttpRequest request = invoke(uri, new RemoteHttpOperation(){
             @Override
@@ -303,13 +320,14 @@ public abstract class AbstractKieServicesClientImpl {
 
         owner.setConversationId(response.header(KieServerConstants.KIE_CONVERSATION_ID_TYPE_HEADER));
 
-        if ( response.code() == Response.Status.OK.getStatusCode() ) {
+        if (response.code() == status.getStatusCode()) {
             ServiceResponse serviceResponse = deserialize( response.body(), ServiceResponse.class );
             checkResultType( serviceResponse, resultType );
             return serviceResponse;
         } else {
             throw createExceptionForUnexpectedResponseCode( request, response );
         }
+
     }
 
 
@@ -785,13 +803,21 @@ public abstract class AbstractKieServicesClientImpl {
  * override of the regular method to allow backward compatibility for string based result of ServiceResponse
  */
     protected <T> ServiceResponse<T> makeBackwardCompatibleHttpPostRequestAndCreateServiceResponse(String uri, Object body, Class<T> resultType, Map<String, String> headers) {
+        return makeBackwardCompatibleHttpPostRequestAndCreateServiceResponse(uri, body, resultType, headers, Status.OK);
+    }
+
+    protected <T> ServiceResponse<T> makeBackwardCompatibleHttpPostRequestAndCreateServiceResponse(String uri,
+                                                                                                   Object body,
+                                                                                                   Class<T> resultType,
+                                                                                                   Map<String, String> headers,
+                                                                                                   Status expectedStatus) {
         logger.debug("About to send POST request to '{}' with payload '{}'", uri, body);
         KieServerHttpRequest request = newRequest( uri ).headers(headers).body(serialize( body )).post();
         KieServerHttpResponse response = request.response();
 
         owner.setConversationId(response.header(KieServerConstants.KIE_CONVERSATION_ID_TYPE_HEADER));
 
-        if ( response.code() == Response.Status.OK.getStatusCode() ) {
+        if (response.code() == expectedStatus.getStatusCode()) {
             ServiceResponse serviceResponse = deserialize( response.body(), ServiceResponse.class );
             // serialize it back to string to make it backward compatible
             serviceResponse.setResult(serialize(serviceResponse.getResult()));
@@ -800,7 +826,9 @@ public abstract class AbstractKieServicesClientImpl {
         } else {
             throw createExceptionForUnexpectedResponseCode( request, response );
         }
+
     }
+
 
     protected <T> ServiceResponse<T> makeBackwardCompatibleHttpPostRequestAndCreateServiceResponse(String uri, String body, Class<T> resultType) {
         logger.debug("About to send POST request to '{}' with payload '{}'", uri, body);

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/RuleServicesClientImpl.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/impl/RuleServicesClientImpl.java
@@ -17,6 +17,8 @@ package org.kie.server.client.impl;
 
 import java.util.Collections;
 
+import javax.ws.rs.core.Response.Status;
+
 import org.drools.core.runtime.impl.ExecutionResultImpl;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
@@ -61,9 +63,10 @@ public class RuleServicesClientImpl extends AbstractKieServicesClientImpl implem
 
 
     @Override
-    public ServiceResponse<ExecutionResults> executeCommandsWithResults(String id, Command<?> cmd) {
+    public ServiceResponse<ExecutionResults> executeCommandsWithResults(String id, Command<?> cmd, Status status) {
         if( config.isRest() ) {
-            return makeHttpPostRequestAndCreateServiceResponse( loadBalancer.getUrl() + "/containers/instances/" + id, cmd, (Class)ExecutionResultImpl.class, getHeaders(cmd) );
+            return makeHttpPostRequestAndCreateServiceResponse(loadBalancer.getUrl() + "/containers/instances/" + id,
+                    cmd, (Class) ExecutionResultImpl.class, getHeaders(cmd), status);
         } else {
             CommandScript script = new CommandScript( Collections.singletonList( (KieServerCommand) new CallContainerCommand( id, serialize(cmd) ) ) );
             ServiceResponse response = executeJmsCommand( script, cmd.getClass().getName(), null, id ).getResponses().get( 0 );

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-drools/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-drools/src/build/revapi-config.json
@@ -26,7 +26,51 @@
   "ignores": {
     "revapi": {
       "_comment": "Changes between 7.48.0.Final and the current branch. These changes are desired and thus ignored.",
-      "ignore": []
-    }
+      "ignore": [
+    {
+   "code": "java.annotation.attributeRemoved",
+   "old": "method javax.ws.rs.core.Response org.kie.server.remote.rest.drools.CommandResource::manageContainer(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String)",
+   "new": "method javax.ws.rs.core.Response org.kie.server.remote.rest.drools.CommandResource::manageContainer(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String)",
+   "annotationType": "io.swagger.annotations.ApiOperation",
+   "annotation": "@io.swagger.annotations.ApiOperation(\"Executes one or more runtime commands\")",
+   "attribute": "response",
+   "value": "org.kie.server.api.model.ServiceResponse.class",
+   "package": "org.kie.server.remote.rest.drools",
+   "classSimpleName": "CommandResource",
+   "methodName": "manageContainer",
+   "elementKind": "method",
+   "justification": "https://issues.redhat.com/browse/RHPAM-3463"
+ },
+ {
+   "code": "java.annotation.attributeRemoved",
+   "old": "method javax.ws.rs.core.Response org.kie.server.remote.rest.drools.CommandResource::manageContainer(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String)",
+   "new": "method javax.ws.rs.core.Response org.kie.server.remote.rest.drools.CommandResource::manageContainer(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String)",
+   "annotationType": "io.swagger.annotations.ApiOperation",
+   "annotation": "@io.swagger.annotations.ApiOperation(\"Executes one or more runtime commands\")",
+   "attribute": "code",
+   "value": "200",
+   "package": "org.kie.server.remote.rest.drools",
+   "classSimpleName": "CommandResource",
+   "methodName": "manageContainer",
+   "elementKind": "method",
+   "justification": "https://issues.redhat.com/browse/RHPAM-3463"
+ },
+ {
+   "code": "java.annotation.attributeValueChanged",
+   "old": "method javax.ws.rs.core.Response org.kie.server.remote.rest.drools.CommandResource::manageContainer(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String)",
+   "new": "method javax.ws.rs.core.Response org.kie.server.remote.rest.drools.CommandResource::manageContainer(javax.ws.rs.core.HttpHeaders, java.lang.String, java.lang.String)",
+   "annotationType": "io.swagger.annotations.ApiResponses",
+   "annotation": "@io.swagger.annotations.ApiResponses({@io.swagger.annotations.ApiResponse(code = 200, message = \"Successful execution\", response = org.kie.server.api.model.ServiceResponse.class), @io.swagger.annotations.ApiResponse(code = 500, message = \"Unexpected error\", response = org.kie.server.api.model.ServiceResponse.class), @io.swagger.annotations.ApiResponse(code = 204, message = \"Command execute successfully, but without response\", response = org.kie.server.api.model.ServiceResponse.class)})",
+   "attribute": "value",
+   "oldValue": "{@io.swagger.annotations.ApiResponse(code = 500, message = \"Unexpected error\")}",
+   "newValue": "{@io.swagger.annotations.ApiResponse(code = 200, message = \"Successful execution\", response = org.kie.server.api.model.ServiceResponse.class), @io.swagger.annotations.ApiResponse(code = 500, message = \"Unexpected error\", response = org.kie.server.api.model.ServiceResponse.class), @io.swagger.annotations.ApiResponse(code = 204, message = \"Command execute successfully, but without response\", response = org.kie.server.api.model.ServiceResponse.class)}",
+   "package": "org.kie.server.remote.rest.drools",
+   "classSimpleName": "CommandResource",
+   "methodName": "manageContainer",
+   "elementKind": "method",
+   "justification": "https://issues.redhat.com/browse/RHPAM-3463"
+ }
+      ]
+     }
   }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerBackwardCompatDroolsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerBackwardCompatDroolsIntegrationTest.java
@@ -23,6 +23,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import javax.ws.rs.core.Response.Status;
+
 import org.drools.core.runtime.impl.ExecutionResultImpl;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -156,7 +158,8 @@ public class KieServerBackwardCompatDroolsIntegrationTest extends DroolsKieServe
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands, "xyz");
 
-        ServiceResponse<String> reply = client.executeCommands(CONTAINER_ID, batchExecution);
+        ServiceResponse<String> reply = client.executeCommands(CONTAINER_ID, batchExecution,
+                Status.INTERNAL_SERVER_ERROR);
         Assert.assertEquals(ServiceResponse.ResponseType.FAILURE, reply.getType());
     }
 }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerDroolsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/KieServerDroolsIntegrationTest.java
@@ -24,6 +24,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import javax.ws.rs.core.Response.Status;
+
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -43,10 +45,11 @@ import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.api.model.ServiceResponsesList;
 import org.kie.server.integrationtests.category.Smoke;
-
-import static org.junit.Assert.*;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.KieServerReflections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class KieServerDroolsIntegrationTest extends DroolsKieServerBaseIntegrationTest {
     private static ReleaseId releaseId = new ReleaseId("foo.bar", "baz", "2.1.0.GA");
@@ -154,7 +157,8 @@ public class KieServerDroolsIntegrationTest extends DroolsKieServerBaseIntegrati
         List<Command<?>> commands = new ArrayList<Command<?>>();
         BatchExecutionCommand batchExecution = commandsFactory.newBatchExecution(commands, "xyz");
 
-        ServiceResponse<ExecutionResults> reply = ruleClient.executeCommandsWithResults(CONTAINER_ID, batchExecution);
+        ServiceResponse<ExecutionResults> reply = ruleClient.executeCommandsWithResults(CONTAINER_ID, batchExecution,
+                Status.INTERNAL_SERVER_ERROR);
         Assert.assertEquals(ServiceResponse.ResponseType.FAILURE, reply.getType());
     }
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/StatefulSessionUsageIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/StatefulSessionUsageIntegrationTest.java
@@ -22,7 +22,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.drools.core.command.runtime.rule.GetFactHandlesCommand;
+import javax.ws.rs.core.Response.Status;
+
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -36,10 +37,12 @@ import org.kie.api.runtime.rule.QueryResults;
 import org.kie.api.runtime.rule.QueryResultsRow;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
-
-import static org.junit.Assert.*;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.KieServerReflections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class StatefulSessionUsageIntegrationTest extends DroolsKieServerBaseIntegrationTest {
 
@@ -89,13 +92,14 @@ public class StatefulSessionUsageIntegrationTest extends DroolsKieServerBaseInte
         commands.add(commandsFactory.newInsert(person, PERSON_1_OUT_IDENTIFIER));
         commands.add(commandsFactory.newFireAllRules());
 
-        ServiceResponse<ExecutionResults> reply = ruleClient.executeCommandsWithResults(CONTAINER_ID, executionCommand);
+        ServiceResponse<ExecutionResults> reply = ruleClient.executeCommandsWithResults(CONTAINER_ID, executionCommand,
+                Status.OK);
         assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
         // now dispose the container
         ServiceResponse<Void> disposeReply = client.disposeContainer(CONTAINER_ID);
         assertEquals("Dispose reply response type.", ServiceResponse.ResponseType.SUCCESS, disposeReply.getType());
         // and try to call the container again. The call should fail as the container no longer exists
-        reply = ruleClient.executeCommandsWithResults(CONTAINER_ID, executionCommand);
+        reply = ruleClient.executeCommandsWithResults(CONTAINER_ID, executionCommand, Status.INTERNAL_SERVER_ERROR);
         assertEquals(ServiceResponse.ResponseType.FAILURE, reply.getType());
         assertTrue("Expected message about non-instantiated container. Got: " + reply.getMsg(),
                 reply.getMsg().contains(String.format("Container '%s' is not instantiated", CONTAINER_ID)));

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/rest/RestMalformedRequestIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/rest/RestMalformedRequestIntegrationTest.java
@@ -15,8 +15,6 @@
 
 package org.kie.server.integrationtests.drools.rest;
 
-import static org.junit.Assert.assertEquals;
-
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
@@ -34,6 +32,8 @@ import org.kie.server.integrationtests.category.RESTOnly;
 import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.basetests.RestOnlyBaseIntegrationTest;
+
+import static org.junit.Assert.assertEquals;
 
 @Category(RESTOnly.class)
 public class RestMalformedRequestIntegrationTest extends RestOnlyBaseIntegrationTest {
@@ -62,7 +62,7 @@ public class RestMalformedRequestIntegrationTest extends RestOnlyBaseIntegration
 
             WebTarget clientRequest = newRequest(TestConfig.getKieServerHttpUrl() + "/containers/instances/" + CONTAINER_ID);
             response = clientRequest.request(getMediaType()).post(createEntity(body));
-            assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+            assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
 
             ServiceResponse<KieContainerResource> serviceResponse =
                     response.readEntity(new GenericType<ServiceResponse<KieContainerResource>>(){});
@@ -87,7 +87,7 @@ public class RestMalformedRequestIntegrationTest extends RestOnlyBaseIntegration
 
             WebTarget clientRequest = newRequest(TestConfig.getKieServerHttpUrl() + "/containers/instances/" + CONTAINER_ID);
             response = clientRequest.request(getMediaType()).post(createEntity(body));
-            assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+            assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response.getStatus());
 
             ServiceResponse<KieContainerResource> serviceResponse =
                     response.readEntity(new GenericType<ServiceResponse<KieContainerResource>>(){});


### PR DESCRIPTION
API and test changed to return different HTTP codes depeding on service result. 

**JIRA**: 

[link](https://issues.redhat.com/browse/JBPM-9611)
