### PR TITLE
[JBPM-9636] When a non int value is passed as int to jaxb marshaller

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
@@ -60,6 +60,7 @@ public class KieServerConstants {
     public static final String KIE_SERVER_MODE = "org.kie.server.mode";
     public static final String KIE_SERVER_INCLUDE_STACKTRACE = "org.kie.server.stacktrace.included";
     public static final String KIE_SERVER_STRICT_ID_FORMAT = "org.kie.server.strict.id.format";
+    public static final String KIE_SERVER_STRICT_JAXB_FORMAT = "org.kie.server.strict.jaxb.format";
     public static final String KIE_SERVER_IMAGESERVICE_MAX_NODES = "org.kie.server.service.image.max_nodes";
     public static final String KIE_SERVER_REST_MODE_READONLY = "org.kie.server.rest.mode.readonly";
     public static final String KIE_SERVER_NOTIFY_UPDATES_TO_CONTROLLERS = "org.kie.server.update.notifications.rest.enabled";

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/jaxb/JaxbMarshaller.java
@@ -22,10 +22,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.ValidationEvent;
+import javax.xml.bind.util.ValidationEventCollector;
 
 import org.drools.core.command.GetVariableCommand;
 import org.drools.core.command.runtime.AdvanceSessionTimeCommand;
@@ -202,6 +205,9 @@ import org.kie.server.api.model.type.JaxbMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static javax.xml.bind.ValidationEvent.ERROR;
+import static javax.xml.bind.ValidationEvent.FATAL_ERROR;
+import static org.kie.server.api.KieServerConstants.KIE_SERVER_STRICT_JAXB_FORMAT;;
 
 public class JaxbMarshaller implements Marshaller {
 
@@ -467,7 +473,24 @@ public class JaxbMarshaller implements Marshaller {
     @Override
     public <T> T unmarshall(String input, Class<T> type) {
         try {
-            return (T) unwrap(getUnmarshaller().unmarshal(new StringReader(input)));
+            Unmarshaller unmarshaller = getUnmarshaller();
+            ValidationEventCollector vec = new ValidationEventCollector();
+            boolean strict = Boolean.getBoolean(KIE_SERVER_STRICT_JAXB_FORMAT);
+            unmarshaller.setEventHandler(vec);
+            Object result = unmarshaller.unmarshal(new StringReader(input));
+            if (strict || logger.isWarnEnabled()) {
+                String errorMessage = Arrays.stream(vec.getEvents())
+                        .filter(ve -> ve.getSeverity() == ERROR || ve.getSeverity() == FATAL_ERROR)
+                        .map(ValidationEvent::getMessage)
+                        .collect(Collectors.joining("\n"));
+                if (!errorMessage.isEmpty()) {
+                    logger.warn(errorMessage);
+                    if (strict) {
+                        throw new MarshallingException(errorMessage);
+                    }
+                }
+            }
+            return (T) unwrap(result);
         } catch (JAXBException e) {
             throw new MarshallingException("Can't unmarshall input string: " + input, e);
         }
@@ -477,13 +500,12 @@ public class JaxbMarshaller implements Marshaller {
         if (data instanceof Wrapped) {
             return ((Wrapped) data).unwrap();
         }
-
         return data;
     }
 
     @Override
     public void dispose() {
-
+        //nothing to do 
     }
 
     @Override
@@ -494,7 +516,6 @@ public class JaxbMarshaller implements Marshaller {
     protected javax.xml.bind.Marshaller getMarshaller() throws JAXBException {
         javax.xml.bind.Marshaller marshaller = jaxbContext.createMarshaller();
         marshaller.setProperty(javax.xml.bind.Marshaller.JAXB_FORMATTED_OUTPUT, true);
-
         return marshaller;
     }
 

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/JAXBMarshallerTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/JAXBMarshallerTest.java
@@ -26,11 +26,13 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Test;
+import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.marshalling.objects.DateObject;
 import org.kie.server.api.model.definition.QueryParam;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class JAXBMarshallerTest {
@@ -94,4 +96,20 @@ public class JAXBMarshallerTest {
         QueryParam param2 = marshaller.unmarshall(converted, QueryParam.class);
         assertTrue(param2.getValue().get(0) instanceof QueryParam);
     }
+
+    @Test
+    public void testMarshallError() {
+        Marshaller marshaller = MarshallerFactory.getMarshaller(new HashSet<>(), MarshallingFormat.JAXB, getClass()
+                .getClassLoader());
+        assertEquals(13, marshaller.unmarshall("<int-type><value>13</value></int-type>", int.class).intValue());
+        assertEquals(0, marshaller.unmarshall("<int-type><value>2kkbk</value></int-type>", int.class).intValue());
+        System.setProperty(KieServerConstants.KIE_SERVER_STRICT_JAXB_FORMAT, "true");
+        try {
+            assertThrows(MarshallingException.class, () -> marshaller.unmarshall(
+                    "<int-type><value>13ab</value></int-type>", int.class));
+        } finally {
+            System.clearProperty(KieServerConstants.KIE_SERVER_STRICT_JAXB_FORMAT);
+        }
+    }
+
 }


### PR DESCRIPTION
Throwing marshalling exception if org.kie.server.strict.jaxb.format is
true

**JIRA**: 
[link](https://issues.redhat.com/browse/JBPM-9636)
