### PR TITLE
[DROOLS-6424] Ignore failing test org.kie.hacep.LocalStorageStreaming…

### DIFF
--- a/drools-ha/ha-core-infra/src/test/java/org/kie/hacep/LocalStorageStreamingKieSessionTest.java
+++ b/drools-ha/ha-core-infra/src/test/java/org/kie/hacep/LocalStorageStreamingKieSessionTest.java
@@ -111,6 +111,7 @@ public class LocalStorageStreamingKieSessionTest {
                 .stream().filter(stock -> !stock.isProcessed()).count());
     }
 
+    @Ignore("https://issues.redhat.com/browse/DROOLS-6424")
     @Test(timeout = 10000)
     public void getCommandsTest() throws ExecutionException, InterruptedException {
 


### PR DESCRIPTION
…KieSessionTest.getCommandsTest

Ignore it as a quick rescue for CI stability. We can revisit to fix it (maybe with DROOLS-5430) later on.

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6424

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
