### PR TITLE
[DROOLS-6566] Upgrade to Karaf 4.3.2 and fix all (but 3) integration …

### DIFF
--- a/kie-osgi/kie-karaf-features/pom.xml
+++ b/kie-osgi/kie-karaf-features/pom.xml
@@ -48,7 +48,7 @@
     <karaf.version.org.apache.servicemix.bundles.dom4j>1.6.1_5</karaf.version.org.apache.servicemix.bundles.dom4j>
     <karaf.version.org.apache.servicemix.bundles.serp>1.14.1_1</karaf.version.org.apache.servicemix.bundles.serp>
     <karaf.version.com.fasterxml.classmate>1.3.1</karaf.version.com.fasterxml.classmate>
-    <karaf.version.org.jboss.jandex>1.1.0.Final</karaf.version.org.jboss.jandex>
+    <karaf.version.org.jboss.jandex>2.2.3.Final</karaf.version.org.jboss.jandex>
     <karaf.version.javax.validation>1.1.0.Final</karaf.version.javax.validation>
 
     <karaf.version.org.apache.logging.log4j>2.5</karaf.version.org.apache.logging.log4j>

--- a/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features-core.xml
+++ b/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features-core.xml
@@ -104,9 +104,9 @@
     <feature>camel-core</feature>
     <feature>camel-spring</feature>
     <feature>camel-cxf</feature>
-    <feature version="[3.2,3.4)">cxf-specs</feature>
-    <feature version="[3.2,3.4)">cxf-core</feature>
-    <feature version="[3.2,3.4)">cxf-jaxrs</feature>
+    <feature version="[3.3,3.4)">cxf-specs</feature>
+    <feature version="[3.3,3.4)">cxf-core</feature>
+    <feature version="[3.3,3.4)">cxf-jaxrs</feature>
     <bundle>mvn:org.kie/kie-camel/${project.version}</bundle>
   </feature>
 

--- a/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features.xml
+++ b/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features.xml
@@ -62,7 +62,6 @@
     <bundle>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.scripting-api-1.0/${karaf.servicemix.version.scripting-api}</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.quartz/${karaf.servicemix.version.org.quartz-scheduler}</bundle>
     <bundle>mvn:jakarta.security.jacc/jakarta.security.jacc-api/${version.jakarta.security.jacc-api}</bundle>
-    <bundle>mvn:jakarta.servlet/jakarta.servlet-api/${version.jakarta.servlet-api}</bundle>
     <bundle>mvn:joda-time/joda-time/${karaf.version.joda-time}</bundle>
     <bundle>mvn:jakarta.interceptor/jakarta.interceptor-api/${version.jakarta.interceptor-api}</bundle>
     <bundle>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/${karaf.version.org.apache.geronimo.specs.jms}</bundle>
@@ -137,13 +136,11 @@
     <bundle dependency="true">mvn:org.javassist/javassist/${version.org.javassist}</bundle>
     <bundle dependency="true">mvn:net.bytebuddy/byte-buddy/${version.net.byte-buddy}</bundle>
     <bundle dependency="true">mvn:jakarta.security.jacc/jakarta.security.jacc-api/${version.jakarta.security.jacc-api}</bundle>
-    <bundle dependency="true">mvn:jakarta.servlet/jakarta.servlet-api/${version.jakarta.servlet-api}</bundle>
-    <bundle dependency="true">wrap:mvn:org.jboss/jandex/${karaf.version.org.jboss.jandex}</bundle>
+    <bundle dependency="true">mvn:org.jboss/jandex/${karaf.version.org.jboss.jandex}</bundle>
     <bundle dependency="true">mvn:javax.validation/validation-api/${karaf.version.javax.validation}</bundle>
     <bundle dependency="true">mvn:org.jboss.logging/jboss-logging/${version.org.jboss.logging.jboss-logging}</bundle>
     <bundle dependency="true">mvn:org.hibernate.common/hibernate-commons-annotations/${version.org.hibernate.commons.annotations}</bundle>
-    <bundle start-level="100">wrap:mvn:org.hibernate/hibernate-core/${version.org.hibernate}$overwrite=merge&amp;Import-Package=org.jbpm.services.task*,*</bundle>
-    <bundle start-level="100">wrap:mvn:org.hibernate/hibernate-entitymanager/${version.org.hibernate}$overwrite=merge&amp;DynamicImport-Package=*</bundle>
+    <bundle start-level="100">mvn:org.hibernate/hibernate-core/${version.org.hibernate}</bundle>
     <bundle start-level="100">mvn:org.hibernate/hibernate-osgi/${version.org.hibernate}</bundle>
     <bundle start-level="100">mvn:org.apache.logging.log4j/log4j-api/${karaf.version.org.apache.logging.log4j}</bundle>
   </feature>
@@ -151,8 +148,8 @@
   <feature name="h2" version="${h2.version}" description="H2 database">
     <bundle>mvn:com.h2database/h2/${h2.version}</bundle>
     <bundle>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/${karaf.version.org.apache.geronimo.specs.jta}</bundle>
