### PR TITLE
[DROOLS-6175] Change CanonicalKieModule metadata path from a dot cont…

### DIFF
--- a/kie-plugins-testing/src/test/java/org/kie/maven/plugin/AlphaNetworkCompilerTest.java
+++ b/kie-plugins-testing/src/test/java/org/kie/maven/plugin/AlphaNetworkCompilerTest.java
@@ -21,12 +21,16 @@ import java.util.List;
 import io.takari.maven.testing.executor.MavenRuntime;
 import org.drools.ancompiler.CompiledNetwork;
 import org.drools.ancompiler.ObjectTypeNodeCompiler;
+import org.drools.compiler.kie.builder.impl.InternalKieModule;
+import org.drools.compiler.kie.builder.impl.KieContainerImpl;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.reteoo.ObjectSinkPropagator;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.Rete;
+import org.drools.modelcompiler.CanonicalKieModule;
 import org.junit.Test;
 import org.kie.api.KieServices;
+import org.kie.api.builder.KieModule;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
@@ -57,6 +61,16 @@ public class AlphaNetworkCompilerTest extends KieMavenPluginBaseIntegrationTest 
         final KieContainer kieContainer = kieServices.newKieContainer(releaseId);
         KieSession kSession = null;
         try {
+            KieModule kieModule = ((KieContainerImpl)kieContainer).getKieModuleForKBase("kbase-compiled-alphanetwork");
+            InternalKieModule internalKieModule;
+            if (kieModule instanceof CanonicalKieModule) {
+                internalKieModule = ((CanonicalKieModule) kieModule).getInternalKieModule();
+            } else {
+                internalKieModule = (InternalKieModule) kieModule;
+            }
+            String ancFileName = CanonicalKieModule.getANCFile(releaseId);
+            assertEquals("META-INF/kie/org/kie/" + ARTIFACT_ID + "/alpha-network-compiler", ancFileName);
+            assertTrue(internalKieModule.isAvailable(ancFileName));
 
             kSession = kieContainer.newKieSession("kbase-compiled-alphanetwork.session");
 

--- a/kie-plugins-testing/src/test/java/org/kie/maven/plugin/ExecModelParameterTest.java
+++ b/kie-plugins-testing/src/test/java/org/kie/maven/plugin/ExecModelParameterTest.java
@@ -16,6 +16,7 @@
 package org.kie.maven.plugin;
 
 import io.takari.maven.testing.executor.MavenRuntime;
+import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.compiler.kie.builder.impl.KieContainerImpl;
 import org.drools.modelcompiler.CanonicalKieModule;
 import org.junit.Test;
@@ -26,7 +27,9 @@ import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
 
 import static java.lang.String.format;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.kie.maven.plugin.TestUtil.getProjectVersion;
 
 public class ExecModelParameterTest extends KieMavenPluginBaseIntegrationTest {
@@ -54,6 +57,12 @@ public class ExecModelParameterTest extends KieMavenPluginBaseIntegrationTest {
                          "clean", "install");
         KieModule kieModule = fireRule(ARTIFACT_ID_WITH_EXEC_MODEL, KBASE_NAME_WITH_EXEC_MODEL);
         assertTrue(kieModule instanceof CanonicalKieModule);
+
+        InternalKieModule internalKieModule = ((CanonicalKieModule) kieModule).getInternalKieModule();
+
+        String modelFileName = CanonicalKieModule.getModelFileWithGAV(internalKieModule.getReleaseId());
+        assertEquals("META-INF/kie/org/kie/" + ARTIFACT_ID_WITH_EXEC_MODEL + "/drools-model", modelFileName);
+        assertTrue(internalKieModule.isAvailable(modelFileName));
     }
 
     @Test
@@ -63,6 +72,12 @@ public class ExecModelParameterTest extends KieMavenPluginBaseIntegrationTest {
                          "clean", "install");
         KieModule kieModule = fireRule(ARTIFACT_ID_WITH_EXEC_MODEL, KBASE_NAME_WITH_EXEC_MODEL);
         assertTrue(kieModule instanceof CanonicalKieModule);
+
+        InternalKieModule internalKieModule = ((CanonicalKieModule) kieModule).getInternalKieModule();
+
+        String modelFileName = CanonicalKieModule.getModelFileWithGAV(internalKieModule.getReleaseId());
+        assertEquals("META-INF/kie/org/kie/" + ARTIFACT_ID_WITH_EXEC_MODEL + "/drools-model", modelFileName);
+        assertTrue(internalKieModule.isAvailable(modelFileName));
     }
 
     @Test


### PR DESCRIPTION
…aining directory to standard package structure

**JIRA**:
https://issues.redhat.com/browse/DROOLS-6175

**referenced Pull Requests**: 
* https://github.com/kiegroup/drools/pull/3466

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
