### PR TITLE
[JBPM-9653] Wrong annotation is used for "processInstanceId" in ProcessAdminResource#migrateProcessInstanceWithSubprocess method + ProcessAdminClient new methods

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-client/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/build/revapi-config.json
@@ -140,6 +140,24 @@
                "methodName": "removePotentialOwnerUsers",
                "elementKind": "method",
                "justification": "[JBPM-9625]  Allow to bypass the authenticated user in the KIE REST API that is adding users or groups as potential owners"
+             },
+             {
+                "code": "java.method.addedToInterface",
+                "new": "method org.kie.server.api.model.admin.MigrationReportInstance org.kie.server.client.admin.ProcessAdminServicesClient::migrateProcessInstanceWithSubprocess(java.lang.String, java.lang.Long, java.lang.String, java.lang.String)",
+                "package": "org.kie.server.client.admin",
+                "classSimpleName": "ProcessAdminServicesClient",
+                "methodName": "migrateProcessInstanceWithSubprocess",
+                "elementKind": "method",
+                "justification": "https://issues.redhat.com/browse/JBPM-9653"
+             },
+             {
+                "code": "java.method.addedToInterface",
+                "new": "method org.kie.server.api.model.admin.MigrationReportInstance org.kie.server.client.admin.ProcessAdminServicesClient::migrateProcessInstanceWithSubprocess(java.lang.String, java.lang.Long, java.lang.String, java.lang.String, java.util.Map<java.lang.String, java.lang.String>)",
+                "package": "org.kie.server.client.admin",
+                "classSimpleName": "ProcessAdminServicesClient",
+                "methodName": "migrateProcessInstanceWithSubprocess",
+                "elementKind": "method",
+                "justification": "https://issues.redhat.com/browse/JBPM-9653"
              }
             ]
         }

--- a/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/admin/ProcessAdminServicesClient.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/main/java/org/kie/server/client/admin/ProcessAdminServicesClient.java
@@ -34,6 +34,10 @@ public interface ProcessAdminServicesClient {
 
     List<MigrationReportInstance> migrateProcessInstances(String containerId, List<Long> processInstancesId, String targetContainerId, String targetProcessId, Map<String, String> nodeMapping);
 
+    MigrationReportInstance migrateProcessInstanceWithSubprocess(String containerId, Long processInstanceId, String targetContainerId, String targetProcessId);
+
+    MigrationReportInstance migrateProcessInstanceWithSubprocess(String containerId, Long processInstanceId, String targetContainerId, String targetProcessId, Map<String, String> nodeMapping);
+
     List<ProcessNode> getProcessNodes(String containerId, Long processInstanceId);
 
     void cancelNodeInstance(String containerId, Long processInstanceId, Long nodeInstanceId);

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/main/java/org/kie/server/remote/rest/jbpm/admin/ProcessAdminResource.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/main/java/org/kie/server/remote/rest/jbpm/admin/ProcessAdminResource.java
@@ -174,7 +174,7 @@ public class ProcessAdminResource {
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public Response migrateProcessInstanceWithSubprocess(@javax.ws.rs.core.Context HttpHeaders headers, 
             @ApiParam(value = "container id that process instances belongs to", required = true, example = "evaluation_1.0.0-SNAPSHOT") @PathParam(CONTAINER_ID) String containerId, 
-            @ApiParam(value = "list of identifiers of process instance to be migrated", required = true) @QueryParam(PROCESS_INST_ID) Long processInstanceId,
+            @ApiParam(value = "list of identifiers of process instance to be migrated", required = true) @PathParam(PROCESS_INST_ID) Long processInstanceId,
             @ApiParam(value = "container id that new process definition belongs to", required = true) @QueryParam("targetContainerId") String targetContainerId, 
             @ApiParam(value = "process definition that process instances should be migrated to", required = true) @QueryParam("targetProcessId") String targetProcessId, 
             @ApiParam(value = "node mapping - unique ids of old definition to new definition given as Map", required = false, examples=@Example(value= {


### PR DESCRIPTION
**[JBPM-9653](https://issues.redhat.com/browse/JBPM-9653)**: Wrong annotation is used for "processInstanceId" in ProcessAdminResource#migrateProcessInstanceWithSubprocess method + ProcessAdminClient new methods