### PR TITLE
JBPM-9701 Migrate FallbackableTypeFactory from LRUMap to LookupCache

### DIFF
--- a/kie-server-parent/kie-server-api/src/build/revapi-config.json
+++ b/kie-server-parent/kie-server-api/src/build/revapi-config.json
@@ -1,23 +1,99 @@
 {
-  "filters": {
-    "revapi": {
-      "java": {
-        "filter": {
-          "_comment": "We don't want to check transitive classes, e.g. from OptaPlanner, since we already check them in their own module.",
-          "packages": {
-            "regex": true,
-            "include": [
-              "org\\.kie\\.server\\.api.*"
-            ]
-          }
-        }
+   "filters":{
+      "revapi":{
+         "java":{
+            "filter":{
+               "_comment":"We don't want to check transitive classes, e.g. from OptaPlanner, since we already check them in their own module.",
+               "packages":{
+                  "regex":true,
+                  "include":[
+                     "org\\.kie\\.server\\.api.*"
+                  ]
+               }
+            }
+         }
       }
-    }
-  },
-  "ignores": {
-    "revapi": {
-      "_comment": "Changes between 7.48.0.Final and the current branch. These changes are desired and thus ignored.",
-      "ignore": []
-    }
-  }
+   },
+   "ignores":{
+      "revapi":{
+         "_comment":"Changes between 7.48.0.Final and the current branch. These changes are desired and thus ignored.",
+         "ignore":[
+            {
+               "code":"java.field.typeChanged",
+               "old":"field com.fasterxml.jackson.databind.type.TypeFactory._typeCache @ org.kie.server.api.marshalling.json.FallbackableTypeFactory",
+               "new":"field com.fasterxml.jackson.databind.type.TypeFactory._typeCache @ org.kie.server.api.marshalling.json.FallbackableTypeFactory",
+               "oldType":"com.fasterxml.jackson.databind.util.LRUMap<java.lang.Object, com.fasterxml.jackson.databind.JavaType>",
+               "newType":"com.fasterxml.jackson.databind.util.LookupCache<java.lang.Object, com.fasterxml.jackson.databind.JavaType>",
+               "package":"org.kie.server.api.marshalling.json",
+               "classSimpleName":"FallbackableTypeFactory",
+               "fieldName":"_typeCache",
+               "elementKind":"field",
+               "justification":"Test"
+            },
+            {
+               "code":"java.method.parameterTypeChanged",
+               "old":"parameter void org.kie.server.api.marshalling.json.FallbackableTypeFactory::<init>(===com.fasterxml.jackson.databind.util.LRUMap<java.lang.Object, com.fasterxml.jackson.databind.JavaType>===)",
+               "new":"parameter void org.kie.server.api.marshalling.json.FallbackableTypeFactory::<init>(===com.fasterxml.jackson.databind.util.LookupCache<java.lang.Object, com.fasterxml.jackson.databind.JavaType>===)",
+               "oldType":"com.fasterxml.jackson.databind.util.LRUMap<java.lang.Object, com.fasterxml.jackson.databind.JavaType>",
+               "newType":"com.fasterxml.jackson.databind.util.LookupCache<java.lang.Object, com.fasterxml.jackson.databind.JavaType>",
+               "package":"org.kie.server.api.marshalling.json",
+               "classSimpleName":"FallbackableTypeFactory",
+               "methodName":"<init>",
+               "parameterIndex":"0",
+               "elementKind":"parameter",
+               "justification":"Test"
+            },
+            {
+               "code":"java.method.parameterTypeChanged",
+               "old":"parameter void org.kie.server.api.marshalling.json.FallbackableTypeFactory::<init>(===com.fasterxml.jackson.databind.util.LRUMap<java.lang.Object, com.fasterxml.jackson.databind.JavaType>===, com.fasterxml.jackson.databind.type.TypeParser, com.fasterxml.jackson.databind.type.TypeModifier[], java.lang.ClassLoader)",
+               "new":"parameter void org.kie.server.api.marshalling.json.FallbackableTypeFactory::<init>(===com.fasterxml.jackson.databind.util.LookupCache<java.lang.Object, com.fasterxml.jackson.databind.JavaType>===, com.fasterxml.jackson.databind.type.TypeParser, com.fasterxml.jackson.databind.type.TypeModifier[], java.lang.ClassLoader)",
+               "oldType":"com.fasterxml.jackson.databind.util.LRUMap<java.lang.Object, com.fasterxml.jackson.databind.JavaType>",
+               "newType":"com.fasterxml.jackson.databind.util.LookupCache<java.lang.Object, com.fasterxml.jackson.databind.JavaType>",
+               "package":"org.kie.server.api.marshalling.json",
+               "classSimpleName":"FallbackableTypeFactory",
+               "methodName":"<init>",
+               "parameterIndex":"0",
+               "elementKind":"parameter",
+               "justification":"Test"
+            },
+            {
+               "code":"java.method.parameterTypeChanged",
+               "old":"parameter void org.kie.server.api.marshalling.json.FallbackableTypeFactory::<init>(===com.fasterxml.jackson.databind.util.LRUMap<java.lang.Object, com.fasterxml.jackson.databind.JavaType>===, com.fasterxml.jackson.databind.type.TypeParser, com.fasterxml.jackson.databind.type.TypeModifier[], java.lang.ClassLoader, java.lang.ClassLoader)",
+               "new":"parameter void org.kie.server.api.marshalling.json.FallbackableTypeFactory::<init>(===com.fasterxml.jackson.databind.util.LookupCache<java.lang.Object, com.fasterxml.jackson.databind.JavaType>===, com.fasterxml.jackson.databind.type.TypeParser, com.fasterxml.jackson.databind.type.TypeModifier[], java.lang.ClassLoader, java.lang.ClassLoader)",
+               "oldType":"com.fasterxml.jackson.databind.util.LRUMap<java.lang.Object, com.fasterxml.jackson.databind.JavaType>",
+               "newType":"com.fasterxml.jackson.databind.util.LookupCache<java.lang.Object, com.fasterxml.jackson.databind.JavaType>",
+               "package":"org.kie.server.api.marshalling.json",
+               "classSimpleName":"FallbackableTypeFactory",
+               "methodName":"<init>",
+               "parameterIndex":"0",
+               "elementKind":"parameter",
+               "justification":"Test"
+            },
+            {
+               "code":"java.method.exception.runtimeAdded",
+               "old":"method com.fasterxml.jackson.databind.JavaType com.fasterxml.jackson.databind.type.TypeFactory::constructSpecializedType(com.fasterxml.jackson.databind.JavaType, java.lang.Class<?>) @ org.kie.server.api.marshalling.json.FallbackableTypeFactory",
+               "new":"method com.fasterxml.jackson.databind.JavaType com.fasterxml.jackson.databind.type.TypeFactory::constructSpecializedType(com.fasterxml.jackson.databind.JavaType, java.lang.Class<?>) throws java.lang.IllegalArgumentException @ org.kie.server.api.marshalling.json.FallbackableTypeFactory",
+               "exception":"java.lang.IllegalArgumentException",
+               "package":"org.kie.server.api.marshalling.json",
+               "classSimpleName":"FallbackableTypeFactory",
+               "methodName":"constructSpecializedType",
+               "elementKind":"method",
+               "justification":"Test"
+            },
+            {
+               "code":"java.method.parameterTypeChanged",
+               "old":"parameter org.kie.server.api.marshalling.json.FallbackableTypeFactory org.kie.server.api.marshalling.json.FallbackableTypeFactory::withCache(===com.fasterxml.jackson.databind.util.LRUMap<java.lang.Object, com.fasterxml.jackson.databind.JavaType>===)",
+               "new":"parameter org.kie.server.api.marshalling.json.FallbackableTypeFactory org.kie.server.api.marshalling.json.FallbackableTypeFactory::withCache(===com.fasterxml.jackson.databind.util.LookupCache<java.lang.Object, com.fasterxml.jackson.databind.JavaType>===)",
+               "oldType":"com.fasterxml.jackson.databind.util.LRUMap<java.lang.Object, com.fasterxml.jackson.databind.JavaType>",
+               "newType":"com.fasterxml.jackson.databind.util.LookupCache<java.lang.Object, com.fasterxml.jackson.databind.JavaType>",
+               "package":"org.kie.server.api.marshalling.json",
+               "classSimpleName":"FallbackableTypeFactory",
+               "methodName":"withCache",
+               "parameterIndex":"0",
+               "elementKind":"parameter",
+               "justification":"Test"
+            }
+         ]
+      }
+   }
 }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/FallbackableTypeFactory.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/FallbackableTypeFactory.java
@@ -22,11 +22,11 @@ import com.fasterxml.jackson.databind.type.TypeModifier;
 import com.fasterxml.jackson.databind.type.TypeParser;
 import com.fasterxml.jackson.databind.util.ArrayBuilders;
 import com.fasterxml.jackson.databind.util.ClassUtil;
-import com.fasterxml.jackson.databind.util.LRUMap;
+import com.fasterxml.jackson.databind.util.LookupCache;
 
 public class FallbackableTypeFactory extends TypeFactory {
 
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
 
     protected final transient ClassLoader fallbackClassLoader;
 
@@ -37,18 +37,18 @@ public class FallbackableTypeFactory extends TypeFactory {
         this.fallbackClassLoader = null;
     }
 
-    protected FallbackableTypeFactory(LRUMap<Object, JavaType> typeCache) {
+    protected FallbackableTypeFactory(LookupCache<Object, JavaType> typeCache) {
         super(typeCache);
         this.fallbackClassLoader = null;
     }
 
-    protected FallbackableTypeFactory(LRUMap<Object, JavaType> typeCache, TypeParser p,
+    protected FallbackableTypeFactory(LookupCache<Object, JavaType> typeCache, TypeParser p,
                                       TypeModifier[] mods, ClassLoader classLoader) {
         super(typeCache, p, mods, classLoader);
         this.fallbackClassLoader = null;
     }
 
-    protected FallbackableTypeFactory(LRUMap<Object, JavaType> typeCache, TypeParser p,
+    protected FallbackableTypeFactory(LookupCache<Object, JavaType> typeCache, TypeParser p,
                                       TypeModifier[] mods, ClassLoader classLoader, ClassLoader fallbackClassLoader) {
         super(typeCache, p, mods, classLoader);
         this.fallbackClassLoader = fallbackClassLoader;
@@ -69,7 +69,7 @@ public class FallbackableTypeFactory extends TypeFactory {
      */
     @Override
     public FallbackableTypeFactory withModifier(TypeModifier mod) {
-        LRUMap<Object, JavaType> typeCache = _typeCache;
+        LookupCache<Object, JavaType> typeCache = _typeCache;
         TypeModifier[] mods;
         if (mod == null) { // mostly for unit tests
             mods = null;
@@ -105,7 +105,7 @@ public class FallbackableTypeFactory extends TypeFactory {
      * @since 2.8
      */
     @Override
-    public FallbackableTypeFactory withCache(LRUMap<Object, JavaType> cache) {
+    public FallbackableTypeFactory withCache(LookupCache<Object, JavaType> cache) {
         return new FallbackableTypeFactory(cache, _parser, _modifiers, _classLoader, fallbackClassLoader);
     }
 


### PR DESCRIPTION
Also add the suggested entries to revapi-config.json

Signed-off-by: Mike Lothian <mike@fireburn.co.uk>

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[JBPM-9701](https://issues.redhat.com/browse/JBPM-9701)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1627
https://github.com/kiegroup/droolsjbpm-integration/pull/2461

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
