### PR TITLE
[DROOLS-6292] perform in memory compilation of generated classes in k…

### DIFF
--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/pom.xml
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/pom.xml
@@ -30,6 +30,10 @@
 
   <packaging>kjar</packaging>
 
+  <properties>
+    <generateDMNModel>YES</generateDMNModel>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.kie</groupId>

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/src/test/java-filtered/org/kie/maven/plugin/ittests/KJarWithDMNIntegrationTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/src/test/java-filtered/org/kie/maven/plugin/ittests/KJarWithDMNIntegrationTestIT.java
@@ -52,6 +52,10 @@ public class KJarWithDMNIntegrationTestIT {
     public void testComplexDMNModel() throws Exception {
         final URL targetLocation = KJarWithDMNIntegrationTestIT.class.getProtectionDomain().getCodeSource().getLocation();
         final KieSession kieSession = ITTestsUtils.getKieSession(targetLocation, GAV_ARTIFACT_ID, GAV_VERSION, KBASE_NAME);
+
+        // verify DMN file is present
+        assertThat(getClass().getClassLoader().getResourceAsStream("META-INF/kie/dmn")).isNotNull();
+
         try {
             final DMNRuntime dmnRuntime = kieSession.getKieRuntime(DMNRuntime.class);
             final DMNModel dmnModel = dmnRuntime.getModel("http://www.trisotech.com/definitions/_3068644b-d2c7-4b81-ab9d-64f011f81f47",

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/src/test/java-filtered/org/kie/maven/plugin/ittests/KJarWithDMNIntegrationTestIT.java
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/src/test/java-filtered/org/kie/maven/plugin/ittests/KJarWithDMNIntegrationTestIT.java
@@ -36,9 +36,9 @@ import org.kie.dmn.api.core.DMNModel;
 import org.kie.dmn.api.core.DMNResult;
 import org.kie.dmn.api.core.DMNRuntime;
 import org.kie.dmn.core.api.DMNFactory;
+import org.kie.dmn.core.compiler.execmodelbased.DMNRuleClassFile;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
 
 public class KJarWithDMNIntegrationTestIT {
 
@@ -54,7 +54,7 @@ public class KJarWithDMNIntegrationTestIT {
         final KieSession kieSession = ITTestsUtils.getKieSession(targetLocation, GAV_ARTIFACT_ID, GAV_VERSION, KBASE_NAME);
 
         // verify DMN file is present
-        assertThat(getClass().getClassLoader().getResourceAsStream("META-INF/kie/dmn")).isNotNull();
+        assertThat(getClass().getClassLoader().getResourceAsStream(DMNRuleClassFile.RULE_CLASS_FILE_NAME)).isNotNull();
 
         try {
             final DMNRuntime dmnRuntime = kieSession.getKieRuntime(DMNRuntime.class);

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/AbstractKieMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/AbstractKieMojo.java
@@ -26,8 +26,8 @@ import java.util.stream.Collectors;
 
 public abstract class AbstractKieMojo extends AbstractMojo {
 
-    @Parameter(property = "dumpGeneratedSources", defaultValue = "false")
-    protected boolean dumpGeneratedSources;
+    @Parameter(property = "dumpKieSourcesFolder", defaultValue = "")
+    protected String dumpKieSourcesFolder;
 
     @Parameter(property = "javaCompiler", defaultValue = "ecj")
     private String javaCompiler;

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/AbstractKieMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/AbstractKieMojo.java
@@ -18,6 +18,7 @@ package org.kie.maven.plugin;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
+import org.kie.memorycompiler.JavaConfiguration;
 
 import java.util.List;
 import java.util.Map;
@@ -25,11 +26,14 @@ import java.util.stream.Collectors;
 
 public abstract class AbstractKieMojo extends AbstractMojo {
 
-    @Parameter(property = "dumpGeneratedSources", defaultValue = "false") // DROOLS-5663 align kie-maven-plugin default value for generateModel configuration flag
-    private boolean dumpGeneratedSources;
+    @Parameter(property = "dumpGeneratedSources", defaultValue = "false")
+    protected boolean dumpGeneratedSources;
 
-    protected boolean isDumpGeneratedSources() {
-        return dumpGeneratedSources;
+    @Parameter(property = "javaCompiler", defaultValue = "ecj")
+    private String javaCompiler;
+
+    protected JavaConfiguration.CompilerType getCompilerType() {
+        return javaCompiler.equalsIgnoreCase("native") ? JavaConfiguration.CompilerType.NATIVE : JavaConfiguration.CompilerType.ECLIPSE;
     }
 
     protected void setSystemProperties(Map<String, String> properties) {

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/AbstractKieMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/AbstractKieMojo.java
@@ -16,6 +16,7 @@
 package org.kie.maven.plugin;
 
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 
 import java.util.List;
@@ -23,6 +24,13 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public abstract class AbstractKieMojo extends AbstractMojo {
+
+    @Parameter(property = "dumpGeneratedSources", defaultValue = "false") // DROOLS-5663 align kie-maven-plugin default value for generateModel configuration flag
+    private boolean dumpGeneratedSources;
+
+    protected boolean isDumpGeneratedSources() {
+        return dumpGeneratedSources;
+    }
 
     protected void setSystemProperties(Map<String, String> properties) {
 

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateANCMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateANCMojo.java
@@ -128,11 +128,11 @@ public class GenerateANCMojo extends AbstractDMNValidationAwareMojo {
                 for (CompiledNetworkSource generatedFile : ancSourceFiles) {
                     String className = toClassName(generatedFile.getSourceName());
                     classNameSourceMap.put(className, generatedFile.getSource());
-                    getLog().info("Written Compiled Alpha Network: " + className);
+                    getLog().info("Generated Alpha Network class: " + className);
                 }
             }
 
-            compileAndWriteClasses(targetDirectory, projectClassLoader, javaCompilerSettings, classNameSourceMap, isDumpGeneratedSources());
+            compileAndWriteClasses(targetDirectory, projectClassLoader, javaCompilerSettings, getCompilerType(), classNameSourceMap, dumpGeneratedSources);
 
             // generate the ANC file
             String ancFile = CanonicalKieModule.getANCFile(new ReleaseIdImpl(

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateANCMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateANCMojo.java
@@ -132,7 +132,7 @@ public class GenerateANCMojo extends AbstractDMNValidationAwareMojo {
                 }
             }
 
-            compileAndWriteClasses(targetDirectory, projectClassLoader, javaCompilerSettings, getCompilerType(), classNameSourceMap, dumpGeneratedSources);
+            compileAndWriteClasses(targetDirectory, projectClassLoader, javaCompilerSettings, getCompilerType(), classNameSourceMap, dumpKieSourcesFolder);
 
             // generate the ANC file
             String ancFile = CanonicalKieModule.getANCFile(new ReleaseIdImpl(

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateCodeUtil.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateCodeUtil.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kie.maven.plugin;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
+import org.apache.maven.artifact.resolver.filter.CumulativeScopeArtifactFilter;
+import org.apache.maven.project.MavenProject;
+import org.kie.memorycompiler.JavaCompilerSettings;
+import org.kie.memorycompiler.JavaConfiguration;
+import org.kie.memorycompiler.KieMemoryCompiler;
+
+public class GenerateCodeUtil {
+
+    public static URLClassLoader getProjectClassLoader(MavenProject project, File outputDirectory, JavaCompilerSettings javaCompilerSettings) {
+        try {
+            Set<URL> urls = new HashSet<>();
+            for (String element : project.getCompileClasspathElements()) {
+                File file = new File(element);
+                javaCompilerSettings.addClasspath(file);
+                urls.add(file.toURI().toURL());
+            }
+
+            project.setArtifactFilter(new CumulativeScopeArtifactFilter(Arrays.asList("compile", "runtime")));
+            for (Artifact artifact : project.getArtifacts()) {
+                File file = artifact.getFile();
+                if (file != null) {
+                    javaCompilerSettings.addClasspath(file);
+                    urls.add(file.toURI().toURL());
+                }
+            }
+            urls.add(outputDirectory.toURI().toURL());
+
+            return URLClassLoader.newInstance(urls.toArray(new URL[0]), GenerateCodeUtil.class.getClassLoader());
+
+        } catch (DependencyResolutionRequiredException | MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void compileAndWriteClasses(File targetDirectory, ClassLoader projectClassLoader, JavaCompilerSettings javaCompilerSettings, Map<String, String> classNameSourceMap, boolean dumpGeneratedSources) {
+        if (dumpGeneratedSources) {
+            dumpGeneratedSources(targetDirectory, classNameSourceMap);
+        }
+
+        Map<String, byte[]> compiledClassesMap = KieMemoryCompiler.compileNoLoad(classNameSourceMap, projectClassLoader, javaCompilerSettings, JavaConfiguration.CompilerType.ECLIPSE);
+
+        for (Map.Entry<String, byte[]> entry : compiledClassesMap.entrySet()) {
+            Path packagesDestinationPath = Paths.get(targetDirectory.getPath(), "classes", entry.getKey().replace('.', '/') + ".class");
+            writeFile(packagesDestinationPath, entry.getValue());
+        }
+    }
+
+    private static void dumpGeneratedSources(File targetDirectory, Map<String, String> classNameSourceMap) {
+        for (Map.Entry<String, String> entry : classNameSourceMap.entrySet()) {
+            Path sourceDestinationPath = Paths.get(targetDirectory.getPath(), "generated-sources", entry.getKey().replace('.', '/') + ".java");
+            writeFile(sourceDestinationPath, entry.getValue().getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    private static void writeFile(Path packagesDestinationPath, byte[] value) {
+        try {
+            if (!Files.exists(packagesDestinationPath)) {
+                Files.createDirectories(packagesDestinationPath.getParent());
+            }
+            Files.write(packagesDestinationPath, value);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static JavaCompilerSettings createJavaCompilerSettings() {
+        JavaCompilerSettings javaCompilerSettings = new JavaCompilerSettings();
+        String javaVersion = findJavaVersion();
+        javaCompilerSettings.setSourceVersion(javaVersion);
+        javaCompilerSettings.setTargetVersion(javaVersion);
+        return javaCompilerSettings;
+    }
+
+    public static String findJavaVersion() {
+        String javaVersion = System.getProperty("java.version");
+        if (javaVersion.startsWith("1.8")) {
+            return "1.8";
+        }
+        int dot = javaVersion.indexOf('.');
+        return dot > 0 ? javaVersion.substring(0, dot) : javaVersion;
+    }
+
+    public static String toClassName(String source) {
+        if (source.startsWith("./")) {
+            source = source.substring(2);
+        }
+        if (source.endsWith(".java")) {
+            source = source.substring(0, source.length()-5);
+        }
+        return source.replace('/', '.');
+    }
+}

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateCodeUtil.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateCodeUtil.java
@@ -69,9 +69,9 @@ public class GenerateCodeUtil {
     }
 
     public static void compileAndWriteClasses(File targetDirectory, ClassLoader projectClassLoader, JavaCompilerSettings javaCompilerSettings,
-                                              JavaConfiguration.CompilerType compilerType, Map<String, String> classNameSourceMap, boolean dumpGeneratedSources) {
-        if (dumpGeneratedSources) {
-            dumpGeneratedSources(targetDirectory, classNameSourceMap);
+                                              JavaConfiguration.CompilerType compilerType, Map<String, String> classNameSourceMap, String dumpKieSourcesFolder) {
+        if (dumpKieSourcesFolder != null && !dumpKieSourcesFolder.isEmpty()) {
+            dumpGeneratedSources(targetDirectory, classNameSourceMap, dumpKieSourcesFolder);
         }
 
         Map<String, byte[]> compiledClassesMap = KieMemoryCompiler.compileNoLoad(classNameSourceMap, projectClassLoader, javaCompilerSettings, compilerType);
@@ -82,9 +82,9 @@ public class GenerateCodeUtil {
         }
     }
 
-    private static void dumpGeneratedSources(File targetDirectory, Map<String, String> classNameSourceMap) {
+    private static void dumpGeneratedSources(File targetDirectory, Map<String, String> classNameSourceMap, String dumpKieSourcesFolder) {
         for (Map.Entry<String, String> entry : classNameSourceMap.entrySet()) {
-            Path sourceDestinationPath = Paths.get(targetDirectory.getPath(), "generated-sources", entry.getKey().replace('.', '/') + ".java");
+            Path sourceDestinationPath = Paths.get(targetDirectory.getPath(), dumpKieSourcesFolder, entry.getKey().replace('.', '/') + ".java");
             writeFile(sourceDestinationPath, entry.getValue().getBytes(StandardCharsets.UTF_8));
         }
     }

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateCodeUtil.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateCodeUtil.java
@@ -109,12 +109,12 @@ public class GenerateCodeUtil {
     }
 
     public static String toClassName(String source) {
-        if (source.startsWith("./")) {
+        if (source.startsWith("./") || source.startsWith(".\\")) {
             source = source.substring(2);
         }
         if (source.endsWith(".java")) {
             source = source.substring(0, source.length()-5);
         }
-        return source.replace('/', '.');
+        return source.replace('/', '.').replace('\\', '.');
     }
 }

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateDMNModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateDMNModelMojo.java
@@ -122,7 +122,7 @@ public class GenerateDMNModelMojo extends AbstractKieMojo {
             }
 
             compileAndWriteClasses(targetDirectory, ((InternalKieModule) kieBuilder.getKieModule()).getModuleClassLoader(),
-                    javaCompilerSettings, getCompilerType(), classNameSourceMap, dumpGeneratedSources);
+                    javaCompilerSettings, getCompilerType(), classNameSourceMap, dumpKieSourcesFolder);
 
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateDMNModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateDMNModelMojo.java
@@ -121,7 +121,8 @@ public class GenerateDMNModelMojo extends AbstractKieMojo {
                 compileDMNFile(kieModule, assemblerService, knowledgeBuilder, dmnFile);
             }
 
-            compileAndWriteClasses(targetDirectory, ((InternalKieModule) kieBuilder.getKieModule()).getModuleClassLoader(), javaCompilerSettings, classNameSourceMap, isDumpGeneratedSources());
+            compileAndWriteClasses(targetDirectory, ((InternalKieModule) kieBuilder.getKieModule()).getModuleClassLoader(),
+                    javaCompilerSettings, getCompilerType(), classNameSourceMap, dumpGeneratedSources);
 
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateDMNModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateDMNModelMojo.java
@@ -124,7 +124,7 @@ public class GenerateDMNModelMojo extends AbstractKieMojo {
 
             createDMNFile(classNameSourceMap.keySet());
 
-            compileAndWriteClasses(targetDirectory, ((InternalKieModule) kieBuilder.getKieModule()).getModuleClassLoader(),
+            compileAndWriteClasses(targetDirectory, contextClassLoader,
                     javaCompilerSettings, getCompilerType(), classNameSourceMap, dumpKieSourcesFolder);
 
         } catch (Exception e) {
@@ -162,7 +162,7 @@ public class GenerateDMNModelMojo extends AbstractKieMojo {
                 }, b -> {
                 });
 
-        assemblerService.addResources(knowledgeBuilder, Collections.singletonList(resourceWithConfiguration), ResourceType.DMN);
+        assemblerService.addResourcesAfterRules(knowledgeBuilder, Collections.singletonList(resourceWithConfiguration), ResourceType.DMN);
     }
 
     private String getCompiledClassName(Path fileNameRelative) {

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateDMNModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateDMNModelMojo.java
@@ -20,13 +20,11 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateDMNModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateDMNModelMojo.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -121,6 +122,8 @@ public class GenerateDMNModelMojo extends AbstractKieMojo {
                 compileDMNFile(kieModule, assemblerService, knowledgeBuilder, dmnFile);
             }
 
+            createDMNFile(classNameSourceMap.keySet());
+
             compileAndWriteClasses(targetDirectory, ((InternalKieModule) kieBuilder.getKieModule()).getModuleClassLoader(),
                     javaCompilerSettings, getCompilerType(), classNameSourceMap, dumpKieSourcesFolder);
 
@@ -131,6 +134,19 @@ public class GenerateDMNModelMojo extends AbstractKieMojo {
         }
 
         getLog().info("DMN Model successfully generated");
+    }
+
+    private void createDMNFile(Collection<String> compiledClassNames) {
+        final Path dmnCompiledClassFile = Paths.get(targetDirectory.getPath(), "classes", DMNRuleClassFile.RULE_CLASS_FILE_NAME);
+
+        try {
+            if (!Files.exists(dmnCompiledClassFile)) {
+                Files.createDirectories(dmnCompiledClassFile.getParent());
+            }
+            Files.write(dmnCompiledClassFile, compiledClassNames);
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to write file", e);
+        }
     }
 
     private List<String> getDMNFIles(InternalKieModule kieModule) {

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
@@ -154,7 +154,7 @@ public class GenerateModelMojo extends AbstractDMNValidationAwareMojo {
                 getLog().info("Generating " + className);
             }
 
-            compileAndWriteClasses(targetDirectory, projectClassLoader, javaCompilerSettings, getCompilerType(), classNameSourceMap, dumpGeneratedSources);
+            compileAndWriteClasses(targetDirectory, projectClassLoader, javaCompilerSettings, getCompilerType(), classNameSourceMap, dumpKieSourcesFolder);
 
             // copy the META-INF packages file
             final String path = CanonicalKieModule.getModelFileWithGAV(kieModule.getReleaseId());

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
@@ -154,7 +154,7 @@ public class GenerateModelMojo extends AbstractDMNValidationAwareMojo {
                 getLog().info("Generating " + className);
             }
 
-            compileAndWriteClasses(targetDirectory, projectClassLoader, javaCompilerSettings, classNameSourceMap, isDumpGeneratedSources());
+            compileAndWriteClasses(targetDirectory, projectClassLoader, javaCompilerSettings, getCompilerType(), classNameSourceMap, dumpGeneratedSources);
 
             // copy the META-INF packages file
             final String path = CanonicalKieModule.getModelFileWithGAV(kieModule.getReleaseId());

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateModelMojo.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
@@ -63,8 +64,15 @@ import org.drools.modelcompiler.builder.ModelSourceClass;
 import org.drools.modelcompiler.builder.ModelWriter;
 import org.kie.api.KieServices;
 import org.kie.api.builder.KieBuilder;
+import org.kie.memorycompiler.JavaCompilerSettings;
+import org.kie.memorycompiler.JavaConfiguration;
+import org.kie.memorycompiler.KieMemoryCompiler;
 
 import static org.kie.maven.plugin.ExecModelMode.isModelCompilerInClassPath;
+import static org.kie.maven.plugin.GenerateCodeUtil.compileAndWriteClasses;
+import static org.kie.maven.plugin.GenerateCodeUtil.createJavaCompilerSettings;
+import static org.kie.maven.plugin.GenerateCodeUtil.getProjectClassLoader;
+import static org.kie.maven.plugin.GenerateCodeUtil.toClassName;
 
 @Mojo(name = "generateModel",
         requiresDependencyResolution = ResolutionScope.NONE,
@@ -110,30 +118,11 @@ public class GenerateModelMojo extends AbstractDMNValidationAwareMojo {
     }
 
     private void generateModel() throws MojoExecutionException, MojoFailureException {
+        JavaCompilerSettings javaCompilerSettings = createJavaCompilerSettings();
+        URLClassLoader projectClassLoader = getProjectClassLoader(project, outputDirectory, javaCompilerSettings);
+
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-        try {
-            Set<URL> urls = new HashSet<>();
-            for (String element : project.getCompileClasspathElements()) {
-                urls.add(new File(element).toURI().toURL());
-            }
-
-            project.setArtifactFilter(new CumulativeScopeArtifactFilter(Arrays.asList("compile",
-                                                                                      "runtime")));
-            for (Artifact artifact : project.getArtifacts()) {
-                File file = artifact.getFile();
-                if (file != null) {
-                    urls.add(file.toURI().toURL());
-                }
-            }
-            urls.add(outputDirectory.toURI().toURL());
-
-            ClassLoader projectClassLoader = URLClassLoader.newInstance(urls.toArray(new URL[0]),
-                                                                        getClass().getClassLoader());
-
-            Thread.currentThread().setContextClassLoader(projectClassLoader);
-        } catch (DependencyResolutionRequiredException | MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
+        Thread.currentThread().setContextClassLoader(projectClassLoader);
 
         try {
             setSystemProperties(properties);
@@ -150,39 +139,22 @@ public class GenerateModelMojo extends AbstractDMNValidationAwareMojo {
                     .filter(f -> f.endsWith("java"))
                     .collect(Collectors.toList());
 
-
-            Set<String> drlFiles = kieModule.getFileNames()
-                    .stream()
-                    .filter(f -> f.endsWith("drl"))
-                    .collect(Collectors.toSet());
-
             getLog().info(String.format("Found %d generated files in Canonical Model", generatedFiles.size()));
 
             MemoryFileSystem mfs = kieModule instanceof CanonicalKieModule ?
                     ((MemoryKieModule) ((CanonicalKieModule) kieModule).getInternalKieModule()).getMemoryFileSystem() :
                     ((MemoryKieModule) kieModule).getMemoryFileSystem();
 
-            final String droolsModelCompilerPath = "/generated-sources/drools-model-compiler/main/java";
-            final String newCompileSourceRoot = targetDirectory.getPath() + droolsModelCompilerPath;
-            project.addCompileSourceRoot(newCompileSourceRoot);
+            Map<String, String> classNameSourceMap = new HashMap<>();
 
             for (String generatedFile : generatedFiles) {
-                final MemoryFile f = (MemoryFile) mfs.getFile(generatedFile);
-                final Path newFile = Paths.get(targetDirectory.getPath(),
-                                               droolsModelCompilerPath,
-                                               f.getPath().toPortableString());
-
-                try {
-                    Files.deleteIfExists(newFile);
-                    Files.createDirectories(newFile.getParent());
-                    Files.copy(f.getContents(), newFile, StandardCopyOption.REPLACE_EXISTING);
-
-                    getLog().info("Generating " + newFile);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                    throw new MojoExecutionException("Unable to write file", e);
-                }
+                MemoryFile f = (MemoryFile) mfs.getFile(generatedFile);
+                String className = toClassName(generatedFile);
+                classNameSourceMap.put(className, new String(mfs.getFileContents( f )));
+                getLog().info("Generating " + className);
             }
+
+            compileAndWriteClasses(targetDirectory, projectClassLoader, javaCompilerSettings, classNameSourceMap, isDumpGeneratedSources());
 
             // copy the META-INF packages file
             final String path = CanonicalKieModule.getModelFileWithGAV(kieModule.getReleaseId());
@@ -205,10 +177,21 @@ public class GenerateModelMojo extends AbstractDMNValidationAwareMojo {
             }
 
             if (ExecModelMode.shouldDeleteFile(getGenerateModelOption())) {
+                Set<String> drlFiles = kieModule.getFileNames()
+                        .stream()
+                        .filter(f -> f.endsWith("drl"))
+                        .collect(Collectors.toSet());
                 deleteDrlFiles(drlFiles);
             }
         } finally {
             Thread.currentThread().setContextClassLoader(contextClassLoader);
+            if (projectClassLoader != null) {
+                try {
+                    projectClassLoader.close();
+                } catch (IOException e) {
+                    getLog().warn(e);
+                }
+            }
         }
 
         getLog().info("DSL successfully generated");

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GeneratePMMLModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GeneratePMMLModelMojo.java
@@ -127,7 +127,7 @@ public class GeneratePMMLModelMojo extends AbstractKieMojo {
         Thread.currentThread().setContextClassLoader(projectClassLoader);
 
         try {
-            compileAndWriteClasses(targetDirectory, projectClassLoader, javaCompilerSettings, getCompilerType(), generateFiles(), dumpGeneratedSources);
+            compileAndWriteClasses(targetDirectory, projectClassLoader, javaCompilerSettings, getCompilerType(), generateFiles(), dumpKieSourcesFolder);
         } finally {
             Thread.currentThread().setContextClassLoader(contextClassLoader);
             if (projectClassLoader != null) {

--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GeneratePMMLModelMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GeneratePMMLModelMojo.java
@@ -127,7 +127,7 @@ public class GeneratePMMLModelMojo extends AbstractKieMojo {
         Thread.currentThread().setContextClassLoader(projectClassLoader);
 
         try {
-            compileAndWriteClasses(targetDirectory, projectClassLoader, javaCompilerSettings, generateFiles(), isDumpGeneratedSources());
+            compileAndWriteClasses(targetDirectory, projectClassLoader, javaCompilerSettings, getCompilerType(), generateFiles(), dumpGeneratedSources);
         } finally {
             Thread.currentThread().setContextClassLoader(contextClassLoader);
             if (projectClassLoader != null) {

--- a/kie-maven-plugin/src/main/resources/META-INF/plexus/components.xml
+++ b/kie-maven-plugin/src/main/resources/META-INF/plexus/components.xml
@@ -14,10 +14,8 @@
                         org.kie:kie-maven-plugin:generateModel,
                         org.kie:kie-maven-plugin:generateDMNModel,
                         org.kie:kie-maven-plugin:generatePMMLModel,
-                        org.apache.maven.plugins:maven-compiler-plugin:compile,
-                        org.kie:kie-maven-plugin:build,
                         org.kie:kie-maven-plugin:generateANC,
-                        org.apache.maven.plugins:maven-compiler-plugin:compile
+                        org.kie:kie-maven-plugin:build
                     </compile>
                     <!-- proces-classes does not have a default plug-in binding for JAR/KJAR, accordingly to https://maven.apache.org/ref/3-LATEST/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging
                          so can directly declare the inject reactive bytecode goal -->


### PR DESCRIPTION
…ie-maven-plugin

**JIRA**: https://issues.redhat.com/browse/DROOLS-6292

This is a first iteration to perform in memory compilation of generated sources. In a subsequent step I will consolidate all the mojos generating sources into a single one.

@gitgabrio as anticipated I gave a try creating the kjar for `trusty-drools-kjar` and it took 1:39 mins on my machine instead of the original 10+. It seems to me that everything has been generated correctly in that kjar, but please give a second look.

I also added a maven parameter `dumpGeneratedSources` (disabled by default) to optionally dump the generated sources which could be useful for debugging.