### PR TITLE
[7.59.x] AF-2880: Use Elytron user group callback just if available

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/JbpmKieServerExtension.java
@@ -122,6 +122,7 @@ import org.kie.server.services.api.KieServerExtension;
 import org.kie.server.services.api.KieServerRegistry;
 import org.kie.server.services.api.SupportedTransports;
 import org.kie.server.services.impl.KieServerImpl;
+import org.kie.server.services.impl.security.ElytronIdentityProvider;
 import org.kie.server.services.jbpm.admin.ProcessAdminServiceBase;
 import org.kie.server.services.jbpm.admin.UserTaskAdminServiceBase;
 import org.kie.server.services.jbpm.jpa.PersistenceUnitExtensionsLoader;
@@ -222,12 +223,17 @@ public class JbpmKieServerExtension implements KieServerExtension {
         // loaded from system property as callback info isn't stored as configuration in kie server repository
         String callbackConfig = System.getProperty(KieServerConstants.CFG_HT_CALLBACK);
 
-        // if no other callback set, use jaas by default
+        // if no other callback set, use Elytron or jaas by default
         if (callbackConfig == null || callbackConfig.isEmpty()) {
-            System.setProperty(KieServerConstants.CFG_HT_CALLBACK, "custom");
-            String name = ElytronUserGroupCallbackImpl.class.getName();
-            ElytronUserGroupCallbackImpl.addExternalUserGroupAdapter(new JMSUserGroupAdapter());
-            System.setProperty(KieServerConstants.CFG_HT_CALLBACK_CLASS, name);
+            if (ElytronIdentityProvider.available()) {
+                System.setProperty(KieServerConstants.CFG_HT_CALLBACK, "custom");
+                String name = ElytronUserGroupCallbackImpl.class.getName();
+                ElytronUserGroupCallbackImpl.addExternalUserGroupAdapter(new JMSUserGroupAdapter());
+                System.setProperty(KieServerConstants.CFG_HT_CALLBACK_CLASS, name);
+            } else {
+                System.setProperty(KieServerConstants.CFG_HT_CALLBACK, "jaas");
+                JAASUserGroupCallbackImpl.addExternalUserGroupAdapter(new JMSUserGroupAdapter());
+            }
         }
 
         this.isExecutorAvailable = isExecutorOnClasspath();


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

**Thank you for submitting this pull request**

**JIRA**: [AF-2880](https://issues.redhat.com/browse/AF-2880)

**referenced Pull Requests**: 

* https://github.com/kiegroup/droolsjbpm-integration/pull/2628

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
