### PR TITLE
[DROOLS-6175] Change CanonicalKieModule metadata path from a dot cont…

### DIFF
--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-default/src/test/java-filtered/org/kie/maven/plugin/ittests/ExecModelParameterTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-default/src/test/java-filtered/org/kie/maven/plugin/ittests/ExecModelParameterTestIT.java
@@ -18,10 +18,12 @@ package org.kie.maven.plugin.ittests;
 
 import java.net.URL;
 
+import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.modelcompiler.CanonicalKieModule;
 import org.junit.Test;
 import org.kie.api.builder.KieModule;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -37,6 +39,12 @@ public class ExecModelParameterTestIT {
         KieModule kieModule = fireRule();
         assertNotNull(kieModule);
         assertTrue(kieModule instanceof CanonicalKieModule);
+
+        InternalKieModule internalKieModule = ((CanonicalKieModule) kieModule).getInternalKieModule();
+
+        String modelFileName = CanonicalKieModule.getModelFileWithGAV(internalKieModule.getReleaseId());
+        assertEquals("META-INF/kie/org/kie/" + GAV_ARTIFACT_ID + "/drools-model", modelFileName);
+        assertTrue(internalKieModule.isAvailable(modelFileName));
     }
 
     private KieModule fireRule() throws Exception {

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-yes-generate/src/test/java-filtered/org/kie/maven/plugin/ittests/ExecModelParameterTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-yes-generate/src/test/java-filtered/org/kie/maven/plugin/ittests/ExecModelParameterTestIT.java
@@ -19,6 +19,7 @@ package org.kie.maven.plugin.ittests;
 import java.net.URL;
 
 import org.assertj.core.api.Assertions;
+import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.drools.compiler.kie.builder.impl.KieContainerImpl;
 import org.drools.modelcompiler.CanonicalKieModule;
 import org.junit.Test;
@@ -42,6 +43,12 @@ public class ExecModelParameterTestIT {
         KieModule kieModule = fireRule();
         assertNotNull(kieModule);
         assertTrue(kieModule instanceof CanonicalKieModule);
+
+        InternalKieModule internalKieModule = ((CanonicalKieModule) kieModule).getInternalKieModule();
+
+        String modelFileName = CanonicalKieModule.getModelFileWithGAV(internalKieModule.getReleaseId());
+        assertEquals("META-INF/kie/org/kie/" + GAV_ARTIFACT_ID + "/drools-model", modelFileName);
+        assertTrue(internalKieModule.isAvailable(modelFileName));
     }
 
     private KieModule fireRule() throws Exception {

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-13/src/test/java-filtered/org/kie/maven/plugin/ittests/AlphaNetworkCompilerTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-13/src/test/java-filtered/org/kie/maven/plugin/ittests/AlphaNetworkCompilerTestIT.java
@@ -23,12 +23,16 @@ import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.drools.ancompiler.CompiledNetwork;
 import org.drools.ancompiler.ObjectTypeNodeCompiler;
+import org.drools.compiler.kie.builder.impl.InternalKieModule;
+import org.drools.compiler.kie.builder.impl.KieContainerImpl;
 import org.drools.core.impl.InternalKnowledgeBase;
 import org.drools.core.reteoo.ObjectSinkPropagator;
 import org.drools.core.reteoo.ObjectTypeNode;
 import org.drools.core.reteoo.Rete;
+import org.drools.modelcompiler.CanonicalKieModule;
 import org.junit.Test;
 import org.kie.api.KieBase;
+import org.kie.api.builder.KieModule;
 import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
 
@@ -50,6 +54,13 @@ public class AlphaNetworkCompilerTestIT {
         KieSession kSession = null;
         try {
 
+            KieModule kieModule = ((KieContainerImpl)kieContainer).getKieModuleForKBase(KBASE_NAME);
+            InternalKieModule internalKieModule = ((CanonicalKieModule) kieModule).getInternalKieModule();
+
+            String ancFileName = CanonicalKieModule.getANCFile(internalKieModule.getReleaseId());
+            assertEquals("META-INF/kie/org/kie/" + GAV_ARTIFACT_ID + "/alpha-network-compiler", ancFileName);
+            assertTrue(internalKieModule.isAvailable(ancFileName));
+
             kSession = kieBase.newKieSession();
             Assertions.assertThat(kSession).isNotNull();
 
@@ -65,7 +76,6 @@ public class AlphaNetworkCompilerTestIT {
             assertEquals(1, rulesFired);
 
             assertReteIsAlphaNetworkCompiled(kSession);
-
         } finally {
             kSession.dispose();
         }


### PR DESCRIPTION
…aining directory to standard package structure

Adding assertions to the new IT tests.

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6175

**referenced Pull Requests**: 
* https://github.com/kiegroup/drools/pull/3466

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
