### PR TITLE
[DROOLS-6177] Parametrize query command in kie-server to choose the return values

### DIFF
--- a/kie-camel/src/test/java/org/kie/camel/embedded/camel/component/BatchTest.java
+++ b/kie-camel/src/test/java/org/kie/camel/embedded/camel/component/BatchTest.java
@@ -40,8 +40,10 @@ import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.dataformat.JaxbDataFormat;
 import org.apache.camel.test.junit4.CamelTestSupport;
 import org.custommonkey.xmlunit.XMLUnit;
+import org.drools.core.common.DisconnectedFactHandle;
 import org.drools.core.common.InternalFactHandle;
 import org.drools.core.impl.StatefulKnowledgeSessionImpl;
+import org.drools.core.runtime.rule.impl.FlatQueryResults;
 import org.drools.core.util.StringUtils;
 import org.drools.modelcompiler.ExecutableModelProject;
 import org.jbpm.process.core.context.variable.VariableScope;
@@ -1267,7 +1269,8 @@ public abstract class BatchTest extends CamelTestSupport {
 
             outXml = execContent("testInsertObjectWithDeclaredFactAndQuery.in.2");
 
-            assertXMLEqual(getContent("testInsertObjectWithDeclaredFactAndQuery.expected.1", fh.toExternalForm()), outXml);
+            DisconnectedFactHandle disconnectedFactHandle = FlatQueryResults.newFrom(fh);
+            assertXMLEqual(getContent("testInsertObjectWithDeclaredFactAndQuery.expected.1", disconnectedFactHandle.toExternalForm()), outXml);
         } finally {
             Thread.currentThread().setContextClassLoader(orig);
         }

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/stateless-session-kjar/src/main/resources/kbase1/rules.drl
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/filtered-resources/kjars-sources/stateless-session-kjar/src/main/resources/kbase1/rules.drl
@@ -27,6 +27,9 @@ then
     }
 end
 
+query "query1"
+    $person : Person()
+end
 
 
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/StatelessSessionUsageIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/StatelessSessionUsageIntegrationTest.java
@@ -22,12 +22,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.drools.core.runtime.rule.impl.FlatQueryResultRow;
+import org.drools.core.runtime.rule.impl.FlatQueryResults;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.kie.api.KieServices;
 import org.kie.api.command.BatchExecutionCommand;
 import org.kie.api.command.Command;
 import org.kie.api.runtime.ExecutionResults;
+import org.kie.api.runtime.rule.QueryResultsRow;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
@@ -97,5 +100,34 @@ public class StatelessSessionUsageIntegrationTest extends DroolsKieServerBaseInt
 
         assertEquals("Expected surname to be set to 'Vader'",
                 PERSON_EXPECTED_SURNAME, KieServerReflections.valueOf(value, PERSON_SURNAME_FIELD));
+    }
+
+
+    @Test
+    public void testQuery() {
+        List<Command<?>> commands = new ArrayList<>();
+        BatchExecutionCommand executionCommand = commandsFactory.newBatchExecution(commands, KIE_SESSION);
+
+        Object person = createInstance(PERSON_CLASS_NAME, PERSON_NAME, "");
+        commands.add(commandsFactory.newInsert(person, PERSON_OUT_IDENTIFIER));
+
+        commands.add(commandsFactory.newQuery("personQueryResult", "query1"));
+
+        ServiceResponse<ExecutionResults> reply = ruleClient.executeCommandsWithResults(CONTAINER_ID, executionCommand);
+        assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
+
+        ExecutionResults actualData = reply.getResult();
+
+        FlatQueryResults personQueryResult = (FlatQueryResults) actualData.getValue("personQueryResult");
+
+        for(QueryResultsRow r : personQueryResult) {
+            FlatQueryResultRow flatQueryResultRow = (FlatQueryResultRow) r;
+
+            assertEquals(1, flatQueryResultRow.getIdentifiers().size());
+
+            for(String i : flatQueryResultRow.getIdentifiers()) {
+                assertNotNull(flatQueryResultRow.get(i));
+            }
+        }
     }
 }


### PR DESCRIPTION
Second version of 

https://issues.redhat.com/browse/DROOLS-6177

This is far simpler but should satisfy the needs of a smaller payload

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

https://github.com/kiegroup/drools/pull/3473
https://github.com/kiegroup/droolsjbpm-integration/pull/2438

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
