### PR TITLE
[7.59.x] [DROOLS-6650] kie-karaf-itests test failures in 7.59.x

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-client/pom.xml
+++ b/kie-server-parent/kie-server-remote/kie-server-client/pom.xml
@@ -162,6 +162,10 @@
               com.thoughtworks.xstream;resolution:=optional,
               org.xmlpull;resolution:=optional,
               javax.security.jacc;resolution:=optional,
+              org.wildfly.security.auth.server;resolution:=optional,
+              org.wildfly.security.credential;resolution:=optional,
+              org.wildfly.security.password;resolution:=optional,
+              org.wildfly.security.password.interfaces;resolution:=optional,
               *
             </Import-Package>
           </instructions>


### PR DESCRIPTION
Import-Package is required by https://github.com/kiegroup/droolsjbpm-integration/commit/00319c16f0def406f050b6744756b528755e502d

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-6650

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
