### PR TITLE
[DROOLS-6576] reserve-network-port issue in kie-server-tests cargo test

### DIFF
--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -378,6 +378,9 @@
             </goals>
             <phase>generate-resources</phase>
             <configuration>
+              <minPortNumber>49152</minPortNumber>
+              <maxPortNumber>65535</maxPortNumber>
+              <randomPort>true</randomPort>
               <portNames>
                 <portName>container.port</portName>
                 <portName>cargo.jboss.ajp.port</portName>
@@ -394,6 +397,9 @@
             </goals>
             <phase>generate-resources</phase>
             <configuration>
+              <minPortNumber>49152</minPortNumber>
+              <maxPortNumber>65535</maxPortNumber>
+              <randomPort>true</randomPort>
               <portNames>
                 <portName>router.port</portName>
               </portNames>


### PR DESCRIPTION
**JIRA**:
https://issues.redhat.com/browse/DROOLS-6576

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
