### PR TITLE
[JBPM-9882] Adding actual owner to TaskEvent

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/TaskEventInstance.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/instance/TaskEventInstance.java
@@ -58,9 +58,8 @@ public class TaskEventInstance {
     @XmlElement(name = "process-type")
     private Integer processType;
 
-
-    public TaskEventInstance() {
-    }
+    @XmlElement(name = "assigned-owner")
+    private String assignedOwner;
 
     public static Builder builder() {
         return new Builder();
@@ -150,10 +149,18 @@ public class TaskEventInstance {
         this.message = message;
     }
 
+    public String getAssignedOwner() {
+        return assignedOwner;
+    }
+
+    public void setAssignedOwner(String actualOwner) {
+        this.assignedOwner = actualOwner;
+    }
+
     @Override
     public String toString() {
         return "TaskEventInstance [id=" + id + ", taskId=" + taskId + ", type=" + type + ", userId=" + userId + ", logTime=" + logTime + ", processInstanceId=" + processInstanceId + ", workItemId=" + workItemId +
-               ", message=" + message + ", correlationKey=" + correlationKey + ", processType=" + processType + "]";
+               ", message=" + message + ", correlationKey=" + correlationKey + ", processType=" + processType + ", actualOwner=" + assignedOwner + "]";
     }
 
     public static class Builder {
@@ -211,6 +218,11 @@ public class TaskEventInstance {
 
         public Builder message(String message) {
             taskEventInstance.setMessage(message);
+            return this;
+        }
+        
+        public Builder assignedOwner (String actualOwner) {
+            taskEventInstance.setAssignedOwner(actualOwner);
             return this;
         }
     }

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/RuntimeDataServiceBase.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/RuntimeDataServiceBase.java
@@ -15,6 +15,30 @@
 
 package org.kie.server.services.jbpm;
 
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.jbpm.services.api.AdvanceRuntimeDataService.TASK_ATTR_NAME;
+import static org.jbpm.services.api.AdvanceRuntimeDataService.TASK_ATTR_OWNER;
+import static org.jbpm.services.api.AdvanceRuntimeDataService.TASK_ATTR_STATUS;
+import static org.jbpm.services.api.query.model.QueryParam.all;
+import static org.kie.server.services.jbpm.ConvertUtils.buildQueryContext;
+import static org.kie.server.services.jbpm.ConvertUtils.buildQueryFilter;
+import static org.kie.server.services.jbpm.ConvertUtils.buildTaskByNameQueryFilter;
+import static org.kie.server.services.jbpm.ConvertUtils.buildTaskStatuses;
+import static org.kie.server.services.jbpm.ConvertUtils.convertToNodeInstance;
+import static org.kie.server.services.jbpm.ConvertUtils.convertToNodeInstanceList;
+import static org.kie.server.services.jbpm.ConvertUtils.convertToProcess;
+import static org.kie.server.services.jbpm.ConvertUtils.convertToProcessInstance;
+import static org.kie.server.services.jbpm.ConvertUtils.convertToProcessInstanceCustomVarsList;
+import static org.kie.server.services.jbpm.ConvertUtils.convertToProcessInstanceList;
+import static org.kie.server.services.jbpm.ConvertUtils.convertToProcessList;
+import static org.kie.server.services.jbpm.ConvertUtils.convertToServiceApiQueryParam;
+import static org.kie.server.services.jbpm.ConvertUtils.convertToTask;
+import static org.kie.server.services.jbpm.ConvertUtils.convertToTaskSummaryList;
+import static org.kie.server.services.jbpm.ConvertUtils.convertToUserTaskWithVariablesList;
+import static org.kie.server.services.jbpm.ConvertUtils.convertToVariablesList;
+import static org.kie.server.services.jbpm.ConvertUtils.nullEmpty;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -63,30 +87,6 @@ import org.kie.server.services.impl.locator.ContainerLocatorProvider;
 import org.kie.server.services.impl.marshal.MarshallerHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static java.util.Arrays.asList;
-import static java.util.stream.Collectors.toList;
-import static org.jbpm.services.api.AdvanceRuntimeDataService.TASK_ATTR_NAME;
-import static org.jbpm.services.api.AdvanceRuntimeDataService.TASK_ATTR_OWNER;
-import static org.jbpm.services.api.AdvanceRuntimeDataService.TASK_ATTR_STATUS;
-import static org.jbpm.services.api.query.model.QueryParam.all;
-import static org.kie.server.services.jbpm.ConvertUtils.buildQueryContext;
-import static org.kie.server.services.jbpm.ConvertUtils.buildQueryFilter;
-import static org.kie.server.services.jbpm.ConvertUtils.buildTaskByNameQueryFilter;
-import static org.kie.server.services.jbpm.ConvertUtils.buildTaskStatuses;
-import static org.kie.server.services.jbpm.ConvertUtils.convertToNodeInstance;
-import static org.kie.server.services.jbpm.ConvertUtils.convertToNodeInstanceList;
-import static org.kie.server.services.jbpm.ConvertUtils.convertToProcess;
-import static org.kie.server.services.jbpm.ConvertUtils.convertToProcessInstance;
-import static org.kie.server.services.jbpm.ConvertUtils.convertToProcessInstanceCustomVarsList;
-import static org.kie.server.services.jbpm.ConvertUtils.convertToProcessInstanceList;
-import static org.kie.server.services.jbpm.ConvertUtils.convertToProcessList;
-import static org.kie.server.services.jbpm.ConvertUtils.convertToServiceApiQueryParam;
-import static org.kie.server.services.jbpm.ConvertUtils.convertToTask;
-import static org.kie.server.services.jbpm.ConvertUtils.convertToTaskSummaryList;
-import static org.kie.server.services.jbpm.ConvertUtils.convertToUserTaskWithVariablesList;
-import static org.kie.server.services.jbpm.ConvertUtils.convertToVariablesList;
-import static org.kie.server.services.jbpm.ConvertUtils.nullEmpty;
 
 public class RuntimeDataServiceBase {
 
@@ -603,6 +603,7 @@ public class RuntimeDataServiceBase {
                         .message(taskSummary.getMessage())
                         .correlationKey(taskSummary.getCorrelationKey())
                         .processType(taskSummary.getProcessType())
+                        .assignedOwner(taskSummary.getCurrentOwner())
                         .build();
                 instances[counter] = task;
                 counter++;

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RuntimeDataServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/RuntimeDataServiceIntegrationTest.java
@@ -15,6 +15,23 @@
 
 package org.kie.server.integrationtests.jbpm;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.jbpm.services.api.AdvanceRuntimeDataService.PROCESS_ATTR_DEFINITION_ID;
+import static org.jbpm.services.api.AdvanceRuntimeDataService.PROCESS_ATTR_DEPLOYMENT_ID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
+import static org.kie.server.api.util.QueryParamFactory.equalsTo;
+import static org.kie.server.api.util.QueryParamFactory.history;
+import static org.kie.server.api.util.QueryParamFactory.list;
+import static org.kie.server.api.util.QueryParamFactory.onlyActiveTasks;
+import static org.kie.server.api.util.QueryParamFactory.onlyCompletedTasks;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -54,23 +71,6 @@ import org.kie.server.integrationtests.category.Smoke;
 import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.integrationtests.shared.KieServerAssert;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.jbpm.services.api.AdvanceRuntimeDataService.PROCESS_ATTR_DEFINITION_ID;
-import static org.jbpm.services.api.AdvanceRuntimeDataService.PROCESS_ATTR_DEPLOYMENT_ID;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
-import static org.kie.server.api.util.QueryParamFactory.equalsTo;
-import static org.kie.server.api.util.QueryParamFactory.history;
-import static org.kie.server.api.util.QueryParamFactory.list;
-import static org.kie.server.api.util.QueryParamFactory.onlyActiveTasks;
-import static org.kie.server.api.util.QueryParamFactory.onlyCompletedTasks;
 
 
 
@@ -1462,6 +1462,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
                     .type(TaskEvent.TaskEventType.ADDED.toString())
                     .processInstanceId(processInstanceId)
                     .taskId(taskInstance.getId())
+                    .assignedOwner("pepe")
                     .user(PROCESS_ID_USERTASK)      // is this really correct to set process id as user for added task
                     .build();
 
@@ -1959,6 +1960,7 @@ public class RuntimeDataServiceIntegrationTest extends JbpmKieServerBaseIntegrat
         assertEquals(expected.getProcessInstanceId(), actual.getProcessInstanceId());
         assertEquals(expected.getTaskId(), actual.getTaskId());
         assertEquals(expected.getUserId(), actual.getUserId());
+        assertEquals(expected.getAssignedOwner(), actual.getAssignedOwner());
         assertNotNull(actual.getId());
         assertNotNull(actual.getLogTime());
         assertNotNull(actual.getWorkItemId());


### PR DESCRIPTION
With this addition, code retrieving the event can determine which
was the actual owner after the operation was applied.



**JIRA**:

[link](https://issues.redhat.com/browse/JBPM-9882)

**referenced Pull Requests**: 
https://github.com/kiegroup/droolsjbpm-knowledge/pull/548