### PR TITLE
AF-2860: Process form renderer for Date objects doesn't submit the correct data

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/AbstractFormRenderer.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/AbstractFormRenderer.java
@@ -96,7 +96,7 @@ public abstract class AbstractFormRenderer implements FormRenderer {
         this.inputTypes.put("ListBox", "select");
         this.inputTypes.put("RadioGroup", "radio");
         this.inputTypes.put("Document", "file");
-        this.inputTypes.put("DatePicker", "date");
+        this.inputTypes.put("DatePicker", "Date");
         this.inputTypes.put("Slider", "slider");
         this.inputTypes.put("DocumentCollection", "documentCollection");
         this.inputTypes.put("MultipleSelector", "multipleSelector");


### PR DESCRIPTION
 * Fixed input type for Date picker 

**JIRA**: 
[AF-2860](https://issues.redhat.com/browse/AF-2860)
[RHPAM-3454](https://issues.redhat.com/browse/RHPAM-3454)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