-    <bundle start-level="100">mvn:commons-dbcp/commons-dbcp/${version.commons-dbcp}</bundle>
-    <bundle start-level="100">mvn:commons-pool/commons-pool/${version.commons-pool}</bundle>
+    <bundle start-level="100">mvn:org.apache.commons/commons-dbcp2/${version.org.apache.commons.dbcp2}</bundle>
+    <bundle start-level="100">mvn:org.apache.commons/commons-pool2/${version.org.apache.commons.pool2}</bundle>
   </feature>
 
   <feature name="jackson" version="${project.version}">
@@ -182,7 +179,8 @@
   </feature>
 
   <feature name="servlet-api-kie" version="${project.version}">
-    <bundle>mvn:org.apache.geronimo.specs/geronimo-servlet_3.0_spec/1.0</bundle>
+    <bundle start="false">mvn:org.kie/kie-osgi-servlet3-compatibility/${project.version}</bundle>
+    <bundle>mvn:jakarta.servlet/jakarta.servlet-api/${version.jakarta.servlet-api}</bundle>
   </feature>
 
   <feature name="kie-pmml" version="${project.version}">

--- a/kie-osgi/kie-karaf-itests/pom.xml
+++ b/kie-osgi/kie-karaf-itests/pom.xml
@@ -15,10 +15,10 @@
     <skipTests>true</skipTests>
 
     <java.module.name>org.kie.karaf.itests.main</java.module.name>
-    <version.org.apache.karaf>4.2.3</version.org.apache.karaf>
+    <version.org.apache.karaf>4.3.2</version.org.apache.karaf>
     <!-- use global version property from kie-parent -->
     <!-- <version.org.apache.cxf>3.2.8</version.org.apache.cxf> -->
-    <version.org.apache.camel>2.21.5</version.org.apache.camel>
+    <!-- version.org.apache.camel>2.21.5</version.org.apache.camel -->
     <version.org.ops4j.pax.exam>4.13.4</version.org.ops4j.pax.exam>
     <version.org.apache.servicemix.bundles.javax-inject>1_2</version.org.apache.servicemix.bundles.javax-inject>
 
@@ -30,7 +30,8 @@
     <maven.jdbc.driver.jar/>
     <maven.jdbc.username>sa</maven.jdbc.username>
     <maven.jdbc.password>sa</maven.jdbc.password>
-    <maven.jdbc.url>jdbc:h2:tcp://localhost/${project.basedir}/target/kie-karaf-itests;MVCC=TRUE</maven.jdbc.url>
+    <maven.jdbc.url>jdbc:h2:mem:test_mem;MVCC=TRUE</maven.jdbc.url>
+    <maven.jdbc.tcp.url>jdbc:h2:tcp://localhost/${project.basedir}/target/kie-karaf-itests;MVCC=TRUE</maven.jdbc.tcp.url>
     <maven.jdbc.schema>public</maven.jdbc.schema>
   </properties>
 

--- a/kie-osgi/kie-karaf-itests/src/test/filtered-resources/org/kie/karaf/itest/blueprint/processpersistence/datasource.xml
+++ b/kie-osgi/kie-karaf-itests/src/test/filtered-resources/org/kie/karaf/itest/blueprint/processpersistence/datasource.xml
@@ -9,9 +9,12 @@
 
   <reference id="transactionManager" interface="javax.transaction.TransactionManager"/>
 
-  <bean id="dataSource" class="org.apache.commons.dbcp.managed.BasicManagedDataSource">
+  <bean id="dataSource" class="org.apache.commons.dbcp2.managed.BasicManagedDataSource">
     <property name="transactionManager" ref="transactionManager"/>
     <property name="driverClassName" value="${maven.jdbc.driver.class}"/>
+    <property name="driverClassLoader">
+      <bean factory-ref="blueprintContainer" factory-method="getClassLoader" />
+    </property>
     <property name="url" value="${maven.jdbc.url}"/>
     <property name="username" value="${maven.jdbc.username}"/>
     <property name="password" value="${maven.jdbc.password}"/>

--- a/kie-osgi/kie-karaf-itests/src/test/filtered-resources/org/kie/karaf/itest/kie-beans-persistence.xml
+++ b/kie-osgi/kie-karaf-itests/src/test/filtered-resources/org/kie/karaf/itest/kie-beans-persistence.xml
@@ -20,7 +20,7 @@
         <property name="driver">
             <bean class="${maven.jdbc.driver.class}" />
         </property>
