### PR TITLE
[7.52.x][JBPM-9716] Wrong bootstrap servers property in the Kafka Emitter

### DIFF
--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-kafka-sample/src/test/java/org/kie/server/springboot/samples/KafkaEmitterHappyPathTest.java
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-kafka-sample/src/test/java/org/kie/server/springboot/samples/KafkaEmitterHappyPathTest.java
@@ -103,8 +103,8 @@ public class KafkaEmitterHappyPathTest extends KafkaFixture {
     @AfterClass
     public static void teardown() {
         kafka.stop();
-        System.clearProperty("org.kie.jbpm.event.emitters.kafka.boopstrap.servers");
-        System.clearProperty("org.kie.jbpm.event.emitters.kafka.client.id");
+        System.clearProperty(BOOTSTRAP_SERVERS);
+        System.clearProperty(CLIENT_ID);
     }
 
     @Test(timeout = 30000)

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-kafka-sample/src/test/java/org/kie/server/springboot/samples/KafkaFixture.java
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-kafka-sample/src/test/java/org/kie/server/springboot/samples/KafkaFixture.java
@@ -111,6 +111,10 @@ public class KafkaFixture {
     
     protected static final String PATH = "src/test/resources/kjars/";
     
+    protected static final String BOOTSTRAP_SERVERS = "org.kie.jbpm.event.emitters.kafka.bootstrap.servers";
+    protected static final String CLIENT_ID = "org.kie.jbpm.event.emitters.kafka.client.id";
+    protected static final String TOPIC_PROCESSES = "org.kie.jbpm.event.emitters.kafka.topic.processes";
+    
     protected static String bootstrapServers;
     
     protected KModuleDeploymentUnit unit = null;
@@ -131,8 +135,8 @@ public class KafkaFixture {
             return;
         }
         
-        System.setProperty("org.kie.jbpm.event.emitters.kafka.boopstrap.servers", bootstrapServers);
-        System.setProperty("org.kie.jbpm.event.emitters.kafka.client.id", "test_jbpm");
+        System.setProperty(BOOTSTRAP_SERVERS, bootstrapServers);
+        System.setProperty(CLIENT_ID, "test_jbpm");
         
         createTopics();
     }

--- a/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-kafka-sample/src/test/java/org/kie/server/springboot/samples/ProxyAwareKafkaEmitterTest.java
+++ b/kie-spring-boot/kie-spring-boot-samples/kie-server-spring-boot-kafka-sample/src/test/java/org/kie/server/springboot/samples/ProxyAwareKafkaEmitterTest.java
@@ -73,7 +73,7 @@ public class ProxyAwareKafkaEmitterTest extends KafkaFixture{
     @BeforeClass
     public static void beforeClass() {
         assumeTrue(isDockerAvailable());
-        System.setProperty("org.kie.jbpm.event.emitters.kafka.topic.processes", CUSTOM_PROCESSES_TOPIC);
+        System.setProperty(TOPIC_PROCESSES, CUSTOM_PROCESSES_TOPIC);
         toxiproxy.start();
         kafkaProxy = toxiproxy.getProxy(kafka, TOXY_PROXY_PORT);
         
@@ -96,9 +96,9 @@ public class ProxyAwareKafkaEmitterTest extends KafkaFixture{
     public static void teardown() {
         kafka.stop();
         toxiproxy.stop();
-        System.clearProperty("org.kie.jbpm.event.emitters.kafka.topic.processes");
-        System.clearProperty("org.kie.jbpm.event.emitters.kafka.boopstrap.servers");
-        System.clearProperty("org.kie.jbpm.event.emitters.kafka.client.id");
+        System.clearProperty(TOPIC_PROCESSES);
+        System.clearProperty(BOOTSTRAP_SERVERS);
+        System.clearProperty(CLIENT_ID);
     }
     
     @Test(timeout = 30000)


### PR DESCRIPTION
**JIRA**: [JBPM-9716](https://issues.redhat.com/browse/JBPM-9716)

Cherry-pick from c8162b722b39b418189f3e4e1f2b2f23105511b5

