### PR TITLE
[DROOLS-5702] Using rules sources generated inside pmml compiler.

### DIFF
--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GeneratePMMLModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GeneratePMMLModelMojo.java
@@ -46,29 +46,23 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
-import org.drools.compiler.compiler.DroolsError;
 import org.drools.compiler.kie.builder.impl.KieBuilderImpl;
 import org.drools.compiler.kproject.ReleaseIdImpl;
-import org.drools.compiler.lang.descr.PackageDescr;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.KnowledgeBaseImpl;
-import org.drools.core.io.impl.DescrResource;
 import org.drools.core.io.impl.FileSystemResource;
 import org.drools.modelcompiler.builder.GeneratedFile;
 import org.drools.modelcompiler.builder.ModelBuilderImpl;
 import org.drools.modelcompiler.builder.PackageSources;
 import org.kie.api.KieServices;
 import org.kie.api.io.Resource;
-import org.kie.api.io.ResourceType;
 import org.kie.internal.builder.CompositeKnowledgeBuilder;
 import org.kie.pmml.commons.model.HasNestedModels;
 import org.kie.pmml.commons.model.HasSourcesMap;
 import org.kie.pmml.commons.model.KiePMMLModel;
-import org.kie.pmml.models.drools.commons.model.KiePMMLDroolsModelWithSources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.util.stream.Collectors.toList;
 import static org.kie.api.pmml.PMMLConstants.KIE_PMML_IMPLEMENTATION;
 import static org.kie.api.pmml.PMMLConstants.LEGACY;
 import static org.kie.api.pmml.PMMLConstants.NEW;
@@ -244,7 +238,6 @@ public class GeneratePMMLModelMojo extends AbstractKieMojo {
         CompositeKnowledgeBuilder batch = modelBuilder.batch();
         List<KiePMMLModel> kiepmmlModels = pmmlResources.getKiePmmlModels();
         addModels(kiepmmlModels, pmmlResources, batch, toReturn);
-//        toReturn.addAll(generateRules(modelBuilder, batch));
         return toReturn;
     }
 

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GeneratePMMLModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GeneratePMMLModelMojo.java
@@ -44,19 +44,14 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-import org.drools.compiler.builder.impl.KnowledgeBuilderConfigurationImpl;
 import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
 import org.drools.compiler.kie.builder.impl.KieBuilderImpl;
-import org.drools.compiler.kproject.ReleaseIdImpl;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.impl.KnowledgeBaseImpl;
 import org.drools.core.io.impl.FileSystemResource;
 import org.drools.modelcompiler.builder.GeneratedFile;
-import org.drools.modelcompiler.builder.ModelBuilderImpl;
-import org.drools.modelcompiler.builder.PackageSources;
 import org.kie.api.KieServices;
 import org.kie.api.io.Resource;
-import org.kie.internal.builder.CompositeKnowledgeBuilder;
 import org.kie.pmml.commons.model.HasNestedModels;
 import org.kie.pmml.commons.model.HasSourcesMap;
 import org.kie.pmml.commons.model.KiePMMLModel;
@@ -230,20 +225,13 @@ public class GeneratePMMLModelMojo extends AbstractKieMojo {
 
     private List<GeneratedFile> getGenerateFiles(final PMMLResource pmmlResources) {
         final List<GeneratedFile> toReturn = new ArrayList<>();
-        ModelBuilderImpl<PackageSources> modelBuilder = new ModelBuilderImpl<>(PackageSources::dumpSources,
-                                                                               new KnowledgeBuilderConfigurationImpl(getClass().getClassLoader()),
-                                                                               new ReleaseIdImpl("dummy:dummy:0.0" +
-                                                                                                         ".0"),
-                                                                               true, false);
-        CompositeKnowledgeBuilder batch = modelBuilder.batch();
         List<KiePMMLModel> kiepmmlModels = pmmlResources.getKiePmmlModels();
-        addModels(kiepmmlModels, pmmlResources, batch, toReturn);
+        addModels(kiepmmlModels, pmmlResources, toReturn);
         return toReturn;
     }
 
     private void addModels(final List<KiePMMLModel> kiepmmlModels,
                            final PMMLResource resource,
-                           final CompositeKnowledgeBuilder batch,
                            final List<GeneratedFile> generatedFiles) {
         for (KiePMMLModel model : kiepmmlModels) {
             if (model.getName() == null || model.getName().isEmpty()) {
@@ -270,7 +258,7 @@ public class GeneratePMMLModelMojo extends AbstractKieMojo {
                 }
             }
             if (model instanceof HasNestedModels) {
-                addModels(((HasNestedModels) model).getNestedModels(), resource, batch, generatedFiles);
+                addModels(((HasNestedModels) model).getNestedModels(), resource, generatedFiles);
             }
         }
     }

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GeneratePMMLModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GeneratePMMLModelMojo.java
@@ -269,53 +269,11 @@ public class GeneratePMMLModelMojo extends AbstractKieMojo {
                     generatedFiles.add(new GeneratedFile(GeneratedFile.Type.RULE, path, rulesSourceMapEntry.getValue()));
                 }
             }
