### PR TITLE
[DROOLS-6577] Suppress info log in kie-server-api unit tests

### DIFF
--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/DecisionMarshallingTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/DecisionMarshallingTest.java
@@ -33,6 +33,8 @@ import org.kie.internal.utils.KieHelper;
 import org.kie.server.api.model.ServiceResponse;
 import org.kie.server.api.model.dmn.DMNContextKS;
 import org.kie.server.api.model.dmn.DMNResultKS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -40,6 +42,8 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(Parameterized.class)
 public class DecisionMarshallingTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(DecisionMarshallingTest.class);
 
     @Parameterized.Parameters(name = "{index}: {0}")
     public static Collection<Object[]> data() {
@@ -99,7 +103,7 @@ public class DecisionMarshallingTest {
     private <V> V marshallUnmarshall(V input) {
         try {
             String marshall = marshaller.marshall(input);
-            System.out.println(marshall);
+            logger.debug(marshall);
             V unmarshall = (V) marshaller.unmarshall(marshall, input.getClass());
             return unmarshall;
         } catch (Exception e) {

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/SolutionMarshallingTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/SolutionMarshallingTest.java
@@ -75,7 +75,7 @@ public class SolutionMarshallingTest {
         );
 
         String marshalledSolverInstance = marshaller.marshall(solverInstance);
-        logger.info("Marshalled SolverInstance ({}): {}", marshallingFormat, marshalledSolverInstance);
+        logger.debug("Marshalled SolverInstance ({}): {}", marshallingFormat, marshalledSolverInstance);
         assertThat(marshalledSolverInstance)
                 .as("Dates should be formatted")
                 .contains(

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/XStreamMarshallerTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/XStreamMarshallerTest.java
@@ -36,12 +36,16 @@ import org.kie.server.api.marshalling.objects.DateObject;
 import org.kie.server.api.marshalling.objects.Message;
 import org.kie.server.api.marshalling.xstream.XStreamMarshaller;
 import org.kie.server.api.model.KieContainerResourceFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
 public class XStreamMarshallerTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(XStreamMarshallerTest.class);
 
     @Test
     public void testXstreamMarshalWithAnnotation() {
@@ -89,10 +93,10 @@ public class XStreamMarshallerTest {
         extraClasses.add(ParameterInfo.class);
         Marshaller marshaller = MarshallerFactory.getMarshaller(extraClasses, MarshallingFormat.XSTREAM, getClass().getClassLoader());
         String marshalled = marshaller.marshall(request);
-        System.out.println(marshalled);
+        logger.debug(marshalled);
 
         PMMLRequestData rqst = marshaller.unmarshall(marshalled, PMMLRequestData.class);
-        System.out.println(rqst);
+        logger.info(rqst.toString());
     }
 
     @Test

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/json/JSONMarshallerExtensionTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/json/JSONMarshallerExtensionTest.java
@@ -31,10 +31,14 @@ import org.kie.server.api.marshalling.Marshaller;
 import org.kie.server.api.marshalling.MarshallerFactory;
 import org.kie.server.api.marshalling.MarshallingFormat;
 import org.kie.server.api.marshalling.objects.CustomPerson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
 
 public class JSONMarshallerExtensionTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(JSONMarshallerExtensionTest.class);
 
     private static final DateFormat FORMATTER = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
@@ -56,7 +60,7 @@ public class JSONMarshallerExtensionTest {
         String mshl = marshaller.marshall(request);
         PMMLRequestData rd = marshaller.unmarshall(mshl, PMMLRequestData.class);
         assertEquals(rd, request);
-        System.out.println(rd);
+        logger.info(rd.toString());
     }
 
     @Test

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/DroolsCommandMarshallingTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/DroolsCommandMarshallingTest.java
@@ -156,7 +156,7 @@ public class DroolsCommandMarshallingTest {
 
     private void verifyMarshallingRoundTrip(Marshaller marshaller, BatchExecutionCommand inputCommand, String expectedPayload) {
         String rawContent = marshaller.marshall(inputCommand);
-        logger.info(rawContent);
+        logger.debug(rawContent);
         Assertions.assertThat(rawContent).isEqualToIgnoringWhitespace(expectedPayload);
 
         BatchExecutionCommandImpl inputBatch = (BatchExecutionCommandImpl) inputCommand;

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/DroolsCommandWithListMarshallingTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/DroolsCommandWithListMarshallingTest.java
@@ -217,7 +217,7 @@ public class DroolsCommandWithListMarshallingTest {
 
     private void verifyMarshallingRoundTrip(Marshaller marshaller, BatchExecutionCommand inputCommand, String expectedPayload) {
         String rawContent = marshaller.marshall(inputCommand);
-        logger.info(rawContent);
+        logger.debug(rawContent);
         Assertions.assertThat(rawContent).isEqualToIgnoringWhitespace(expectedPayload);
 
         BatchExecutionCommandImpl inputBatch = (BatchExecutionCommandImpl) inputCommand;

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/MarshallingRoundTripNestedClassesTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/MarshallingRoundTripNestedClassesTest.java
@@ -70,7 +70,7 @@ public class MarshallingRoundTripNestedClassesTest {
 
     private void verifyMarshallingRoundTrip(Marshaller marshaller, Object inputObject) {
         String rawContent = marshaller.marshall(inputObject);
-        logger.info(rawContent);
+        logger.debug(rawContent);
         Object testObjectAfterMarshallingTurnAround = marshaller.unmarshall(rawContent, inputObject.getClass());
         Assertions.assertThat(testObjectAfterMarshallingTurnAround).isEqualTo(inputObject);
     }

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/MarshallingRoundTripNestedClassesWithAnnotationsTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/model/MarshallingRoundTripNestedClassesWithAnnotationsTest.java
@@ -81,7 +81,7 @@ public class MarshallingRoundTripNestedClassesWithAnnotationsTest {
 
     private void verifyMarshallingRoundTrip(Marshaller marshaller, Object inputObject) {
         String rawContent = marshaller.marshall(inputObject);
-        logger.info(rawContent);
+        logger.debug(rawContent);
         Object testObjectAfterMarshallingTurnAround = marshaller.unmarshall(rawContent, inputObject.getClass());
         Assertions.assertThat(testObjectAfterMarshallingTurnAround).isEqualTo(inputObject);
     }


### PR DESCRIPTION
**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6577

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
