### PR TITLE
[DROOLS-6053] Reduce unnecessary classloading by parent classloader

### DIFF
--- a/kie-plugins-testing/src/test/java/org/drools/modelcompiler/ExecModelTestUtil.java
+++ b/kie-plugins-testing/src/test/java/org/drools/modelcompiler/ExecModelTestUtil.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.drools.modelcompiler;
+
+import java.util.Set;
+
+public class ExecModelTestUtil {
+
+    public static Set<String> getGeneratedClassNames(CanonicalKieModule module) {
+        return module.getGeneratedClassNames();
+    }
+
+    private ExecModelTestUtil() {
+        // It is forbidden to create instances of util classes.
+    }
+}

--- a/kie-plugins-testing/src/test/java/org/kie/maven/plugin/ExecModelParameterTest.java
+++ b/kie-plugins-testing/src/test/java/org/kie/maven/plugin/ExecModelParameterTest.java
@@ -15,9 +15,12 @@
  */
 package org.kie.maven.plugin;
 
+import java.util.Set;
+
 import io.takari.maven.testing.executor.MavenRuntime;
 import org.drools.compiler.kie.builder.impl.KieContainerImpl;
 import org.drools.modelcompiler.CanonicalKieModule;
+import org.drools.modelcompiler.ExecModelTestUtil;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieModule;
@@ -54,6 +57,9 @@ public class ExecModelParameterTest extends KieMavenPluginBaseIntegrationTest {
                          "clean", "install");
         KieModule kieModule = fireRule(ARTIFACT_ID_WITH_EXEC_MODEL, KBASE_NAME_WITH_EXEC_MODEL);
         assertTrue(kieModule instanceof CanonicalKieModule);
+        CanonicalKieModule canonicalKieModule = (CanonicalKieModule) kieModule;
+        Set<String> generatedClassNames = ExecModelTestUtil.getGeneratedClassNames(canonicalKieModule);
+        assertGeneratedClassNames(generatedClassNames);
     }
 
     @Test
@@ -63,6 +69,25 @@ public class ExecModelParameterTest extends KieMavenPluginBaseIntegrationTest {
                          "clean", "install");
         KieModule kieModule = fireRule(ARTIFACT_ID_WITH_EXEC_MODEL, KBASE_NAME_WITH_EXEC_MODEL);
         assertTrue(kieModule instanceof CanonicalKieModule);
+        CanonicalKieModule canonicalKieModule = (CanonicalKieModule) kieModule;
+        Set<String> generatedClassNames = ExecModelTestUtil.getGeneratedClassNames(canonicalKieModule);
+        assertGeneratedClassNames(generatedClassNames);
+    }
+
+    private void assertGeneratedClassNames(Set<String> generatedClassNames) {
+        String[] nameFragments = new String[] {"Rules", "LambdaConsequence", "DomainClassesMetadata"};
+        for (String nameFragment : nameFragments) {
+            boolean contains = false;
+            for (String generatedClassName : generatedClassNames) {
+                if (generatedClassName.contains(nameFragment)) {
+                    contains = true;
+                    break;
+                }
+            }
+            if (!contains) {
+                fail("generatedClassNames doesn't contain [" + nameFragment + "] class. : " + generatedClassNames);
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
- Adding generated-class-names in kjar

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6053

**referenced Pull Requests**:
* https://github.com/kiegroup/drools/pull/3458

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
