### PR TITLE
 [BAPL-2054] Update MockProducer usage related to Kafka 2.8.0 upgrade

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-kafka/src/test/java/org/kie/server/services/jbpm/kafka/KafkaServerExtensionProducerTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-kafka/src/test/java/org/kie/server/services/jbpm/kafka/KafkaServerExtensionProducerTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.drools.core.event.MessageEventImpl;
 import org.drools.core.event.SignalEventImpl;
 import org.jbpm.runtime.manager.impl.SimpleRegisterableItemsFactory;
@@ -88,7 +90,7 @@ public class KafkaServerExtensionProducerTest {
         System.setProperty(SIGNAL_MAPPING_PROPERTY, Mapping.AUTO.toString());
         itemsFactory = new SimpleRegisterableItemsFactory();
         itemsFactory.addProcessListener(new KafkaServerProcessListener());
-        mockProducer = new MockProducer<>();
+        mockProducer = new MockProducer<>(false, new StringSerializer(), new ByteArraySerializer());
         extension = new MockKafkaServerExtension(mockProducer);
         server = mock(KieServerImpl.class);
         registry = mock(KieServerRegistry.class);


### PR DESCRIPTION
**JIRA**:  [BAPL-2054](https://issues.redhat.com/browse/BAPL-2054)

Update Kafka to version 2.8.0

PRs:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1714
- https://github.com/kiegroup/droolsjbpm-integration/pull/2568
- https://github.com/kiegroup/jbpm/pull/1996

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest</b> (using <i>this</i> e.g. <b>Jenkins retest this</b> optional but no longer required)
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
