### PR TITLE
BAQE-1706 - Fix for Kie Server error introduced with jdk11

### DIFF
--- a/kie-performance-kit/pom.xml
+++ b/kie-performance-kit/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <java.module.name>org.kie.performance.kit</java.module.name>
-    <metrics.version>3.1.0</metrics.version>
+    <metrics.version>4.1.18</metrics.version>
     <perfrepo.version>1.7</perfrepo.version>
   </properties>
 

--- a/kie-performance-kit/src/main/java/org/kie/perf/Executor.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/Executor.java
@@ -102,20 +102,6 @@ public class Executor {
                 metrics.registerAll(new MemoryUsageGaugeSet(scenario.getClass()));
             } else if (m == Measure.FILEDESCRIPTORS) {
                 metrics.register(MetricRegistry.name(scenario.getClass(), "file.descriptors.usage"), new FileDescriptorRatioGauge());
-                metrics.register(MetricRegistry.name(scenario.getClass(), "file.descriptors.used"), new Gauge<Long>() {
-                    @Override
-                    public Long getValue() {
-                        try {
-                            OperatingSystemMXBean os = ManagementFactory.getOperatingSystemMXBean();
-                            Method method = os.getClass().getDeclaredMethod("getOpenFileDescriptorCount");
-                            method.setAccessible(true);
-                            return (Long) method.invoke(os);
-                        } catch (Exception e) {
-
-                        }
-                        return -1L;
-                    }
-                });
             } else if (m == Measure.THREADSTATES) {
                 metrics.registerAll(new ThreadStatesGaugeSet(scenario.getClass()));
             } else if (m == Measure.CPUUSAGE) {

--- a/kie-performance-kit/src/main/java/org/kie/perf/TestConfig.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/TestConfig.java
@@ -49,7 +49,9 @@ public class TestConfig {
     protected String perfRepoUrlPath;
     protected String perfRepoUsername;
     protected String perfRepoPassword;
-    
+
+    protected String testUIDSuffix;
+
     protected String version = Executor.class.getPackage().getImplementationVersion();
 
     protected List<Measure> measure;
@@ -157,6 +159,10 @@ public class TestConfig {
         perfRepoPassword = System.getProperty("perfRepo.password");
         if (perfRepoPassword != null) {
             properties.put("perfRepo.password", perfRepoPassword);
+        }
+        testUIDSuffix = System.getProperty("testUIDSuffix");
+        if (testUIDSuffix != null) {
+            properties.put("testUIDSuffix", testUIDSuffix);
         }
 
         return properties;
@@ -280,6 +286,10 @@ public class TestConfig {
         return perfRepoPassword;
     }
 
+    public String getTestUIDSuffix() {
+        return testUIDSuffix;
+    }
+
     public static enum ReporterType {
         CONSOLE, CSV, CSVSINGLE, PERFREPO
     }
@@ -307,5 +317,4 @@ public class TestConfig {
             return instance;
         }
     }
-
 }

--- a/kie-performance-kit/src/main/java/org/kie/perf/metrics/CPUUsageHistogramSet.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/metrics/CPUUsageHistogramSet.java
@@ -1,8 +1,7 @@
 package org.kie.perf.metrics;
 
 import java.lang.management.ManagementFactory;
-import java.lang.management.OperatingSystemMXBean;
-import java.lang.reflect.Method;
+import com.sun.management.OperatingSystemMXBean;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Timer;
@@ -19,22 +18,15 @@ public class CPUUsageHistogramSet implements MetricSet {
     private Class<?> scenario;
     private Histogram cpuUsageHistogram = new Histogram(new UniformReservoir());
     private OperatingSystemMXBean operatingSystemMXBean;
-    private Method getProcessCpuLoad;
     private Timer timer = new Timer();
 
     private static CPUUsageHistogramSet instance = null;
 
     private CPUUsageHistogramSet(Class<?> scenario) {
         this.scenario = scenario;
-
-        operatingSystemMXBean = ManagementFactory.getOperatingSystemMXBean();
-        try {
-            getProcessCpuLoad = operatingSystemMXBean.getClass().getMethod("getProcessCpuLoad");
-            getProcessCpuLoad.setAccessible(true);
-        } catch (Exception e) {
-
+        operatingSystemMXBean = (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean();
         }
-    }
+
 
     public static CPUUsageHistogramSet getInstance(Class<?> scenario) {
         if (instance == null) {
@@ -46,8 +38,8 @@ public class CPUUsageHistogramSet implements MetricSet {
     private void update() {
         Double value = null;
         try {
-            if (getProcessCpuLoad != null && operatingSystemMXBean != null) {
-                value = (Double) getProcessCpuLoad.invoke(operatingSystemMXBean);
+            if (operatingSystemMXBean != null) {
+                value = operatingSystemMXBean.getProcessCpuLoad();
                 value *= 100;
             }
         } catch (Exception e) {
@@ -76,7 +68,7 @@ public class CPUUsageHistogramSet implements MetricSet {
     public Map<String, Metric> getMetrics() {
         final Map<String, Metric> metrics = new HashMap<String, Metric>();
 
-        if (getProcessCpuLoad != null && operatingSystemMXBean != null) {
+        if (operatingSystemMXBean != null) {
             metrics.put(MetricRegistry.name(scenario, "cpu.usage"), cpuUsageHistogram);
         }
 

--- a/kie-performance-kit/src/main/java/org/kie/perf/metrics/PerfRepoReporter.java
+++ b/kie-performance-kit/src/main/java/org/kie/perf/metrics/PerfRepoReporter.java
@@ -111,6 +111,9 @@ public class PerfRepoReporter extends ScheduledReporter {
         }
 
         String testUid = tc.getProjectName().toLowerCase().replaceAll(" ", "_") + "_" + tc.getSuite().toLowerCase() + "_" + tc.getScenario().toLowerCase();
+        if (tc.getTestUIDSuffix() != null && !tc.getTestUIDSuffix().isEmpty()) {
+            testUid = testUid + "_" + tc.getTestUIDSuffix();
+        }
 
         TestExecutionBuilder testExecution = TestExecution.builder().testUid(testUid).name(testExecutionName + " - Result").started(new Date());
 


### PR DESCRIPTION
BAQE-1706 - Transition to jdk11 and fixing bugs that came out in KIE server tests. Merge together with Kie-benchmark PR and changed test definition in bxms-qe-tests