### PR TITLE
[JBPM-9687] - Stabilize a flaky test with SocketTimeoutException around KieServer

### DIFF
--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/java/org/kie/server/springboot/samples/rest/KieServerWithExtraEndpointTest.java
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-sample/src/test/java/org/kie/server/springboot/samples/rest/KieServerWithExtraEndpointTest.java
@@ -49,7 +49,7 @@ public class KieServerWithExtraEndpointTest {
         KieServerHttpRequest httpRequest =
                 KieServerHttpRequest.newRequest(extraEndpoint, user, password)
                 .followRedirects(true)
-                .timeout(1000)
+                .timeout(5000)
                 .contentType("application/json")
                 .accept("application/json");
         httpRequest.get();


### PR DESCRIPTION
**[JBPM-9687](https://issues.redhat.com/browse/JBPM-9687)**: Stabilize a flaky test with SocketTimeoutException around KieServer