### PR TITLE
[JBPM-9778] Fixing broken test

### DIFF
--- a/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features.xml
+++ b/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features.xml
@@ -88,6 +88,7 @@
     <bundle>mvn:org.jbpm/jbpm-human-task-workitems/${version.org.jbpm}</bundle>
     <bundle>mvn:org.jbpm/jbpm-human-task-jpa/${version.org.jbpm}</bundle>
     <bundle>mvn:org.jbpm/jbpm-human-task-audit/${version.org.jbpm}</bundle>
+    <bundle>mvn:com.fasterxml.jackson.datatype.jsr310/${version.com.fasterxml.jackson}</bundle>
   </feature>
 
   <feature name="jbpm" version="${project.version}" description="jBPM Engine">

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
@@ -21,7 +21,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.junit.Assume;
 import org.junit.BeforeClass;
@@ -416,7 +415,7 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
             assertEquals(query.getExpression(), replaced.getExpression());
             assertEquals(query.getTarget(), replaced.getTarget());
             assertNotNull(replaced.getColumns());
-            assertEquals(replaced.getColumns().size(), 18);
+            assertEquals(19, replaced.getColumns().size());
 
             tasks = queryClient.query(query.getName(), QueryServicesClient.QUERY_MAP_TASK, 0, 10, TaskInstance.class);
             assertNotNull(tasks);


### PR DESCRIPTION
No FDB test was performed when original PR was merged. 
The number of columns (since the JIRA added a new end date clolum) is now 19, not 18

**JIRA**: 

[link](https://issues.redhat.com/browse/JBPM-9778)

