### PR TITLE
[7.52.x] [DROOLS-6396] Fix FallbackableTypeFactory for 7.52.x

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/FallbackableTypeFactory.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/FallbackableTypeFactory.java
@@ -54,6 +54,11 @@ public class FallbackableTypeFactory extends TypeFactory {
         this.fallbackClassLoader = fallbackClassLoader;
     }
 
+    public FallbackableTypeFactory(ClassLoader classLoader) {
+        super(null);
+        this.fallbackClassLoader = classLoader;
+    }
+
     /**
      * "Mutant factory" method which will construct a new instance with specified fallback
      * {@link ClassLoader} to use by {@link #findClass} only when main classloader or thread context classloader can not resolve.

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
@@ -102,6 +102,8 @@ public class JSONMarshaller implements Marshaller {
     private boolean formatDate;
     private String dateFormatStr = System.getProperty("org.kie.server.json.date_format", "yyyy-MM-dd'T'hh:mm:ss.SSSZ");
 
+    private boolean fallbackClassLoaderEnabled = Boolean.parseBoolean(System.getProperty("org.kie.server.json.fallbackClassLoader.enabled", "false"));
+
     public static class JSONContext {
 
         private boolean stripped;
@@ -291,8 +293,11 @@ public class JSONMarshaller implements Marshaller {
 
             deserializeObjectMapper.registerModule(modDeser);
             deserializeObjectMapper.setConfig(deserializeObjectMapper.getDeserializationConfig().with(introspectorPair));
-            // Don't use withClassLoader() because we rely on thread context classloader. We use classLoader only for fallback
-            deserializeObjectMapper.setTypeFactory(FallbackableTypeFactory.defaultInstance().withFallbackClassLoader(classLoader));
+
+            if (fallbackClassLoaderEnabled) {
+                // Don't use withClassLoader() because we rely on thread context classloader. We use classLoader only for fallback
+                deserializeObjectMapper.setTypeFactory(new FallbackableTypeFactory(classLoader));
+            }
         }
 
         if (formatDate) {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/pom.xml
@@ -116,6 +116,7 @@
               <kie.server.testing.kjars.build.settings.xml>${kie.server.testing.kjars.build.settings.xml}</kie.server.testing.kjars.build.settings.xml>
               <org.kie.prometheus.server.ext.disabled>${org.kie.prometheus.server.ext.disabled}</org.kie.prometheus.server.ext.disabled>
               <org.kie.scenariosimulation.server.ext.disabled>${org.kie.scenariosimulation.server.ext.disabled}</org.kie.scenariosimulation.server.ext.disabled>
+              <org.kie.server.json.fallbackClassLoader.enabled>true</org.kie.server.json.fallbackClassLoader.enabled>
             </systemPropertyVariables>
           </configuration>
         </plugin>
@@ -159,6 +160,7 @@
               <org.kie.prometheus.server.ext.disabled>${org.kie.prometheus.server.ext.disabled}</org.kie.prometheus.server.ext.disabled>
               <org.kie.scenariosimulation.server.ext.disabled>${org.kie.scenariosimulation.server.ext.disabled}</org.kie.scenariosimulation.server.ext.disabled>
               <kie-pmml-implementation>legacy</kie-pmml-implementation>
+              <org.kie.server.json.fallbackClassLoader.enabled>true</org.kie.server.json.fallbackClassLoader.enabled>
             </systemProperties>
           </container>
         </configuration>


### PR DESCRIPTION
- Compiled with jackson 2.10 and linkable with jackson 2.12 for Fuse 7.9 integration

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6396

This is a special fix for 7.52.x for RHDM/RHPAM 7.11.1 integration with Fuse 7.9 which depends on jackson 2.12.


<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