-        <property name="url" value="${maven.jdbc.url}"/>
+        <property name="url" value="${maven.jdbc.tcp.url}"/>
         <property name="username" value="${maven.jdbc.username}"/>
         <property name="password" value="${maven.jdbc.password}"/>
     </bean>

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/AbstractKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/AbstractKarafIntegrationTest.java
@@ -229,10 +229,10 @@ abstract public class AbstractKarafIntegrationTest {
         options.add(editConfigurationFilePut("etc/system.properties", "patching.disabled", "true"));
         if (!"features-fuse".equals(System.getProperty("kie.features.classifier"))) {
             // when not running on Fuse, we have to configure overrides and add some missing features
-            options.add(editConfigurationFilePut("etc/startup.properties", "mvn:org.ops4j.pax.url/pax-url-wrap/2.6.1/jar/uber", "5"));
+            options.add(editConfigurationFilePut("etc/startup.properties", "mvn:org.ops4j.pax.url/pax-url-wrap/2.6.7/jar/uber", "5"));
             // Camel 2.21 requires Spring 4.3, so it has to be spring-legacy
             options.add(editConfigurationFileExtend("etc/org.apache.karaf.features.cfg",
-                    "featuresRepositories", "mvn:org.apache.karaf.features/spring-legacy/" + karafVersion + "/xml/features"));
+                    "featuresRepositories", "mvn:org.apache.karaf.features/spring/" + karafVersion + "/xml/features"));
             options.add(editConfigurationFileExtend("etc/org.apache.karaf.features.cfg",
                     "featuresRepositories", "mvn:org.apache.cxf.karaf/apache-cxf/" + cxfVersion + "/xml/features"));
             options.add(editConfigurationFileExtend("etc/org.apache.karaf.features.cfg",
@@ -241,6 +241,8 @@ abstract public class AbstractKarafIntegrationTest {
             options.add(editConfigurationFileExtend("etc/org.apache.karaf.features.cfg", "featuresBoot", "aries-blueprint/" + karafVersion));
             options.add(editConfigurationFileExtend("etc/org.apache.karaf.features.cfg", "featuresBoot", "pax-http-jetty"));
             options.add(editConfigurationFileExtend("etc/org.apache.karaf.features.cfg", "featuresBoot", "cxf-http"));
+            // this feature ensures single Servlet API bundle + fragment bundle adding Servlet API 3 version exports (for Jetty)
+            options.add(editConfigurationFileExtend("etc/org.apache.karaf.features.cfg", "featuresBoot", "servlet-api-kie"));
             options.add(editConfigurationFilePut("etc/org.apache.karaf.features.repos.cfg", "cxf", "mvn:org.apache.cxf.karaf/apache-cxf/" + cxfVersion + "/xml/features"));
             options.add(editConfigurationFilePut("etc/org.apache.karaf.features.repos.cfg", "camel", "mvn:org.apache.camel.karaf/apache-camel/" + camelVersion + "/xml/features"));
         }

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/DecisionTablesIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/DecisionTablesIntegrationTest.java
@@ -19,7 +19,6 @@ package org.kie.karaf.itest;
 import org.drools.decisiontable.ExternalSpreadsheetCompiler;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.Configuration;
@@ -32,7 +31,6 @@ import org.ops4j.pax.exam.spi.reactors.PerClass;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
-@Ignore
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class DecisionTablesIntegrationTest extends AbstractKarafIntegrationTest {

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/InstallFeaturesKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/InstallFeaturesKarafIntegrationTest.java
@@ -24,7 +24,6 @@ import javax.inject.Inject;
 import org.apache.karaf.features.FeaturesService;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -44,7 +43,6 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
  */
 @RunWith(PaxExamParameterized.class)
 @ExamReactorStrategy(PerClass.class)
-@Ignore
 public class InstallFeaturesKarafIntegrationTest extends AbstractKarafIntegrationTest {
 
     private String featureName;

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieDMNKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieDMNKarafIntegrationTest.java
@@ -19,7 +19,6 @@ package org.kie.karaf.itest;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.api.KieServices;
@@ -39,7 +38,6 @@ import static org.junit.Assert.assertTrue;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
-@Ignore
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class KieDMNKarafIntegrationTest extends AbstractKarafIntegrationTest {

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieSpringDependencyKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieSpringDependencyKarafIntegrationTest.java
@@ -18,7 +18,6 @@ package org.kie.karaf.itest;
 
 import javax.inject.Inject;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.api.runtime.KieSession;
@@ -40,7 +39,6 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 import static org.ops4j.pax.tinybundles.core.TinyBundles.bundle;
 
-@Ignore
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerMethod.class)
 public class KieSpringDependencyKarafIntegrationTest extends AbstractKarafIntegrationTest {

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieSpringMetaInfAppContextKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieSpringMetaInfAppContextKarafIntegrationTest.java
@@ -18,7 +18,6 @@ package org.kie.karaf.itest;
 
 import javax.inject.Inject;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.api.runtime.KieSession;
@@ -37,7 +36,6 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 import static org.ops4j.pax.tinybundles.core.TinyBundles.bundle;
 
-@Ignore
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerMethod.class)
 public class KieSpringMetaInfAppContextKarafIntegrationTest extends AbstractKarafIntegrationTest {

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieSpringjBPMPersistenceKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/KieSpringjBPMPersistenceKarafIntegrationTest.java
@@ -32,7 +32,6 @@ import org.h2.tools.Server;
 import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
 import org.jbpm.services.task.identity.JBossUserGroupCallbackImpl;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.api.KieServices;
@@ -73,7 +72,6 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 import static org.ops4j.pax.tinybundles.core.TinyBundles.bundle;
 
-@Ignore
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class KieSpringjBPMPersistenceKarafIntegrationTest extends AbstractKieSpringKarafIntegrationTest {

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/RuntimeManagerFeatureKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/RuntimeManagerFeatureKarafIntegrationTest.java
@@ -19,7 +19,6 @@ package org.kie.karaf.itest;
 import javax.inject.Inject;
 
 import org.apache.karaf.features.FeaturesService;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.api.runtime.manager.RuntimeManagerFactory;
@@ -39,7 +38,6 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerMethod.class)
-@Ignore
 public class RuntimeManagerFeatureKarafIntegrationTest extends AbstractKarafIntegrationTest {
 
     @Inject

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/SimpleKieSpringKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/SimpleKieSpringKarafIntegrationTest.java
@@ -19,7 +19,6 @@ package org.kie.karaf.itest;
 import javax.inject.Inject;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.api.KieBase;
@@ -45,7 +44,6 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.features;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 import static org.ops4j.pax.tinybundles.core.TinyBundles.bundle;
 
-@Ignore
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class SimpleKieSpringKarafIntegrationTest extends AbstractKieSpringKarafIntegrationTest {

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/WorkbenchModelsKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/WorkbenchModelsKarafIntegrationTest.java
@@ -19,7 +19,6 @@ package org.kie.karaf.itest;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.api.KieBase;
@@ -37,7 +36,6 @@ import org.ops4j.pax.exam.spi.reactors.PerClass;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
-@Ignore
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class WorkbenchModelsKarafIntegrationTest extends AbstractKarafIntegrationTest {

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/blueprint/KieBlueprintjBPMPersistenceKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/blueprint/KieBlueprintjBPMPersistenceKarafIntegrationTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 
 import javax.inject.Inject;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.api.runtime.KieSession;
@@ -50,7 +49,6 @@ import static org.ops4j.pax.tinybundles.core.TinyBundles.bundle;
 /**
  * Tests starting a jBPM process using RuntimeManager with persistence enabled in Blueprint environment.
  */
-@Ignore("JPA 2.1 not supported with Aries Blueprint - see https://issues.jboss.org/browse/DROOLS-1380")
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class KieBlueprintjBPMPersistenceKarafIntegrationTest extends AbstractKarafIntegrationTest {
@@ -122,7 +120,7 @@ public class KieBlueprintjBPMPersistenceKarafIntegrationTest extends AbstractKar
                 .set(Constants.BUNDLE_SYMBOLICNAME, "Test-Blueprint-Datasource-Bundle")
                 .set(Constants.IMPORT_PACKAGE, "javax.transaction," +
                                                "javax.sql," +
-                                               "org.apache.commons.dbcp.managed," +
+                                               "org.apache.commons.dbcp2.managed," +
                                                "org.h2")
                 .build()).start());
 
@@ -166,15 +164,23 @@ public class KieBlueprintjBPMPersistenceKarafIntegrationTest extends AbstractKar
                                                "org.kie.api.runtime.manager," +
                                                "org.kie.api.runtime.process," +
                                                "org.kie.api.task," +
+                                               "org.kie.api.task.model," +
+                                               "org.jbpm.persistence.correlation," +
                                                "org.jbpm.persistence.processinstance," +
                                                "org.jbpm.runtime.manager.impl," +
+                                               "org.jbpm.runtime.manager.impl.jpa," +
+                                               "org.jbpm.process.audit," +
                                                "org.jbpm.process.instance.impl," +
+                                               "org.jbpm.services.task.audit.impl.model," +
                                                "org.jbpm.services.task.identity," +
                                                "org.jbpm.services.task.impl.model," +
+                                               "org.jbpm.services.task.query," +
+                                               "org.kie.internal.task.api," +
+                                               "org.kie.internal.task.api.model," +
                                                "org.kie.internal.runtime.manager.context," +
+                                               "org.drools.persistence.info," +
                                                "javax.transaction," +
-                                               "javax.persistence," +
-                                               "*")
+                                               "javax.persistence")
                 .set(Constants.BUNDLE_SYMBOLICNAME, "Test-Blueprint-Bundle")
                 .build()).start());
 

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/camel/kiecamel/KieCamelBlueprintIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/camel/kiecamel/KieCamelBlueprintIntegrationTest.java
@@ -21,7 +21,6 @@ import javax.inject.Inject;
 import org.apache.camel.CamelContext;
 import org.apache.camel.component.bean.PojoProxyHelper;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.karaf.itest.AbstractKarafIntegrationTest;
@@ -43,7 +42,6 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 /**
  * Basic KIE-Camel with Blueprint functional tests running in Fuse.
  */
-@Ignore
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class KieCamelBlueprintIntegrationTest extends AbstractKarafIntegrationTest {

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/camel/kiecamel/KieCamelRemoteIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/camel/kiecamel/KieCamelRemoteIntegrationTest.java
@@ -30,7 +30,6 @@ import org.drools.core.command.runtime.rule.FireAllRulesCommand;
 import org.drools.core.command.runtime.rule.InsertObjectCommand;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.api.command.ExecutableCommand;
@@ -54,7 +53,6 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
 @RunWith(PaxExamWithWireMock.class)
 @ExamReactorStrategy(PerClass.class)
-@Ignore
 public class KieCamelRemoteIntegrationTest extends AbstractKarafIntegrationTest {
 
     public static final String HOST = "localhost";

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/KieServerClientKarafIntegrationJaxbIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/KieServerClientKarafIntegrationJaxbIntegrationTest.java
@@ -36,7 +36,7 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
 @RunWith(PaxExamWithWireMock.class)
 @ExamReactorStrategy(PerClass.class)
-@Ignore
+@Ignore("DROOLS-6581")
 public class KieServerClientKarafIntegrationJaxbIntegrationTest extends BaseKieServerClientKarafIntegrationTest {
 
     private static final Logger logger = LoggerFactory.getLogger(KieServerClientKarafIntegrationJaxbIntegrationTest.class);

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/KieServerClientKarafIntegrationJsonIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/KieServerClientKarafIntegrationJsonIntegrationTest.java
@@ -16,7 +16,6 @@
 
 package org.kie.karaf.itest.kieserver;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.karaf.itest.AbstractKarafIntegrationTest;
@@ -33,7 +32,6 @@ import org.slf4j.LoggerFactory;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
-@Ignore
 @RunWith(PaxExamWithWireMock.class)
 @ExamReactorStrategy(PerClass.class)
 public class KieServerClientKarafIntegrationJsonIntegrationTest extends BaseKieServerClientKarafIntegrationTest {

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/KieServerClientKarafIntegrationXstreamIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/KieServerClientKarafIntegrationXstreamIntegrationTest.java
@@ -16,7 +16,6 @@
 
 package org.kie.karaf.itest.kieserver;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.karaf.itest.AbstractKarafIntegrationTest;
@@ -34,7 +33,6 @@ import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configure
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
 
-@Ignore
 @RunWith(PaxExamWithWireMock.class)
 @ExamReactorStrategy(PerClass.class)
 public class KieServerClientKarafIntegrationXstreamIntegrationTest extends BaseKieServerClientKarafIntegrationTest {

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/planner/PlannerCloudBalanceIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/planner/PlannerCloudBalanceIntegrationTest.java
@@ -49,7 +49,6 @@ import org.optaplanner.core.config.solver.termination.TerminationConfig;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
-@Ignore
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class PlannerCloudBalanceIntegrationTest extends AbstractKarafIntegrationTest {

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/pmml/KiePmmlIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/pmml/KiePmmlIntegrationTest.java
@@ -19,13 +19,11 @@ package org.kie.karaf.itest.pmml;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.ops4j.pax.exam.junit.PaxExam;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 
-@Ignore
 @RunWith(PaxExam.class)
 @ExamReactorStrategy(PerClass.class)
 public class KiePmmlIntegrationTest extends AbstractPmmlIntegrationTest {

--- a/kie-osgi/kie-karaf-itests/src/test/resources/META-INF/Taskorm.xml
+++ b/kie-osgi/kie-karaf-itests/src/test/resources/META-INF/Taskorm.xml
@@ -23,9 +23,12 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable,
+                plog.correlationKey,
+                plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.businessAdministrators businessAdministrators
             where
             t.archived = 0 and
@@ -53,9 +56,12 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable,
+                plog.correlationKey,
+                plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.businessAdministrators businessAdministrators
             where
             t.archived = 0 and
@@ -85,9 +91,12 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable,
+                plog.correlationKey,
+                plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.excludedOwners excludedOwners
             where
             t.archived = 0 and
@@ -115,9 +124,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and
@@ -148,9 +158,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and
@@ -181,16 +192,17 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and            
             (t.taskData.actualOwner.id = :userId or t.taskData.actualOwner is null) and 
             t.taskData.status in (:status) and 
             ( potentialOwners.id = :userId or potentialOwners.id in (:groupIds) ) and 
-            (:userId not member of t.peopleAssignments.excludedOwners) 
+            (:userId IS NULL OR :userId NOT MEMBER OF t.peopleAssignments.excludedOwners) 
             order by t.id DESC
         </query>
         <!-- hint name="org.hibernate.timeout" value="200"/ -->
@@ -214,16 +226,17 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and            
             (t.taskData.actualOwner.id = :userId or t.taskData.actualOwner is null) and 
             t.taskData.status in ('Created', 'Ready', 'Reserved', 'InProgress', 'Suspended') and 
             ( potentialOwners.id = :userId or potentialOwners.id in (:groupIds) )  and 
-            (:userId not member of t.peopleAssignments.excludedOwners) 
+            (:userId IS NULL OR :userId NOT MEMBER OF t.peopleAssignments.excludedOwners) 
             order by t.id DESC          
         </query>
         <!-- hint name="org.hibernate.timeout" value="200"/ -->
@@ -247,16 +260,17 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and            
             (t.taskData.actualOwner.id = :userId or t.taskData.actualOwner is null) and 
             t.taskData.status in (:status) and 
             ( potentialOwners.id = :userId or potentialOwners.id in (:groupIds) )  and 
-            (:userId not member of t.peopleAssignments.excludedOwners) 
+            (:userId IS NULL OR :userId NOT MEMBER OF t.peopleAssignments.excludedOwners) 
             order by t.id DESC
         </query>
         <!-- hint name="org.hibernate.timeout" value="200"/ -->
@@ -280,9 +294,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners 
             where
             t.archived = 0 and
@@ -334,9 +349,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and            
@@ -344,7 +360,7 @@
             t.taskData.expirationTime = :expirationDate and
             t.taskData.status in (:status) and 
             ( potentialOwners.id = :userId or potentialOwners.id in (:groupIds) )  and 
-            (:userId not member of t.peopleAssignments.excludedOwners) 
+            (:userId IS NULL OR :userId NOT MEMBER OF t.peopleAssignments.excludedOwners) 
             order by t.id DESC
         </query>
         <!-- hint name="org.hibernate.timeout" value="200"/ -->
@@ -369,9 +385,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners 
             where
             t.archived = 0 and            
@@ -379,7 +396,7 @@
             (t.taskData.expirationTime = :expirationDate or t.taskData.expirationTime is null) and
             t.taskData.status in (:status) and 
             ( potentialOwners.id = :userId or potentialOwners.id in (:groupIds) )  and 
-            (:userId not member of t.peopleAssignments.excludedOwners) 
+            (:userId IS NULL OR :userId NOT MEMBER OF t.peopleAssignments.excludedOwners) 
             order by t.id DESC     
         </query>
         <!-- hint name="org.hibernate.timeout" value="200"/ -->
@@ -470,9 +487,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and
@@ -480,7 +498,7 @@
             (t.taskData.actualOwner.id = :userId or t.taskData.actualOwner is null) and 
             t.taskData.status in ('Created', 'Ready', 'Reserved', 'InProgress', 'Suspended') and 
             (potentialOwners.id = :userId or potentialOwners.id in (:groupIds)) and 
-            (:userId not member of t.peopleAssignments.excludedOwners) 
+            (:userId IS NULL OR :userId NOT MEMBER OF t.peopleAssignments.excludedOwners) 
             order by t.id DESC
         </query>
         <!-- hint name="org.hibernate.timeout" value="200"/ -->
@@ -505,10 +523,9 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
-            TaskImpl t,
-            OrganizationalEntityImpl potentialOwners
+            TaskImpl t left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
             t.archived = 0 and
             t.taskData.parentId = :parentId and
@@ -538,9 +555,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.recipients recipients
             where
             t.archived = 0 and
@@ -568,9 +586,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.taskInitiator taskInitiators
             where
             t.archived = 0 and
@@ -598,9 +617,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.taskStakeholders taskStakeholders
             where
             t.archived = 0 and
@@ -629,10 +649,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
-    
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
             t.archived = 0 and
             t.taskData.actualOwner.id = :userId 
@@ -662,9 +682,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t 
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             left join t.peopleAssignments.potentialOwners potOwners
             where
             t.archived = 0 and          
@@ -696,10 +717,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t 
-    
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             left join t.peopleAssignments.potentialOwners potOwners
             where
             t.archived = 0 and
@@ -731,9 +752,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t 
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             left join t.peopleAssignments.potentialOwners potOwners
             where
             t.archived = 0 and          
@@ -770,9 +792,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
                 TaskImpl t 
+                left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             
             where
             t.archived = 0 and
@@ -800,10 +823,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t 
-            
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
             t.archived = 0 and
             t.taskData.status = :status and
@@ -834,9 +857,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t 
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
             t.archived = 1
 
@@ -864,10 +888,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t 
-    
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
             t.archived = 0 and          
             t.taskData.actualOwner.id = :userId and
@@ -899,10 +923,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t 
-    
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
             t.id in (:taskIds)  
             order by t.id DESC
@@ -1084,10 +1108,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t 
-            
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
             t.archived = 0 and
             t.taskData.processInstanceId = :processInstanceId and
@@ -1116,10 +1140,10 @@
                 t.taskData.processInstanceId,
                 t.taskData.parentId,
                 t.taskData.deploymentId,
-                t.taskData.skipable              )
+                t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
-            
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
             t.archived = 0 and
             t.taskData.processInstanceId = :processInstanceId and
@@ -1179,16 +1203,17 @@
             t.taskData.processInstanceId,
             t.taskData.parentId,
             t.taskData.deploymentId,
-            t.taskData.skipable              )
+            t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and
             (t.taskData.actualOwner.id = :userId or t.taskData.actualOwner is null) and 
             t.taskData.status in (:status) and 
             ( potentialOwners.id = :userId or potentialOwners.id in (:groupIds) ) and 
-            (:userId not member of t.peopleAssignments.excludedOwners) 
+            (:userId IS NULL OR :userId NOT MEMBER OF t.peopleAssignments.excludedOwners) 
             order by t.id DESC          
         </query>
         <!-- hint name="org.hibernate.timeout" value="200"/ -->
@@ -1217,9 +1242,10 @@
             t.taskData.processInstanceId,
             t.taskData.parentId,
             t.taskData.deploymentId,
-            t.taskData.skipable              )
+            t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and            
@@ -1227,7 +1253,7 @@
             (t.taskData.expirationTime = :expirationDate or t.taskData.expirationTime is null) and
             t.taskData.status in (:status) and 
             ( potentialOwners.id = :userId or potentialOwners.id in (:groupIds) ) and 
-            (:userId not member of t.peopleAssignments.excludedOwners) 
+            (:userId IS NULL OR :userId NOT MEMBER OF t.peopleAssignments.excludedOwners) 
             order by t.id DESC     
         </query>
         <!-- hint name="org.hibernate.timeout" value="200"/ -->
@@ -1252,9 +1278,10 @@
             t.taskData.processInstanceId,
             t.taskData.parentId,
             t.taskData.deploymentId,
-            t.taskData.skipable              )
+            t.taskData.skipable, plog.correlationKey, plog.processType)
             from
             TaskImpl t
+            left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and            
@@ -1262,7 +1289,7 @@
             t.taskData.expirationTime = :expirationDate and
             t.taskData.status in (:status) and 
             ( potentialOwners.id = :userId or potentialOwners.id in (:groupIds) )  and 
-            (:userId not member of t.peopleAssignments.excludedOwners) 
+            (:userId IS NULL OR :userId NOT MEMBER OF t.peopleAssignments.excludedOwners) 
             order by t.id DESC
         </query>
         <!-- hint name="org.hibernate.timeout" value="200"/ -->
@@ -1287,16 +1314,17 @@
                     t.taskData.processInstanceId,
                     t.taskData.parentId,
                     t.taskData.deploymentId,
-                    t.taskData.skipable               )
+                    t.taskData.skipable, plog.correlationKey, plog.processType )
             from
                 TaskImpl t
+                left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
                 join t.peopleAssignments.potentialOwners potentialOwners
             where
                 t.archived = 0 and
                 (t.taskData.actualOwner.id = :userId or t.taskData.actualOwner is null) and
                 t.taskData.status in (:status) and 
                 (potentialOwners.id  = :userId or potentialOwners.id in (:groupIds)) and 
-                (:userId not member of t.peopleAssignments.excludedOwners)           
+                (:userId IS NULL OR :userId NOT MEMBER OF t.peopleAssignments.excludedOwners)           
             order by t.id DESC    
         </query>
         <!-- hint name="org.hibernate.timeout" value="200"/ -->
@@ -1321,9 +1349,10 @@
                     t.taskData.processInstanceId,
                     t.taskData.parentId,
                     t.taskData.deploymentId,
-                    t.taskData.skipable              )
+                    t.taskData.skipable, plog.correlationKey, plog.processType)
             from
                 TaskImpl t
+                left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
                 join t.peopleAssignments.potentialOwners potentialOwners
             where
             t.archived = 0 and            
@@ -1331,7 +1360,7 @@
             (t.taskData.expirationTime = :expirationDate or t.taskData.expirationTime is null) and
             t.taskData.status in (:status) and 
             ( potentialOwners.id = :userId or potentialOwners.id in (:groupIds) )  and 
-            (:userId not member of t.peopleAssignments.excludedOwners) 
+            (:userId IS NULL OR :userId NOT MEMBER OF t.peopleAssignments.excludedOwners) 
             order by t.id DESC     
         </query>
         <!-- hint name="org.hibernate.timeout" value="200"/ -->
@@ -1355,9 +1384,10 @@
                     t.taskData.processInstanceId,
                     t.taskData.parentId,
                     t.taskData.deploymentId,
-                    t.taskData.skipable              )
+                    t.taskData.skipable, plog.correlationKey, plog.processType)
             from
                 TaskImpl t
