### PR TITLE
[JBPM-9355] - Stabilize some jBPM integration tests by upgrading TJWSEmbeddedJaxrsServer embedded server

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/pom.xml
@@ -87,19 +87,11 @@
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-client</artifactId>
     </dependency>
-
-    <!-- Embedded application server dependencies, placed as a direct dependency as this common module specifies embedded components -->
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
-      <artifactId>tjws</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-      </exclusions>
+      <artifactId>resteasy-undertow</artifactId>
     </dependency>
- 
+
     <!-- test -->
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerStartupIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerStartupIntegrationTest.java
@@ -201,14 +201,8 @@ public class KieControllerStartupIntegrationTest extends KieControllerManagement
         controllerClient.startContainer(containerSpec);
 
         // Check that there is one container deployed.
-        try {
-            KieServerSynchronization.waitForKieServerSynchronization(client, 1);
-        } catch (TimeoutException e) {
-            // Sometimes creating container fails in embedded server (unknown Socket timeout error, tends to happen here).
-            // Retrigger container creation. These tests should be refactored to use more reliable container instead of embedded TJWSEmbeddedJaxrsServer.
-            controllerClient.startContainer(containerSpec);
-            KieServerSynchronization.waitForKieServerSynchronization(client, 1);
-        }
+        KieServerSynchronization.waitForKieServerSynchronization(client, 1);
+
         ServiceResponse<KieContainerResourceList> containersList = client.listContainers();
         assertEquals(ServiceResponse.ResponseType.SUCCESS, containersList.getType());
         assertNotNull(containersList.getResult().getContainers());


### PR DESCRIPTION
**[JBPM-9355](https://issues.redhat.com/browse/JBPM-9355)**: Stabilize some jBPM integration tests by upgrading TJWSEmbeddedJaxrsServer embedded server

**referenced Pull Requests**: https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1596