### PR TITLE
[7.52.x] [DROOLS-6395] PrometheusMetricsDroolsListener is repeatedly added to …

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-drools/src/main/java/org/kie/server/services/drools/DroolsKieSessionLookupHandler.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-drools/src/main/java/org/kie/server/services/drools/DroolsKieSessionLookupHandler.java
@@ -63,9 +63,11 @@ public class DroolsKieSessionLookupHandler implements KieSessionLookupHandler {
             }
 
             //default handler
-            PrometheusMetricsDroolsListener listener = new PrometheusMetricsDroolsListener(PrometheusKieServerExtension.getMetrics(),
-                    kieSessionId, containerInstance);
-            eventManager.addEventListener(listener);
+            if (eventManager.getAgendaEventListeners().stream().noneMatch(PrometheusMetricsDroolsListener.class::isInstance)) {
+                PrometheusMetricsDroolsListener listener = new PrometheusMetricsDroolsListener(PrometheusKieServerExtension.getMetrics(),
+                                                                                               kieSessionId, containerInstance);
+                eventManager.addEventListener(listener);
+            }
 
             //custom handlers
             List<AgendaEventListener> droolsListeners = extension.getDroolsListeners(kieSessionId, containerInstance);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/DroolsMetricIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/DroolsMetricIntegrationTest.java
@@ -17,8 +17,10 @@
 package org.kie.server.integrationtests.drools;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.client.Client;
@@ -40,19 +42,28 @@ import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 import org.kie.server.integrationtests.shared.KieServerReflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.core.IsNot.not;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class DroolsMetricIntegrationTest extends DroolsKieServerBaseIntegrationTest {
+
+    private static Logger logger = LoggerFactory.getLogger(DroolsMetricIntegrationTest.class);
 
     private static ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "stateless-session-kjar",
             "1.0.0");
 
-    private static final String CONTAINER_ID = "stateless-kjar1";
+    private static final String CONTAINER_ID = "stateless-kjar1-metric";
+    private static final String CONTAINER_ID_WITHOUT_LOOKUP = "stateless-kjar1-metric-without-lookup";
+
     private static final String KIE_SESSION = "kbase1.stateless";
+    private static final String KIE_SESSION_WITHOUT_LOOKUP = "default";
+
     private static final String PERSON_OUT_IDENTIFIER = "person1";
     private static final String PERSON_CLASS_NAME = "org.kie.server.testing.Person";
     private static final String PERSON_NAME = "Darth";
@@ -69,6 +80,7 @@ public class DroolsMetricIntegrationTest extends DroolsKieServerBaseIntegrationT
         kjarClassLoader = KieServices.Factory.get().newKieContainer(releaseId).getClassLoader();
 
         createContainer(CONTAINER_ID, releaseId);
+        createContainer(CONTAINER_ID_WITHOUT_LOOKUP, releaseId);
     }
 
     @Override
@@ -124,8 +136,22 @@ public class DroolsMetricIntegrationTest extends DroolsKieServerBaseIntegrationT
                 "drl_match_fired_nanosecond_bucket",
                 "drl_match_fired_nanosecond_count",
                 "drl_match_fired_nanosecond_sum",
-                "ksessionId=\"kbase1.stateless\""
+                "ksessionId=\"" + KIE_SESSION + "\""
             );
+
+            int firstCount = getCount(res, CONTAINER_ID, KIE_SESSION);
+            response.close();
+
+            // One more time
+            ruleClient.executeCommandsWithResults(CONTAINER_ID, executionCommand);
+            clientRequest = newRequest(uriString);
+            response = clientRequest.request(MediaType.TEXT_PLAIN_TYPE).get();
+            Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+            res = response.readEntity(String.class);
+            logger.debug("response: " + res);
+            assertEquals(firstCount + 1, getCount(res, CONTAINER_ID, KIE_SESSION));
+            response.close();
+
         } catch (Exception e) {
             throw new RuntimeException(e);
         } finally {
@@ -133,6 +159,18 @@ public class DroolsMetricIntegrationTest extends DroolsKieServerBaseIntegrationT
                 response.close();
             }
         }
+    }
+
+    private int getCount(String res, String containerId, String ksessionId) {
+        Optional<String> opt = Arrays.stream(res.split("\n"))
+                .filter(s -> s.contains("drl_match_fired_nanosecond_count") &&
+                        s.contains("container_id=\"" + containerId + "\"") &&
+                        s.contains("ksessionId=\"" + ksessionId + "\""))
+                .findFirst();
+        assertTrue(opt.isPresent());
+        String line = opt.get();
+        String count = line.substring(line.lastIndexOf(" "));
+        return (int)Double.parseDouble(count);
     }
 
     @Test
@@ -143,7 +181,7 @@ public class DroolsMetricIntegrationTest extends DroolsKieServerBaseIntegrationT
         Object person = createInstance(PERSON_CLASS_NAME, PERSON_NAME, "");
         commands.add(commandsFactory.newInsert(person, PERSON_OUT_IDENTIFIER));
 
-        ServiceResponse<ExecutionResults> reply = ruleClient.executeCommandsWithResults(CONTAINER_ID, executionCommand);
+        ServiceResponse<ExecutionResults> reply = ruleClient.executeCommandsWithResults(CONTAINER_ID_WITHOUT_LOOKUP, executionCommand);
         assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
 
         ExecutionResults actualData = reply.getResult();
@@ -169,8 +207,22 @@ public class DroolsMetricIntegrationTest extends DroolsKieServerBaseIntegrationT
                 "drl_match_fired_nanosecond_bucket",
                 "drl_match_fired_nanosecond_count",
                 "drl_match_fired_nanosecond_sum",
-                "ksessionId=\"default\""
+                "ksessionId=\"" + KIE_SESSION_WITHOUT_LOOKUP + "\""
             );
+
+            int firstCount = getCount(res, CONTAINER_ID_WITHOUT_LOOKUP, KIE_SESSION_WITHOUT_LOOKUP);
+            response.close();
+
+            // One more time
+            ruleClient.executeCommandsWithResults(CONTAINER_ID_WITHOUT_LOOKUP, executionCommand);
+            clientRequest = newRequest(uriString);
+            response = clientRequest.request(MediaType.TEXT_PLAIN_TYPE).get();
+            Assert.assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+            res = response.readEntity(String.class);
+            logger.debug("response: " + res);
+            assertEquals(firstCount + 1, getCount(res, CONTAINER_ID_WITHOUT_LOOKUP, KIE_SESSION_WITHOUT_LOOKUP));
+            response.close();
+
         } catch (Exception e) {
             throw new RuntimeException(e);
         } finally {

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/resources/logback-test.xml
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/resources/logback-test.xml
@@ -11,7 +11,6 @@
   <logger name="org.kie.server" level="INFO" />
   <logger name="org.apache.http" level="WARN" />
   <logger name="org.apache.maven" level="WARN" />
-  <logger name="org.kie.server.services.PrometheusMetricsDroolsListener" level="DEBUG" />
 
   <root level="INFO">
     <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
…the same ksession instance (#2504)

Backport DROOLS-6395 to 7.52.x

**JIRA**: 

https://issues.redhat.com/browse/RHPAM-3737

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
