### PR TITLE
[JBPM-9729] KIE-Server template is removed after a ping failure

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/events/ContainerSpecUpdated.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/events/ContainerSpecUpdated.java
@@ -39,6 +39,8 @@ public class ContainerSpecUpdated implements KieServerControllerEvent {
         this.serverTemplate = serverTemplate;
         this.containerSpec = containerSpec;
         this.containers = containers;
+        this.serverTemplate = new ServerTemplate(serverTemplate);
+        this.serverTemplate.clearOfflineServerInstances();
     }
 
     public ServerTemplate getServerTemplate() {

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/events/ServerTemplateUpdated.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/events/ServerTemplateUpdated.java
@@ -34,6 +34,8 @@ public class ServerTemplateUpdated implements KieServerControllerEvent {
     public ServerTemplateUpdated(ServerTemplate serverTemplate, boolean resetBeforeUpdate) {
         this.serverTemplate = serverTemplate;
         this.resetBeforeUpdate = resetBeforeUpdate;
+        this.serverTemplate = new ServerTemplate(serverTemplate);
+        this.serverTemplate.clearOfflineServerInstances();
     }
 
     public ServerTemplate getServerTemplate() {

--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/runtime/ServerInstanceKey.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/model/runtime/ServerInstanceKey.java
@@ -17,6 +17,7 @@ package org.kie.server.controller.api.model.runtime;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -33,7 +34,20 @@ public class ServerInstanceKey {
     @XmlElement(name = "server-url")
     private String url;
 
+    @XmlAttribute(name = "online")
+    private boolean online;
+
+    
     public ServerInstanceKey() {
+
+    }
+
+    public ServerInstanceKey(ServerInstanceKey key) {
+        this.serverTemplateId = key.serverTemplateId;
+        this.serverName = key.serverName;
+        this.serverInstanceId = key.serverInstanceId;
+        this.url = key.url;
+        this.online = key.online;
     }
 
     public ServerInstanceKey(String serverTemplateId, String serverName, String serverInstanceId, String url) {
@@ -41,6 +55,7 @@ public class ServerInstanceKey {
         this.serverName = serverName;
         this.serverInstanceId = serverInstanceId;
         this.url = url;
+        this.online = true;
     }
 
     public String getServerTemplateId() {
@@ -75,6 +90,15 @@ public class ServerInstanceKey {
         this.url = url;
     }
 
+    
+    public Boolean isOnline() {
+        return online;
+    }
+
+    public void setOnline(Boolean online) {
+        this.online = online;
+    }
+
     @Override
     public String toString() {
         return "ServerInstanceKey{" +
@@ -82,6 +106,7 @@ public class ServerInstanceKey {
                 ", serverName='" + serverName + '\'' +
                 ", serverTemplateId='" + serverTemplateId + '\'' +
                 ", url='" + url + '\'' +
+                ", online='" + online + '\'' +
                 '}';
     }
 

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerHealthCheckControllerImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/KieServerHealthCheckControllerImpl.java
@@ -73,12 +73,9 @@ public class KieServerHealthCheckControllerImpl extends KieServerControllerImpl 
                 while (!stop.get()) {
                     for (KieServerInfo kieServerInfo : getServerInfoList()) {
                         ServerInstanceKey serverInstanceKey = ModelFactory.newServerInstanceKey(kieServerInfo.getServerId(), kieServerInfo.getLocation());
-                        if (!KieServerInstanceManager.getInstance().isAlive(serverInstanceKey)) {
-                            logger.debug("ping isAlive " + kieServerInfo.getLocation() + ": KO. disconnected.");
-                            disconnect(kieServerInfo);
-                        } else {
-                            logger.debug("ping isAlive " + kieServerInfo.getLocation() + ": OK");
-                        }
+                        boolean isAlive = KieServerInstanceManager.getInstance().isAlive(serverInstanceKey);
+                        markOnlineAs(kieServerInfo, isAlive);
+                        logger.debug("ping isAlive to location {}: {}.", kieServerInfo.getLocation(), isAlive ? "connected" : "disconnected");
                     }
                     Thread.sleep(PING_INTERVAL);
                 }
@@ -118,7 +115,7 @@ public class KieServerHealthCheckControllerImpl extends KieServerControllerImpl 
         List<ServerTemplateKey> templateKeys = getTemplateStorage().loadKeys();
         for (ServerTemplateKey templateKey : templateKeys) {
             ServerTemplate template = getTemplateStorage().load(templateKey.getId());
-            for (ServerInstanceKey serverInstanceKey : template.getServerInstanceKeys()) {
+            for (ServerInstanceKey serverInstanceKey : template.getAllServerInstanceKeys()) {
                 KieServerInfo serverInfo = new KieServerInfo(template.getId(), template.getName());
                 serverInfo.setLocation(serverInstanceKey.getUrl());
                 serversInfo.add(serverInfo);

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/SpecManagementServiceImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/service/SpecManagementServiceImpl.java
@@ -158,10 +158,11 @@ public class SpecManagementServiceImpl implements SpecManagementService {
 
     @Override
     public ServerTemplate getServerTemplate(String serverTemplateId) {
-        final ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
+        ServerTemplate serverTemplate = templateStorage.load(serverTemplateId);
         if (serverTemplate == null) {
             throw new KieServerControllerIllegalArgumentException("No server template found for id " + serverTemplateId);
         }
+        serverTemplate = new ServerTemplate(serverTemplate);
         return serverTemplate;
     }
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/JBPM-9729
adding kie server instance online flag and modifying alive ping so the server can have that possibility of comming back alive if there is a network glitch during ping is alive.