### PR TITLE
[7.59.x][JBPM-9885] QueryDataServiceIntegrationTest tests are failing due to removal of end_date column

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/QueryDataServiceIntegrationTest.java
@@ -415,7 +415,7 @@ public class QueryDataServiceIntegrationTest extends JbpmKieServerBaseIntegratio
             assertEquals(query.getExpression(), replaced.getExpression());
             assertEquals(query.getTarget(), replaced.getTarget());
             assertNotNull(replaced.getColumns());
-            assertEquals(replaced.getColumns().size(), 19);
+            assertEquals(replaced.getColumns().size(), 18);
 
             tasks = queryClient.query(query.getName(), QueryServicesClient.QUERY_MAP_TASK, 0, 10, TaskInstance.class);
             assertNotNull(tasks);


### PR DESCRIPTION
Backport of https://github.com/kiegroup/droolsjbpm-integration/pull/2592