+                left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
                 join t.peopleAssignments.potentialOwners potentialOwners
             where
                 t.archived = 0 and
@@ -1365,7 +1395,7 @@
                 t.taskData.expirationTime = :expirationDate and
                 t.taskData.status in (:status) and 
 	            ( potentialOwners.id = :userId or potentialOwners.id in (:groupIds) )  and 
-                (:userId not member of t.peopleAssignments.excludedOwners) 
+                (:userId IS NULL OR :userId NOT MEMBER OF t.peopleAssignments.excludedOwners) 
                 order by t.id DESC
         </query>
         <!-- hint name="org.hibernate.timeout" value="200"/ -->
@@ -1389,9 +1419,10 @@
                     t.taskData.processInstanceId,
                     t.taskData.parentId,
                     t.taskData.deploymentId,
-                    t.taskData.skipable              )
+                    t.taskData.skipable, plog.correlationKey, plog.processType)
             from
                 TaskImpl t
+                left join ProcessInstanceLog plog ON t.taskData.processInstanceId = plog.processInstanceId
             where
                 t.archived = 0 and
                 t.taskData.actualOwner.id = :userId and

--- a/kie-osgi/kie-karaf-itests/src/test/resources/org.apache.karaf.features.xml
+++ b/kie-osgi/kie-karaf-itests/src/test/resources/org.apache.karaf.features.xml
@@ -2,16 +2,24 @@
 <featuresProcessing xmlns="http://karaf.apache.org/xmlns/features-processing/v1.0.0">
 
     <blacklistedRepositories>
