### PR TITLE
[DROOLS-6407] Fix missing droolsjbpm-integration Wording

### DIFF
--- a/droolsjbpm-integration-distribution/src/main/assembly/filtered-resources/ReadMeDroolsJbpmIntegration.txt
+++ b/droolsjbpm-integration-distribution/src/main/assembly/filtered-resources/ReadMeDroolsJbpmIntegration.txt
@@ -57,4 +57,4 @@ The source jars are in the sources directory.
 But to build from sources, pull the sources with git:
   https://github.com/kiegroup
 and follow these instructions:
-  https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/master/README.md
+  https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/main/README.md


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

https://issues.redhat.com/browse/DROOLS-6407

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
