### PR TITLE
[JBPM-9872] Banned classes in kie-server-services-openshift artifact

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-openshift/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-openshift/pom.xml
@@ -39,6 +39,10 @@
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>

--- a/kie-server-parent/kie-server-services/kie-server-services-openshift/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-openshift/pom.xml
@@ -41,6 +41,10 @@
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
**[JBPM-9872](https://issues.redhat.com/browse/JBPM-9872)**: Banned classes in kie-server-services-openshift artifact

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
