### PR TITLE
[DROOLS-6569] Disable camel-container-integration-tests for wildfly23

### DIFF
--- a/camel-container-tests/camel-container-integration-tests/pom.xml
+++ b/camel-container-tests/camel-container-integration-tests/pom.xml
@@ -164,118 +164,18 @@
   <profiles>
     <profile>
       <id>wildfly</id>
+      <!-- wildfly test is disabled because wildfly-camel is not aligned to wildfly 23 -->
       <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>pre-integration-test</phase>
-                <goals>
-                  <goal>unpack</goal>
-                </goals>
-                <configuration>
-                  <artifactItems>
-                    <artifactItem>
-                      <groupId>org.wildfly</groupId>
-                      <artifactId>wildfly-dist</artifactId>
-                      <version>${version.org.wildfly}</version>
-                      <type>zip</type>
-                      <outputDirectory>${project.build.directory}/application-server</outputDirectory>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>org.wildfly.camel</groupId>
-                      <artifactId>wildfly-camel-patch</artifactId>
-                      <version>${version.org.wildfly.camel}</version>
-                      <type>tar.gz</type>
-                      <outputDirectory>${project.build.directory}/application-server/wildfly-${version.org.wildfly}</outputDirectory>
-                    </artifactItem>
-                  </artifactItems>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.codehaus.cargo</groupId>
-            <artifactId>cargo-maven3-plugin</artifactId>
-            <configuration>
-              <container>
-                <containerId>wildfly23x</containerId>
-                <home>${project.build.directory}/application-server/wildfly-${version.org.wildfly}</home>
-                <type>installed</type>
-                <systemProperties>
-                  <kie.maven.settings.custom>${kie.maven.settings.custom}</kie.maven.settings.custom>
-                  <org.kie.server.mode>${org.kie.server.mode.production}</org.kie.server.mode>
-                  <kie.server.port>${container.port}</kie.server.port>
-                </systemProperties>
-                <timeout>300000</timeout>
-              </container>
-              <deployables>
-                <deployable>
-                  <groupId>org.kie.server</groupId>
-                  <artifactId>kie-server</artifactId>
-                  <!-- default, may be overridden in container specific profiles -->
-                  <classifier>${kie.server.classifier}</classifier>
-                  <type>war</type>
-                  <properties>
-                    <context>${kie.server.context}</context>
-                  </properties>
-                  <pingURL>${single.kie.server.base.http.url}</pingURL>
-                  <pingTimeout>300000</pingTimeout>
-                </deployable>
-                <deployable>
-                  <groupId>org.drools</groupId>
-                  <artifactId>camel-container-tests-module</artifactId>
-                  <type>war</type>
-                </deployable>
-              </deployables>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <artifactId>maven-failsafe-plugin</artifactId>
               <configuration>
-                <users>
-                  <user>
-                    <name>yoda</name>
-                    <password>test</password>
-                    <roles>
-                      <role>kie-server</role>
-                      <role>guest</role>
-                    </roles>
-                  </user>
-                </users>
-                <properties>
-                  <cargo.jboss.configuration>standalone-full-camel</cargo.jboss.configuration>
-                  <cargo.servlet.port>${container.port}</cargo.servlet.port>
-                  <cargo.jboss.ajp.port>${cargo.jboss.ajp.port}</cargo.jboss.ajp.port>
-                  <cargo.jboss.https.port>${cargo.jboss.https.port}</cargo.jboss.https.port>
-                  <cargo.jboss.management-http.port>${cargo.jboss.management-http.port}</cargo.jboss.management-http.port>
-                  <cargo.jboss.management-https.port>${cargo.jboss.management-https.port}</cargo.jboss.management-https.port>
-                  <!--
-                  <cargo.start.jvmargs>
-                    -Xdebug
-                    -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8787
-                    -Xnoagent
-                  </cargo.start.jvmargs>
-                  -->
-                </properties>
+                <skipITs>true</skipITs>
               </configuration>
-            </configuration>
-            <executions>
-              <execution>
-                <id>start-container</id>
-                <phase>pre-integration-test</phase>
-                <goals>
-                  <goal>start</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>stop-container</id>
-                <phase>post-integration-test</phase>
-                <goals>
-                  <goal>stop</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
+            </plugin>
+          </plugins>
+        </pluginManagement>
       </build>
     </profile>
     <profile>

--- a/camel-container-tests/camel-container-integration-tests/src/test/java/org/kie/camel/container/integration/tests/ProcessEngineIntegrationTest.java
+++ b/camel-container-tests/camel-container-integration-tests/src/test/java/org/kie/camel/container/integration/tests/ProcessEngineIntegrationTest.java
@@ -24,10 +24,8 @@ import org.drools.core.command.runtime.process.GetProcessIdsCommand;
 import org.drools.core.command.runtime.process.SignalEventCommand;
 import org.drools.core.command.runtime.process.StartProcessCommand;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.kie.api.runtime.ExecutionResults;
 
