### PR TITLE
[DROOLS-6369] Fix kie-karaf-itests failures because of guava upgrade

### DIFF
--- a/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features.xml
+++ b/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features.xml
@@ -74,6 +74,7 @@
     <feature version="${project.version}">drools-jpa</feature>
     <feature version="${project.version}">jbpm-commons</feature>
     <bundle>mvn:com.google.guava/guava/${version.com.google.guava}</bundle>
+    <bundle>mvn:com.google.guava/failureaccess/${version.com.google.guava.failureaccess}</bundle>
     <bundle>mvn:com.fasterxml.jackson.core/jackson-annotations/${version.com.fasterxml.jackson}</bundle>
     <bundle>mvn:javax.mail/mail/${version.javax.mail}</bundle>
     <bundle>mvn:org.jbpm/jbpm-flow/${version.org.jbpm}</bundle>
@@ -113,6 +114,7 @@
     <bundle>mvn:org.apache.commons/commons-math3/${version.org.apache.commons.math3}</bundle>
     <bundle>mvn:commons-io/commons-io/${version.commons-io}</bundle>
     <bundle>mvn:com.google.guava/guava/${version.com.google.guava}</bundle>
+    <bundle>mvn:com.google.guava/failureaccess/${version.com.google.guava.failureaccess}</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.reflections/${karaf.version.org.apache.servicemix.bundles.reflections}</bundle>
   </feature>
 


### PR DESCRIPTION
**JIRA**: 

https://issues.redhat.com/browse/DROOLS-6369

**referenced Pull Requests**: 

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1652

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
