### PR TITLE
[7.59.x] [JBPM-9908] Exclude webservice tests for WAS and WLS

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/category/WildflyOnly.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/category/WildflyOnly.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.kie.server.integrationtests.category;
+
+public interface WildflyOnly {
+}

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/WebServiceBase.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/WebServiceBase.java
@@ -20,9 +20,10 @@ import org.junit.experimental.categories.Category;
 import org.kie.api.KieServices;
 import org.kie.server.api.model.ReleaseId;
 import org.kie.server.integrationtests.category.JEEOnly;
+import org.kie.server.integrationtests.category.WildflyOnly;
 import org.kie.server.integrationtests.shared.KieServerDeployer;
 
-@Category({JEEOnly.class})
+@Category({JEEOnly.class, WildflyOnly.class})
 public class WebServiceBase extends JbpmKieServerBaseIntegrationTest {
 
     private static ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "webservice-project", "1.0.0.Final");

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/WebServiceHeadersDumbEscapeIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/WebServiceHeadersDumbEscapeIntegrationTest.java
@@ -15,7 +15,6 @@
 
 package org.kie.server.integrationtests.jbpm;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
@@ -24,9 +23,10 @@ import java.util.Map;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.server.integrationtests.category.JEEOnly;
+import org.kie.server.integrationtests.category.WildflyOnly;
 import org.kie.server.integrationtests.config.TestConfig;
 
-@Category({JEEOnly.class})
+@Category({JEEOnly.class, WildflyOnly.class})
 public class WebServiceHeadersDumbEscapeIntegrationTest extends WebServiceBase {
 
     @Test

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/WebServiceHeadersNoEscapeIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/WebServiceHeadersNoEscapeIntegrationTest.java
@@ -15,7 +15,6 @@
 
 package org.kie.server.integrationtests.jbpm;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
@@ -24,9 +23,10 @@ import java.util.Map;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.server.integrationtests.category.JEEOnly;
+import org.kie.server.integrationtests.category.WildflyOnly;
 import org.kie.server.integrationtests.config.TestConfig;
 
-@Category({JEEOnly.class})
+@Category({JEEOnly.class, WildflyOnly.class})
 public class WebServiceHeadersNoEscapeIntegrationTest extends WebServiceBase {
 
     @Test

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/WebServiceHeadersNoEscapeNoMatchIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/WebServiceHeadersNoEscapeNoMatchIntegrationTest.java
@@ -15,7 +15,6 @@
 
 package org.kie.server.integrationtests.jbpm;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
@@ -24,9 +23,10 @@ import java.util.Map;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.server.integrationtests.category.JEEOnly;
+import org.kie.server.integrationtests.category.WildflyOnly;
 import org.kie.server.integrationtests.config.TestConfig;
 
-@Category({JEEOnly.class})
+@Category({JEEOnly.class, WildflyOnly.class})
 public class WebServiceHeadersNoEscapeNoMatchIntegrationTest extends WebServiceBase {
 
     @Test

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/WebServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/WebServiceIntegrationTest.java
@@ -25,9 +25,10 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.integrationtests.category.JEEOnly;
+import org.kie.server.integrationtests.category.WildflyOnly;
 import org.kie.server.integrationtests.config.TestConfig;
 
-@Category({JEEOnly.class})
+@Category({JEEOnly.class, WildflyOnly.class})
 public class WebServiceIntegrationTest extends WebServiceBase {
 
     protected static final String PROCESS_ID_WS = "org.specialtripsagency.specialtripsagencyprocess";

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/WebServiceWrappedParamsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/WebServiceWrappedParamsIntegrationTest.java
@@ -20,17 +20,13 @@ import static org.junit.Assert.assertEquals;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.kie.api.KieServices;
-import org.kie.server.api.model.ReleaseId;
-import org.kie.server.api.model.instance.ProcessInstance;
 import org.kie.server.integrationtests.category.JEEOnly;
+import org.kie.server.integrationtests.category.WildflyOnly;
 import org.kie.server.integrationtests.config.TestConfig;
-import org.kie.server.integrationtests.shared.KieServerDeployer;
 
-@Category({JEEOnly.class})
+@Category({JEEOnly.class, WildflyOnly.class})
 public class WebServiceWrappedParamsIntegrationTest extends WebServiceBase {
 
     protected static final String PROCESS_ID_WRAPPED_WS = "org.specialtripsagency.travelAgencyWrappedParamsProcess";

--- a/kie-server-parent/kie-server-tests/pom.xml
+++ b/kie-server-parent/kie-server-tests/pom.xml
@@ -1105,7 +1105,7 @@
         <kie.server.connection.factory>jms/cf/KIE.SERVER.REQUEST</kie.server.connection.factory>
         <org.kie.server.persistence.ds>jdbc/jbpm</org.kie.server.persistence.ds>
         <cargo.container.id>weblogic122x</cargo.container.id>
-        <failsafe.excluded.groups>org.kie.server.integrationtests.category.Email,org.kie.server.integrationtests.category.Transactional</failsafe.excluded.groups>
+        <failsafe.excluded.groups>org.kie.server.integrationtests.category.Email,org.kie.server.integrationtests.category.Transactional,org.kie.server.integrationtests.category.WildflyOnly</failsafe.excluded.groups>
         <kie.server.classifier>ee7</kie.server.classifier>
         <kie.server.war.path>${org.kie.server:kie-server:war:ee7}</kie.server.war.path>
         <!-- Enable integration tests and Cargo when running with application server. -->
@@ -1235,7 +1235,7 @@
         <org.kie.server.persistence.ds>jdbc/jbpm</org.kie.server.persistence.ds>
         <kie.server.classifier>ee7</kie.server.classifier>
         <cargo.container.id>websphere9x</cargo.container.id>
-        <failsafe.excluded.groups>org.kie.server.integrationtests.category.Email,org.kie.server.integrationtests.category.RemotelyControlled,org.kie.server.integrationtests.category.Transactional</failsafe.excluded.groups>
+        <failsafe.excluded.groups>org.kie.server.integrationtests.category.Email,org.kie.server.integrationtests.category.RemotelyControlled,org.kie.server.integrationtests.category.Transactional,org.kie.server.integrationtests.category.WildflyOnly</failsafe.excluded.groups>
         <kie.server.war.path>${org.kie.server:kie-server:war:ee7}</kie.server.war.path>
         <!-- Enable integration tests and Cargo when running with application server. -->
         <skipITs>false</skipITs>


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

**Thank you for submitting this pull request**

**JIRA**: [JBPM-9908](https://issues.redhat.com/browse/JBPM-9908)

https://github.com/kiegroup/droolsjbpm-integration/pull/2616

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
