### PR TITLE
[DROOLS-6177] Parametrize query command in kie-server to choose the r…

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/stateless-session-kjar/src/main/resources/kbase1/rules.drl
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/stateless-session-kjar/src/main/resources/kbase1/rules.drl
@@ -27,6 +27,9 @@ then
     }
 end
 
+query "query1"
+    $person : Person()
+end
 
 
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/resources/logback-test.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/resources/logback-test.xml
@@ -8,7 +8,7 @@
     </encoder>
   </appender>
 
-  <logger name="org.kie.server" level="INFO" />
+  <logger name="org.kie.server" level="DEBUG" />
   <logger name="org.apache.http" level="WARN" />
   <logger name="org.apache.maven" level="WARN" />
   <logger name="org.kie.server.services.PrometheusMetricsDroolsListener" level="DEBUG" />


### PR DESCRIPTION
…eturn values Luca Molteni Moments ago

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

https://issues.redhat.com/browse/DROOLS-6177

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

https://github.com/kiegroup/droolsjbpm-knowledge/pull/512
https://github.com/kiegroup/drools/pull/3472
https://github.com/kiegroup/droolsjbpm-integration/pull/2436

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