-
-//            if (model instanceof KiePMMLDroolsModelWithSources) {
-//
-//
-//                PackageDescr packageDescr = ((KiePMMLDroolsModelWithSources) model).getPackageDescr();
-//                batch.add(new DescrResource(packageDescr), ResourceType.DESCR);
-//            }
             if (model instanceof HasNestedModels) {
                 addModels(((HasNestedModels) model).getNestedModels(), resource, batch, generatedFiles);
             }
         }
     }
-
-//    private List<GeneratedFile> generateRules(ModelBuilderImpl<PackageSources> modelBuilder,
-//                                              CompositeKnowledgeBuilder batch) {
-//        try {
-//            batch.build();
-//            if (modelBuilder.hasErrors()) {
-//                StringBuilder builder = new StringBuilder();
-//                for (DroolsError error : modelBuilder.getErrors().getErrors()) {
-//                    logger.error(error.toString());
-//                    builder.append(error.toString()).append(" ");
-//                }
-//                throw new MojoExecutionException(builder.toString());
-//            }
-//        } catch (Exception e) {
-//            logger.error(e.getMessage());
-//            StringBuilder builder = new StringBuilder(e.getMessage()).append(" ");
-//            for (DroolsError error : modelBuilder.getErrors().getErrors()) {
-//                logger.error(error.toString());
-//                builder.append(error.toString()).append(" ");
-//            }
-//            throw new RuntimeException(builder.toString(), e);
-//        }
-//        return generateModels(modelBuilder)
-//                .stream()
-//                .map(f -> new GeneratedFile(GeneratedFile.Type.RULE, f.getPath(), new String(f.getData())))
-//                .collect(toList());
-//    }
-
-//    List<org.drools.modelcompiler.builder.GeneratedFile> generateModels(ModelBuilderImpl<PackageSources> modelBuilder) {
-//        List<org.drools.modelcompiler.builder.GeneratedFile> toReturn = new ArrayList<>();
-//        for (PackageSources pkgSources : modelBuilder.getPackageSources()) {
-//            pkgSources.collectGeneratedFiles(toReturn);
-//        }
-//        return toReturn;
-//    }
 
     private PMMLResource parseResource(Resource resource) {
         final InternalKnowledgeBase knowledgeBase = new KnowledgeBaseImpl("PMML", null);

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GeneratePMMLModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GeneratePMMLModelMojo.java
@@ -244,7 +244,7 @@ public class GeneratePMMLModelMojo extends AbstractKieMojo {
         CompositeKnowledgeBuilder batch = modelBuilder.batch();
         List<KiePMMLModel> kiepmmlModels = pmmlResources.getKiePmmlModels();
         addModels(kiepmmlModels, pmmlResources, batch, toReturn);
-        toReturn.addAll(generateRules(modelBuilder, batch));
+//        toReturn.addAll(generateRules(modelBuilder, batch));
         return toReturn;
     }
 
@@ -269,50 +269,60 @@ public class GeneratePMMLModelMojo extends AbstractKieMojo {
                 String path = sourceMapEntry.getKey().replace('.', File.separatorChar) + ".java";
                 generatedFiles.add(new GeneratedFile(GeneratedFile.Type.PMML, path, sourceMapEntry.getValue()));
             }
-            if (model instanceof KiePMMLDroolsModelWithSources) {
-                PackageDescr packageDescr = ((KiePMMLDroolsModelWithSources) model).getPackageDescr();
-                batch.add(new DescrResource(packageDescr), ResourceType.DESCR);
+            Map<String, String> rulesSourceMap = ((HasSourcesMap) model).getRulesSourcesMap();
+            if (rulesSourceMap != null) {
+                for (Map.Entry<String, String> rulesSourceMapEntry : rulesSourceMap.entrySet()) {
+                    String path = rulesSourceMapEntry.getKey().replace('.', File.separatorChar) + ".java";
+                    generatedFiles.add(new GeneratedFile(GeneratedFile.Type.RULE, path, rulesSourceMapEntry.getValue()));
+                }
             }
+
+//            if (model instanceof KiePMMLDroolsModelWithSources) {
+//
+//
+//                PackageDescr packageDescr = ((KiePMMLDroolsModelWithSources) model).getPackageDescr();
+//                batch.add(new DescrResource(packageDescr), ResourceType.DESCR);
+//            }
             if (model instanceof HasNestedModels) {
                 addModels(((HasNestedModels) model).getNestedModels(), resource, batch, generatedFiles);
             }
         }
     }
 
