### PR TITLE
[JBPM-9651] - Enforcer exception - duplicated classes in kie-server-services-common

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
@@ -192,6 +192,10 @@
           <groupId>javax.xml.bind</groupId>
           <artifactId>jaxb-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>jakarta.xml.bind</groupId>
+          <artifactId>jakarta.xml.bind-api</artifactId>
+        </exclusion>
       </exclusions>
     	<scope>test</scope>
     </dependency>


### PR DESCRIPTION
**[JBPM-9651](https://issues.redhat.com/browse/JBPM-9651)**: Enforcer exception - duplicated classes in kie-server-services-common
