### PR TITLE
DROOLS-6263: Test Scenario - expected vs actual alert is misleading

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-scenario-simulation/src/test/java/org/kie/server/integrationtests/scenariosimulation/ScenarioSimulationIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-scenario-simulation/src/test/java/org/kie/server/integrationtests/scenariosimulation/ScenarioSimulationIntegrationTest.java
@@ -91,7 +91,7 @@ public class ScenarioSimulationIntegrationTest
         assertEquals(1, dmnResponseFail.getResult().getRunCount());
         assertEquals("Test Scenario execution failed", dmnResponseFail.getMsg());
         assertFalse(dmnResponseFail.getResult().getFailures().isEmpty());
-        assertEquals("#1 KO scenario: Failed in \"Greeting Message\": The expected value is \"\"Hello John\"\" but the actual one is \"\"Hello John 1\"\"",
+        assertEquals("#1 KO scenario: Failed in \"Greeting Message\": The expected value is \"\"Hello John 1\"\" but the actual one is \"\"Hello John\"\"",
                      dmnResponseFail.getResult().getFailures().get(0).getErrorMessage());
 
         ServiceResponse<ScenarioSimulationResult> ruleResponseSuccess = methodToTest.apply(CONTAINER_1_ID, RULE_SCESIM_SUCCESS_PATH);
@@ -106,7 +106,7 @@ public class ScenarioSimulationIntegrationTest
         assertEquals(1, ruleResponseFail.getResult().getRunCount());
         assertEquals("Test Scenario execution failed", ruleResponseFail.getMsg());
         assertFalse(ruleResponseFail.getResult().getFailures().isEmpty());
-        assertEquals("#1 KO scenario: Failed in \"String\": The expected value is \"John\" but the actual one is \"John 1\"",
+        assertEquals("#1 KO scenario: Failed in \"String\": The expected value is \"John 1\" but the actual one is \"John\"",
                      ruleResponseFail.getResult().getFailures().get(0).getErrorMessage());
     }
 


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6263

**referenced Pull Requests**: 

* https://github.com/kiegroup/drools/pull/3510
* https://github.com/kiegroup/droolsjbpm-integration/pull/2448
<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