-        <repository>mvn:org.apache.cxf.karaf/apache-cxf/[3.3,*)/xml/features</repository>
-        <repository>mvn:org.apache.camel.karaf/apache-camel/[2.22.0,*)/xml/features</repository>
+        <repository>mvn:org.apache.cxf.karaf/apache-cxf/[3.4,*)/xml/features</repository>
+        <repository>mvn:org.apache.camel.karaf/apache-camel/[2.25.0,*)/xml/features</repository>
     </blacklistedRepositories>
 
     <!-- A list of blacklisted feature identifiers that can't be installed in Karaf and are not part of the distribution -->
     <blacklistedFeatures>
-        <feature version="[3,4.3)">spring*</feature>
-        <feature version="[4.4,*)">spring*</feature>
-        <feature version="[3.3,*)">cxf*</feature>
+        <feature version="[3,4.5)">spring*</feature>
+        <feature version="[3.4,*)">cxf*</feature>
         <feature version="[4,4.3)">aries-blueprint-spring</feature>
     </blacklistedFeatures>
+
+    <blacklistedBundles>
+        <bundle>mvn:javax.servlet/javax.servlet-api/[3,4)</bundle>
+    </blacklistedBundles>
+
+    <bundleReplacements>
+        <bundle originalUri="mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javax-websocket-api/[1,2)"
+                replacement="mvn:javax.websocket/javax.websocket-api/1.1" mode="maven" />
+    </bundleReplacements>
 
 </featuresProcessing>