-    private List<GeneratedFile> generateRules(ModelBuilderImpl<PackageSources> modelBuilder,
-                                              CompositeKnowledgeBuilder batch) {
-        try {
-            batch.build();
-            if (modelBuilder.hasErrors()) {
-                StringBuilder builder = new StringBuilder();
-                for (DroolsError error : modelBuilder.getErrors().getErrors()) {
-                    logger.error(error.toString());
-                    builder.append(error.toString()).append(" ");
-                }
-                throw new MojoExecutionException(builder.toString());
-            }
-        } catch (Exception e) {
-            logger.error(e.getMessage());
-            StringBuilder builder = new StringBuilder(e.getMessage()).append(" ");
-            for (DroolsError error : modelBuilder.getErrors().getErrors()) {
-                logger.error(error.toString());
-                builder.append(error.toString()).append(" ");
-            }
-            throw new RuntimeException(builder.toString(), e);
-        }
-        return generateModels(modelBuilder)
-                .stream()
-                .map(f -> new GeneratedFile(GeneratedFile.Type.RULE, f.getPath(), new String(f.getData())))
-                .collect(toList());
-    }
+//    private List<GeneratedFile> generateRules(ModelBuilderImpl<PackageSources> modelBuilder,
+//                                              CompositeKnowledgeBuilder batch) {
+//        try {
+//            batch.build();
+//            if (modelBuilder.hasErrors()) {
+//                StringBuilder builder = new StringBuilder();
+//                for (DroolsError error : modelBuilder.getErrors().getErrors()) {
+//                    logger.error(error.toString());
+//                    builder.append(error.toString()).append(" ");
+//                }
+//                throw new MojoExecutionException(builder.toString());
+//            }
+//        } catch (Exception e) {
+//            logger.error(e.getMessage());
+//            StringBuilder builder = new StringBuilder(e.getMessage()).append(" ");
+//            for (DroolsError error : modelBuilder.getErrors().getErrors()) {
+//                logger.error(error.toString());
+//                builder.append(error.toString()).append(" ");
+//            }
+//            throw new RuntimeException(builder.toString(), e);
+//        }
+//        return generateModels(modelBuilder)
+//                .stream()
+//                .map(f -> new GeneratedFile(GeneratedFile.Type.RULE, f.getPath(), new String(f.getData())))
+//                .collect(toList());
+//    }
 
