### PR TITLE
AF-2811: Required Process Variable Tags shouldn't be accepted in forms when empty

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/definition/ProcessDefinition.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/definition/ProcessDefinition.java
@@ -19,6 +19,7 @@ package org.kie.server.api.model.definition;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -57,6 +58,8 @@ public class ProcessDefinition {
     private Collection<NodeDefinition> nodes;
     @XmlElementWrapper(name = "timers")
     private Collection<TimerDefinition> timers;
+    @XmlElementWrapper(name = "tags")
+    private Map<String, String[]> tagsByVariable;
 
     @XmlElement(name = "dynamic")
     private boolean dynamic;
@@ -132,6 +135,14 @@ public class ProcessDefinition {
         this.processVariables = processVariables;
     }
 
+    public Map<String, String[]> getTagsByVariable() {
+        return tagsByVariable;
+    }
+
+    public void setTagsByVariable(Map<String, String[]> tagsByVariable) {
+        this.tagsByVariable = tagsByVariable;
+    }
+
     public Collection<String> getReusableSubProcesses() {
         return reusableSubProcesses;
     }
@@ -178,6 +189,7 @@ public class ProcessDefinition {
                 ", reusableSubProcesses=" + reusableSubProcesses +
                 ", nodes=" + nodes +
                 ", timers=" + timers +
+                ", tagsByVariable=" + tagsByVariable +
                 ", dynamic=" + dynamic +
                 '}';
     }
@@ -244,6 +256,16 @@ public class ProcessDefinition {
 
         public Builder subprocesses(Collection<String> subprocesses) {
             definition.setReusableSubProcesses(subprocesses);
+            return this;
+        }
+
+        public Builder tagsByVariables(Map<String, Set<String>> tagsByVariables) {
+            Map<String, String[]> data = new HashMap<String, String[]>();
+
+            for (Map.Entry<String, Set<String>> entry : tagsByVariables.entrySet()) {
+                data.put(entry.getKey(), entry.getValue().toArray(new String[entry.getValue().size()]));
+            }
+            definition.setTagsByVariable(data);
             return this;
         }
 

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/FormRendererBase.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/FormRendererBase.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -260,6 +261,9 @@ public class FormRendererBase {
                 field.setName(entry.getKey());
                 field.setType(entry.getValue());
                 field.setTags(processDesc.getTagsForVariable(entry.getKey()));
+                Set<String> tags = processDesc.getTagsForVariable(entry.getKey());
+                field.setRequired(tags.contains("required"));
+                field.setRequired(tags.contains("readonly"));
                 
                 form.getFields().add(field);
                 

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/FormRendererBase.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/FormRendererBase.java
@@ -263,7 +263,7 @@ public class FormRendererBase {
                 field.setTags(processDesc.getTagsForVariable(entry.getKey()));
                 Set<String> tags = processDesc.getTagsForVariable(entry.getKey());
                 field.setRequired(tags.contains("required"));
-                field.setRequired(tags.contains("readonly"));
+                field.setReadOnly(tags.contains("readonly"));
                 
                 form.getFields().add(field);
                 

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/AbstractFormRenderer.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/AbstractFormRenderer.java
@@ -24,16 +24,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.jbpm.casemgmt.api.model.CaseDefinition;
@@ -449,9 +440,14 @@ public abstract class AbstractFormRenderer implements FormRenderer {
                                     item.setValue((value != null) ? value.toString() : "");
                                     break;
                             }
-
-                            item.setReadOnly(field.isReadOnly());
-                            item.setRequired(field.isRequired());
+                            Set<String> tags = field.getTags();
+                            if(tags != null) {
+                                item.setRequired(tags.contains("required"));
+                                item.setReadOnly(tags.contains("readonly"));
+                            } else {
+                                item.setRequired(field.isRequired());
+                                item.setReadOnly(field.isReadOnly());
+                            }
 
                             // generate column content                    
                             Map<String, Object> parameters = new HashMap<>();

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/AbstractFormRenderer.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/AbstractFormRenderer.java
@@ -24,7 +24,17 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Optional;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.jbpm.casemgmt.api.model.CaseDefinition;
@@ -110,7 +120,7 @@ public abstract class AbstractFormRenderer implements FormRenderer {
     }
     
     public String renderCase(String containerId, CaseDefinition caseDefinition, FormInstance form) {
-        List<String> scriptDataList = new ArrayList<>();        
+        List<String> scriptDataList = new ArrayList<>();
         
         
         StringBuilder jsonTemplate = new StringBuilder();
@@ -441,7 +451,7 @@ public abstract class AbstractFormRenderer implements FormRenderer {
                                     break;
                             }
                             Set<String> tags = field.getTags();
-                            if(tags != null) {
+                            if (tags != null) {
                                 item.setRequired(tags.contains("required"));
                                 item.setReadOnly(tags.contains("readonly"));
                             } else {

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/resources/form-templates-providers/js/kieserver-ui.js
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/resources/form-templates-providers/js/kieserver-ui.js
@@ -32,7 +32,7 @@ function clearNotifications() {
 }
 
 function startProcess(button) {
-	if (validate()) {
+	if (validate('')) {
 		button.disabled = true;
 		
 		console.log('Process started with data ' + JSON.stringify(getData()));
@@ -61,7 +61,7 @@ function startProcess(button) {
 }
 
 function startCase(button) {
-	if (validate()) {
+	if (validate('')) {
 		button.disabled = true;
 			
 		$.ajax({

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/DefinitionServiceBase.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/DefinitionServiceBase.java
@@ -62,6 +62,7 @@ public class DefinitionServiceBase {
                 .serviceTasks(procDef.getServiceTasks())
                 .subprocesses(procDef.getReusableSubProcesses())
                 .variables(procDef.getProcessVariables())
+                .tagsByVariables(procDef.getTagsInfo())
                 .dynamic(procDef.isDynamic())
                 .nodes(procDef.getNodes().stream().map(node -> NodeDefinition.builder().id(node.getId()).name(node.getName()).type(node.getNodeType()).uniqueId(node.getUniqueId()).build()).collect(toSet()))
                 .timers(procDef.getTimers().stream().map(timer -> TimerDefinition.builder().id(timer.getId()).nodeId(timer.getNodeId()).nodeName(timer.getNodeName()).uniqueId(timer.getUniqueId()).build()).collect(toSet()))


### PR DESCRIPTION
 * Added "required" and "readonly" property to FormField by tags
 * Fixed validation for input box in ProcessInstance form

**JIRA**: 
[AF-2811](https://issues.redhat.com/browse/AF-2811)
[RHPAM-3047](https://issues.redhat.com/browse/RHPAM-3047)

**referenced Pull Requests**: 
https://github.com/kiegroup/kie-wb-common/pull/3609
https://github.com/kiegroup/jbpm-wb/pull/1486

Original PR : https://github.com/kiegroup/droolsjbpm-integration/pull/2398

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