-@Ignore
 public class ProcessEngineIntegrationTest extends AbstractKieCamelIntegrationTest {
 
     private static final String SIMPLE_PROCESS_ID = "process1";

--- a/camel-container-tests/camel-container-integration-tests/src/test/java/org/kie/camel/container/integration/tests/RuleEngineIntegrationTest.java
+++ b/camel-container-tests/camel-container-integration-tests/src/test/java/org/kie/camel/container/integration/tests/RuleEngineIntegrationTest.java
@@ -23,13 +23,11 @@ import org.drools.core.command.runtime.rule.DeleteCommand;
 import org.drools.core.command.runtime.rule.FireAllRulesCommand;
 import org.drools.core.command.runtime.rule.GetObjectCommand;
 import org.drools.core.command.runtime.rule.InsertObjectCommand;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.runtime.ExecutionResults;
 import org.kie.api.runtime.rule.FactHandle;
 import org.kie.camel.container.api.model.Person;
 
-@Ignore
 public class RuleEngineIntegrationTest extends AbstractKieCamelIntegrationTest {
 
     private static final String GLOBAL_NAME = "testGlobal";

--- a/camel-container-tests/camel-container-integration-tests/src/test/java/org/kie/camel/container/integration/tests/remote/DMNClientIntegrationTest.java
+++ b/camel-container-tests/camel-container-integration-tests/src/test/java/org/kie/camel/container/integration/tests/remote/DMNClientIntegrationTest.java
@@ -5,15 +5,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.camel.container.api.ExecutionServerCommand;
 import org.kie.dmn.api.core.DMNContext;
 import org.kie.dmn.api.core.DMNResult;
 
-import static org.junit.Assert.assertThat;
-
-@Ignore
 public class DMNClientIntegrationTest extends AbstractRemoteIntegrationTest {
 
     @Test

--- a/camel-container-tests/camel-container-integration-tests/src/test/java/org/kie/camel/container/integration/tests/remote/ProcessClientIntegrationTest.java
+++ b/camel-container-tests/camel-container-integration-tests/src/test/java/org/kie/camel/container/integration/tests/remote/ProcessClientIntegrationTest.java
@@ -19,12 +19,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.camel.container.api.ExecutionServerCommand;
 import org.kie.server.api.model.definition.ProcessDefinition;
 
-@Ignore
 public class ProcessClientIntegrationTest extends AbstractRemoteIntegrationTest {
 
     @Test

--- a/camel-container-tests/camel-container-integration-tests/src/test/java/org/kie/camel/container/integration/tests/remote/QueryClientIntegrationTest.java
+++ b/camel-container-tests/camel-container-integration-tests/src/test/java/org/kie/camel/container/integration/tests/remote/QueryClientIntegrationTest.java
@@ -23,14 +23,12 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.camel.container.api.ExecutionServerCommand;
 import org.kie.server.api.model.definition.ProcessDefinition;
 import org.kie.server.api.model.definition.QueryDefinition;
 import org.kie.server.api.model.instance.ProcessInstance;
 
-@Ignore
 public class QueryClientIntegrationTest extends AbstractRemoteIntegrationTest {
 
     @Test

--- a/camel-container-tests/camel-container-integration-tests/src/test/java/org/kie/camel/container/integration/tests/remote/RuleClientIntegrationTest.java
+++ b/camel-container-tests/camel-container-integration-tests/src/test/java/org/kie/camel/container/integration/tests/remote/RuleClientIntegrationTest.java
@@ -24,13 +24,11 @@ import org.assertj.core.api.Assertions;
 import org.drools.core.command.runtime.BatchExecutionCommandImpl;
 import org.drools.core.command.runtime.rule.FireAllRulesCommand;
 import org.drools.core.command.runtime.rule.InsertObjectCommand;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.command.ExecutableCommand;
 import org.kie.camel.container.api.ExecutionServerCommand;
 import org.kie.camel.container.api.model.Person;
 
-@Ignore
 public class RuleClientIntegrationTest extends AbstractRemoteIntegrationTest {
 
     @Test

--- a/camel-container-tests/camel-container-integration-tests/src/test/java/org/kie/camel/container/integration/tests/remote/SolverClientIntegrationTest.java
+++ b/camel-container-tests/camel-container-integration-tests/src/test/java/org/kie/camel/container/integration/tests/remote/SolverClientIntegrationTest.java
@@ -23,13 +23,11 @@ import java.util.Map;
 import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.camel.container.api.ExecutionServerCommand;
 import org.kie.camel.container.api.model.cloudbalance.CloudBalance;
 import org.kie.server.api.model.instance.SolverInstance;
 
-@Ignore
 public class SolverClientIntegrationTest extends AbstractRemoteIntegrationTest {
 
     private static final String CLOUD_BALANCE_SOLVER_ID = "cloudsolver";

--- a/camel-container-tests/camel-container-integration-tests/src/test/java/org/kie/camel/container/integration/tests/remote/UserTaskClientIntegrationTest.java
+++ b/camel-container-tests/camel-container-integration-tests/src/test/java/org/kie/camel/container/integration/tests/remote/UserTaskClientIntegrationTest.java
@@ -20,13 +20,11 @@ import java.util.List;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.camel.container.api.ExecutionServerCommand;
 import org.kie.server.api.model.instance.TaskInstance;
 import org.kie.server.api.model.instance.TaskSummary;
 
-@Ignore
 public class UserTaskClientIntegrationTest extends AbstractRemoteIntegrationTest {
 
     private static final String INITIAL_PROCESS_VARIABLE_VALUE = "initial-value";


### PR DESCRIPTION
**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6569

As discussed, wildfly-camel is not aligned to wildfly 23. `@Ignore` were added to test cases in camel-container-integration-tests by https://github.com/kiegroup/droolsjbpm-integration/commit/ed250d3ffe6cdfb5c1774ac725961d5a4ebcb16c but build is still failing (e.g. https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/main/job/deployedRep/job/droolsjbpm-integration/35//consoleText )

This fix is to simply disable tests including cargo execution for wildfly profile. On the other hand, in order to be able to test for eap profile (fuse), I removed `@Ignore` from test cases.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
