### PR TITLE
[DROOLS-6184] Add profile for Fuse on Spring boot

### DIFF
--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -1583,5 +1583,25 @@
    </mirrors>]]></maven.settings.mirror>
       </properties>
     </profile>
+
+    <profile>
+      <id>fuse-on-springboot</id>
+      <activation>
+        <property>
+          <name>fuse.springboot.version</name>
+        </property>
+      </activation>
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>org.jboss.redhat-fuse</groupId>
+            <artifactId>fuse-springboot-bom</artifactId>
+            <version>${fuse.springboot.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Add profile for testing of kie server client with Fuse on Springboot bom. It should be possible to specify Fuse on Spring boot version using fuse.springboot.version environment property.