--- a/kie-osgi/kie-osgi-integration/src/main/java/org/kie/osgi/compiler/OsgiKieModule.java
+++ b/kie-osgi/kie-osgi-integration/src/main/java/org/kie/osgi/compiler/OsgiKieModule.java
@@ -161,7 +161,13 @@ public class OsgiKieModule extends AbstractKieModule {
     public static String parseBundleId(String url) {
         if (isOsgiBundleUrl(url)) {
             int slashesIdx = url.indexOf("://");
-            return url.substring(slashesIdx + "://".length(), url.indexOf('.'));
+            int underscoreIdx = url.indexOf("_", slashesIdx + "://".length());
+            if (underscoreIdx >= 0) {
+                // special format for OSGi Core R7 (bundle://<uuid>_<id>.n:m/)
+                return url.substring(underscoreIdx + 1, url.indexOf('.'));
+            } else {
+                return url.substring(slashesIdx + "://".length(), url.indexOf('.'));
+            }
         } else {
             return null;
         }

--- a/kie-osgi/kie-osgi-servlet3-compatibility/pom.xml
+++ b/kie-osgi/kie-osgi-servlet3-compatibility/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.kie</groupId>
     <artifactId>kie-osgi</artifactId>
-    <version>7.60.0-SNAPSHOT</version>
+    <version>7.59.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>kie-osgi-servlet3-compatibility</artifactId>

--- a/kie-osgi/kie-osgi-servlet3-compatibility/pom.xml
+++ b/kie-osgi/kie-osgi-servlet3-compatibility/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.kie</groupId>
+    <artifactId>kie-osgi</artifactId>
+    <version>7.60.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>kie-osgi-servlet3-compatibility</artifactId>
+  <packaging>bundle</packaging>
+
+  <name>KIE :: OSGi Integration :: Servlet API 3.1 compatibility</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <configuration>
+          <instructions>
+            <Fragment-Host>jakarta.servlet-api</Fragment-Host>
+            <Export-Package>
+              javax.servlet;version="3.1.0";uses:="javax.servlet.annotation,javax.servlet.descriptor",
+              javax.servlet.annotation;version="3.1.0";uses:="javax.servlet",
+              javax.servlet.http;version="3.1.0";uses:="javax.servlet",
+              javax.servlet.descriptor;version="3.1.0"
+            </Export-Package>
+          </instructions>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/kie-osgi/pom.xml
+++ b/kie-osgi/pom.xml
@@ -26,6 +26,7 @@
   <modules>
     <module>kie-karaf-itests-domain-model</module>
     <module>kie-osgi-integration</module>
+    <module>kie-osgi-servlet3-compatibility</module>
     <module>kie-karaf-features</module>
     <module>kie-karaf-itests</module>
   </modules>


### PR DESCRIPTION
…tests ... (#2588)

The changes can be summarized:
* there's special kie-osgi-servlet3-compatibility bundle fragment
  provided to handle Servlet API 3/4 OSGi problems
* I've changed dbcp to dbcp2 in "h2" feature to be able to set proper
  ClassLoader to load H2 driver
* droolsjbpm-hibernate no longer needs to "wrap:" hibernate bundles -
  Entity classes should *always* be loaded from the EMF bundle and
  required imports are added in
  KieBlueprintjBPMPersistenceKarafIntegrationTest#getDefaultOptions()
* I've copied changed version of Taskorm.xml from JBPM to reflect model
  changes
* OsgiKieModule can now deal with changed bundle: URI from Felix 6 (OSGi
  Core R7)

(cherry picked from commit 298c727b5023a168d72aa25b00216fa3225a3487)

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