-    List<org.drools.modelcompiler.builder.GeneratedFile> generateModels(ModelBuilderImpl<PackageSources> modelBuilder) {
-        List<org.drools.modelcompiler.builder.GeneratedFile> toReturn = new ArrayList<>();
-        for (PackageSources pkgSources : modelBuilder.getPackageSources()) {
-            pkgSources.collectGeneratedFiles(toReturn);
-        }
-        return toReturn;
-    }
+//    List<org.drools.modelcompiler.builder.GeneratedFile> generateModels(ModelBuilderImpl<PackageSources> modelBuilder) {
+//        List<org.drools.modelcompiler.builder.GeneratedFile> toReturn = new ArrayList<>();
+//        for (PackageSources pkgSources : modelBuilder.getPackageSources()) {
+//            pkgSources.collectGeneratedFiles(toReturn);
+//        }
+//        return toReturn;
+//    }
 
     private PMMLResource parseResource(Resource resource) {
         final InternalKnowledgeBase knowledgeBase = new KnowledgeBaseImpl("PMML", null);

--- a/kie-plugins-testing/src/test/java/org/kie/maven/plugin/BuildPMMLTrustyTest.java
+++ b/kie-plugins-testing/src/test/java/org/kie/maven/plugin/BuildPMMLTrustyTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.maven.plugin;
+
+import java.io.File;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import io.takari.maven.testing.executor.MavenExecutionResult;
+import io.takari.maven.testing.executor.MavenRuntime;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class BuildPMMLTrustyTest extends KieMavenPluginBaseIntegrationTest {
+
+    private static final String PROJECT_NAME = "kjar-12-with-pmml-trusty";
+
+    private static final String GAV_ARTIFACT_ID = "kie-maven-plugin-test-kjar-12";
+    private static final String GAV_VERSION = "1.0.0.Final";
+
+
+    private static final String PMML_FILE_NAME = "logisticregressionirisdata/logisticRegressionIrisData.pmml";
+    private static final String EXAMPLE_PMML_CLASS = "compoundnestedpredicatescorecard/PMMLRuleMappersImpl.class";
+
+    public BuildPMMLTrustyTest(MavenRuntime.MavenRuntimeBuilder builder) {
+        super(builder);
+    }
+
+    @Test
+    public void testContentKjarWithPMML() throws Exception {
+        final MavenExecutionResult result = buildKJarProject(PROJECT_NAME,
+                                                             new String[]{"-Dorg.kie.version=" + TestUtil.getProjectVersion()},
+                                                             "clean", "install");
+
+        final File basedir = result.getBasedir();
+        final File kjarFile = new File(basedir, "target/" + GAV_ARTIFACT_ID + "-" + GAV_VERSION + ".jar");
+        Assertions.assertThat(kjarFile).exists();
+
+        final JarFile jarFile = new JarFile(kjarFile);
+        final Set<String> jarContent = new HashSet<>();
+        final Enumeration<JarEntry> kjarEntries = jarFile.entries();
+        while (kjarEntries.hasMoreElements()) {
+            final String entryName = kjarEntries.nextElement().getName();
+            jarContent.add(entryName);
+        }
+
+        Assertions.assertThat(jarContent).isNotEmpty();
+        Assertions.assertThat(jarContent).contains(PMML_FILE_NAME);
+        Assertions.assertThat(jarContent).contains(EXAMPLE_PMML_CLASS);
+    }
+}

--- a/kie-plugins-testing/src/test/projects/kjar-12-with-pmml-trusty/pom.xml
+++ b/kie-plugins-testing/src/test/projects/kjar-12-with-pmml-trusty/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.kie</groupId>
+  <artifactId>kie-maven-plugin-test-kjar-12</artifactId>
+  <version>1.0.0.Final</version>
+
+  <packaging>kjar</packaging>
+
+  <properties>
+<!--    <kie.version>7.51.0-SNAPSHOT</kie.version>-->
+    <generateModel>NO</generateModel>
+    <generateDMNModel>NO</generateDMNModel>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-model-compiler</artifactId>
+      <version>${org.kie.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-pmml-dependencies</artifactId>
+      <version>${org.kie.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>set-system-properties</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <property>
+                  <name>kie-pmml-implementation</name>
+                  <value>new</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-maven-plugin</artifactId>
+        <version>${org.kie.version}</version>
+        <extensions>true</extensions>
+        <configuration>
+          <properties>
+            <drools.dialect.java.compiler.lnglevel>1.8</drools.dialect.java.compiler.lnglevel>
+          </properties>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/kie-plugins-testing/src/test/projects/kjar-12-with-pmml-trusty/src/main/resources/META-INF/kmodule.xml
+++ b/kie-plugins-testing/src/test/projects/kjar-12-with-pmml-trusty/src/main/resources/META-INF/kmodule.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kmodule xmlns="http://jboss.org/kie/6.0.0/kmodule">
+
+</kmodule>

--- a/kie-plugins-testing/src/test/projects/kjar-12-with-pmml-trusty/src/main/resources/categoricalvariablesregression/categoricalVariablesRegression.pmml
+++ b/kie-plugins-testing/src/test/projects/kjar-12-with-pmml-trusty/src/main/resources/categoricalvariablesregression/categoricalVariablesRegression.pmml
@@ -1,0 +1,38 @@
+<PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.2" xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-2-1/pmml-4-2.xsd" xmlns="http://www.dmg.org/PMML-4_2">
+  <Header/>
+  <DataDictionary numberOfFields="3">
+    <DataField name="result" optype="continuous" dataType="double"/>
+    <DataField name="x" optype="categorical" dataType="string">
+      <Value value="red"/>
+      <Value value="green"/>
+      <Value value="blue"/>
+      <Value value="orange"/>
+      <Value value="yellow"/>
+    </DataField>
+    <DataField name="y" optype="categorical" dataType="string">
+      <Value value="classA"/>
+      <Value value="classB"/>
+      <Value value="classC"/>
+    </DataField>
+  </DataDictionary>
+  <RegressionModel modelName="categoricalVariables_Model" functionName="regression">
+    <MiningSchema>
+      <MiningField name="result" usageType="predicted" invalidValueTreatment="returnInvalid"/>
+      <MiningField name="x" usageType="active" invalidValueTreatment="returnInvalid"/>
+      <MiningField name="y" usageType="active" invalidValueTreatment="returnInvalid"/>
+    </MiningSchema>
+    <Output>
+      <OutputField name="Predicted_result" optype="continuous" dataType="double" feature="predictedValue"/>
+    </Output>
+    <RegressionTable intercept="-22.1">
+      <CategoricalPredictor name="x" value="red" coefficient="5.5"/>
+      <CategoricalPredictor name="x" value="green" coefficient="15"/>
+      <CategoricalPredictor name="x" value="blue" coefficient="12"/>
+      <CategoricalPredictor name="x" value="orange" coefficient="5.5"/>
+      <CategoricalPredictor name="x" value="yellow" coefficient="-100.25"/>
+      <CategoricalPredictor name="y" value="classA" coefficient="0"/>
+      <CategoricalPredictor name="y" value="classB" coefficient="20"/>
+      <CategoricalPredictor name="y" value="classC" coefficient="40"/>
+    </RegressionTable>
+  </RegressionModel>
+</PMML>

--- a/kie-plugins-testing/src/test/projects/kjar-12-with-pmml-trusty/src/main/resources/compoundnestedpredicatescorecard/CompoundNestedPredicateScorecard.pmml
+++ b/kie-plugins-testing/src/test/projects/kjar-12-with-pmml-trusty/src/main/resources/compoundnestedpredicatescorecard/CompoundNestedPredicateScorecard.pmml
@@ -1,0 +1,60 @@
+<PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.2" xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-2-1/pmml-4-2.xsd" xmlns="http://www.dmg.org/PMML-4_2">
+  <Header/>
+  <DataDictionary>
+    <DataField name="input1" optype="continuous" dataType="double"/>
+    <DataField name="input2" optype="categorical" dataType="string"/>
+    <DataField name="score" optype="continuous" dataType="double"/>
+  </DataDictionary>
+  <Scorecard modelName="CompoundNestedPredicateScorecard" functionName="regression" useReasonCodes="true" reasonCodeAlgorithm="pointsBelow" initialScore="-15" baselineMethod="other">
+    <MiningSchema>
+      <MiningField name="input1" usageType="active" invalidValueTreatment="asMissing"/>
+      <MiningField name="input2" usageType="active" invalidValueTreatment="asMissing"/>
+      <MiningField name="score" usageType="target"/>
+    </MiningSchema>
+    <Output>
+      <OutputField name="Score" feature="predictedValue" dataType="double" optype="continuous"/>
+      <OutputField name="Reason Code 1" rank="1" feature="reasonCode" dataType="string" optype="categorical"/>
+      <OutputField name="Reason Code 2" rank="2" feature="reasonCode" dataType="string" optype="categorical"/>
+    </Output>
+    <Characteristics>
+      <Characteristic name="characteristic1Score" baselineScore="21.8" reasonCode="characteristic1ReasonCode">
+        <Attribute partialScore="-10.5">
+          <CompoundPredicate booleanOperator="and">
+            <CompoundPredicate booleanOperator="and">
+              <True/>
+              <SimplePredicate field="input1" operator="greaterThan" value="-15"/>
+              <SimplePredicate field="input1" operator="lessOrEqual" value="25.4"/>
+            </CompoundPredicate>
+            <SimplePredicate field="input2" operator="notEqual" value="classA"/>
+          </CompoundPredicate>
+        </Attribute>
+        <Attribute partialScore="25">
+          <True/>
+        </Attribute>
+      </Characteristic>
+      <Characteristic name="characteristic2Score" baselineScore="11" reasonCode="characteristic2ReasonCode">
+        <Attribute partialScore="-18">
+          <CompoundPredicate booleanOperator="or">
+            <SimplePredicate field="input1" operator="lessOrEqual" value="-20"/>
+            <SimplePredicate field="input2" operator="equal" value="classA"/>
+          </CompoundPredicate>
+        </Attribute>
+        <Attribute partialScore="10">
+          <CompoundPredicate booleanOperator="or">
+            <CompoundPredicate booleanOperator="and">
+              <CompoundPredicate booleanOperator="and">
+                <SimplePredicate field="input1" operator="greaterOrEqual" value="5"/>
+                <SimplePredicate field="input1" operator="lessThan" value="12"/>
+              </CompoundPredicate>
+              <SimplePredicate field="input2" operator="equal" value="classB"/>
+            </CompoundPredicate>
+            <SimplePredicate field="input2" operator="equal" value="classC"/>
+          </CompoundPredicate>
+        </Attribute>
+        <Attribute partialScore="100.5">
+          <True/>
+        </Attribute>
+      </Characteristic>
+    </Characteristics>
+  </Scorecard>
+</PMML>

--- a/kie-plugins-testing/src/test/projects/kjar-12-with-pmml-trusty/src/main/resources/logisticregressionirisdata/logisticRegressionIrisData.pmml
+++ b/kie-plugins-testing/src/test/projects/kjar-12-with-pmml-trusty/src/main/resources/logisticregressionirisdata/logisticRegressionIrisData.pmml
@@ -1,0 +1,51 @@
+<PMML xmlns="http://www.dmg.org/PMML-4_2" version="4.2">
+  <Header/>
+  <DataDictionary numberOfFields="5">
+    <DataField name="Sepal.Length" optype="continuous" dataType="double"/>
+    <DataField name="Sepal.Width" optype="continuous" dataType="double"/>
+    <DataField name="Petal.Length" optype="continuous" dataType="double"/>
+    <DataField name="Petal.Width" optype="continuous" dataType="double"/>
+
+    <DataField name="Species" optype="categorical" dataType="string">
+      <Value value="setosa"/>
+      <Value value="virginica"/>
+      <Value value="versicolor"/>
+    </DataField>
+  </DataDictionary>
+  <RegressionModel functionName="classification" modelName="LogisticRegressionIrisData" targetFieldName="Species">
+    <MiningSchema>
+      <MiningField name="Sepal.Length"/>
+      <MiningField name="Sepal.Width"/>
+      <MiningField name="Petal.Length"/>
+      <MiningField name="Petal.Width"/>
+
+      <MiningField name="Species" usageType="target"/>
+    </MiningSchema>
+    <Output>
+      <OutputField name="Probability_setosa" optype="continuous" dataType="double" feature="probability" value="setosa"/>
+      <OutputField name="Probability_versicolor" optype="continuous" dataType="double" feature="probability" value="versicolor"/>
+      <OutputField name="Probability_virginica" optype="continuous" dataType="double" feature="probability" value="virginica"/>
+    </Output>
+
+    <RegressionTable targetCategory="setosa" intercept="0.11822288946815">
+      <NumericPredictor name="Sepal.Length" exponent="1" coefficient="0.0660297693761902"/>
+      <NumericPredictor name="Sepal.Width" exponent="1" coefficient="0.242847872054487"/>
+      <NumericPredictor name="Petal.Length" exponent="1" coefficient="-0.224657116235727"/>
+      <NumericPredictor name="Petal.Width" exponent="1" coefficient="-0.0574727291860025"/>
+    </RegressionTable>
+
+    <RegressionTable targetCategory="versicolor" intercept="1.57705897385745">
+      <NumericPredictor name="Sepal.Length" exponent="1" coefficient="-0.0201536848255179"/>
+      <NumericPredictor name="Sepal.Width" exponent="1" coefficient="-0.44561625761404"/>
+      <NumericPredictor name="Petal.Length" exponent="1" coefficient="0.22066920522933"/>
+      <NumericPredictor name="Petal.Width" exponent="1" coefficient="-0.494306595747785"/>
+    </RegressionTable>
+
+    <RegressionTable targetCategory="virginica" intercept="-0.695281863325603">
+      <NumericPredictor name="Sepal.Length" exponent="1" coefficient="-0.0458760845506725"/>
+      <NumericPredictor name="Sepal.Width" exponent="1" coefficient="0.202768385559553"/>
+      <NumericPredictor name="Petal.Length" exponent="1" coefficient="0.00398791100639665"/>
+      <NumericPredictor name="Petal.Width" exponent="1" coefficient="0.551779324933787"/>
+    </RegressionTable>
+  </RegressionModel>
+</PMML>

--- a/kie-plugins-testing/src/test/projects/kjar-12-with-pmml-trusty/src/main/resources/simplescorecardcategorical/SimpleScorecardCategorical.pmml
+++ b/kie-plugins-testing/src/test/projects/kjar-12-with-pmml-trusty/src/main/resources/simplescorecardcategorical/SimpleScorecardCategorical.pmml
@@ -1,0 +1,38 @@
+<PMML xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="4.2" xsi:schemaLocation="http://www.dmg.org/PMML-4_2 http://www.dmg.org/v4-2-1/pmml-4-2.xsd" xmlns="http://www.dmg.org/PMML-4_2">
+  <Header/>
+  <DataDictionary>
+    <DataField name="input1" optype="categorical" dataType="string"/>
+    <DataField name="input2" optype="categorical" dataType="string"/>
+    <DataField name="score" optype="continuous" dataType="double"/>
+  </DataDictionary>
+  <Scorecard modelName="SimpleScorecardCategorical" functionName="regression" useReasonCodes="true" reasonCodeAlgorithm="pointsBelow" initialScore="5" baselineMethod="other">
+    <MiningSchema>
+      <MiningField name="input1" usageType="active" invalidValueTreatment="asMissing"/>
+      <MiningField name="input2" usageType="active" invalidValueTreatment="asMissing"/>
+      <MiningField name="score" usageType="target"/>
+    </MiningSchema>
+    <Output>
+      <OutputField name="Score" feature="predictedValue" dataType="double" optype="continuous"/>
+      <OutputField name="Reason Code 1" rank="1" feature="reasonCode" dataType="string" optype="categorical"/>
+      <OutputField name="Reason Code 2" rank="2" feature="reasonCode" dataType="string" optype="categorical"/>
+    </Output>
+    <Characteristics>
+      <Characteristic name="input1Score" baselineScore="4" reasonCode="Input1ReasonCode">
+        <Attribute partialScore="-12">
+          <SimplePredicate field="input1" operator="equal" value="classA"/>
+        </Attribute>
+        <Attribute partialScore="50">
+          <SimplePredicate field="input1" operator="equal" value="classB"/>
+        </Attribute>
+      </Characteristic>
+      <Characteristic name="input2Score" baselineScore="8" reasonCode="Input2ReasonCode">
+        <Attribute partialScore="-8">
+          <SimplePredicate field="input2" operator="equal" value="classA"/>
+        </Attribute>
+        <Attribute partialScore="32">
+          <SimplePredicate field="input2" operator="equal" value="classB"/>
+        </Attribute>
+      </Characteristic>
+    </Characteristics>
+  </Scorecard>
+</PMML>


### PR DESCRIPTION
@danielezonca @mariofusco @jiripetrlik

This PR removes Rules source generation from maven-plugin/GeneratePMMLMojo

Depends on https://github.com/kiegroup/drools/pull/3395