### PR TITLE
[7.59.x] Kie server: Introduce timeout for Kie server startup tests

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/WebSocketKieControllerStartupIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/WebSocketKieControllerStartupIntegrationTest.java
@@ -126,7 +126,7 @@ public class WebSocketKieControllerStartupIntegrationTest extends KieControllerM
         }
     }
 
-    @Test
+    @Test(timeout = 60 * 1000)
     public void testRegisterKieServerAfterStartup() throws Exception {
         // Turn off embedded kie server.
         server.stopKieServer();
@@ -156,7 +156,7 @@ public class WebSocketKieControllerStartupIntegrationTest extends KieControllerM
         assertEquals(reply.getResult().getServerId(), deployedServerInstance.getId());
     }
 
-    @Test
+    @Test(timeout = 60 * 1000)
     public void testTurnOffKieServerAfterShutdown() throws Exception {
         // Register kie server in controller.
         ServiceResponse<KieServerInfo> kieServerInfo = client.getServerInfo();
@@ -181,7 +181,7 @@ public class WebSocketKieControllerStartupIntegrationTest extends KieControllerM
         assertEquals(kieServerInfo.getResult().getServerId(), instanceList.getServerTemplates()[0].getId()); //maybe change to avoid next -> null
     }
 
-    @Test
+    @Test(timeout = 60 * 1000)
     public void testContainerCreatedAfterStartup() throws Exception {
         // Getting info from currently started kie server.
         ServiceResponse<KieServerInfo> kieServerInfo = client.getServerInfo();


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

**Thank you for submitting this pull request**

https://github.com/kiegroup/droolsjbpm-integration/pull/2630

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
