### PR TITLE
JBPM-9778: Update checked columns count

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
@@ -120,7 +120,7 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
             assertEquals(query.getExpression(), registered.getExpression());
             assertEquals(query.getTarget(), registered.getTarget());
             assertNotNull(registered.getColumns());
-            assertEquals(registered.getColumns().size(), 19);
+            assertEquals(registered.getColumns().size(), 18);
 
             List<QueryDefinition> queries = queryClient.getQueries(0, 100);
 
@@ -415,7 +415,7 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
             assertEquals(query.getExpression(), replaced.getExpression());
             assertEquals(query.getTarget(), replaced.getTarget());
             assertNotNull(replaced.getColumns());
-            assertEquals(replaced.getColumns().size(), 18);
+            assertEquals(replaced.getColumns().size(), 19);
 
             tasks = queryClient.query(query.getName(), QueryServicesClient.QUERY_MAP_TASK, 0, 10, TaskInstance.class);
             assertNotNull(tasks);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -121,7 +120,7 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
             assertEquals(query.getExpression(), registered.getExpression());
             assertEquals(query.getTarget(), registered.getTarget());
             assertNotNull(registered.getColumns());
-            assertEquals(registered.getColumns().size(), 18);
+            assertEquals(registered.getColumns().size(), 19);
 
             List<QueryDefinition> queries = queryClient.getQueries(0, 100);
 


### PR DESCRIPTION
Due to updates in https://issues.redhat.com/browse/JBPM-9778, where a new column was added into table, we need to increase checked columns count in QueryDataServiceIntegrationTest.

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
