### PR TITLE
[7.59.x] Skip unstable Kie server tests

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerValidationIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerValidationIntegrationTest.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.kie.server.api.KieServerConstants;
 import org.kie.server.api.KieServerEnvironment;
 import org.kie.server.api.model.KieServerConfig;
@@ -31,6 +32,7 @@ import org.kie.server.controller.api.model.runtime.ServerInstanceKeyList;
 import org.kie.server.controller.api.model.spec.Capability;
 import org.kie.server.controller.api.model.spec.ServerTemplate;
 import org.kie.server.controller.api.model.spec.ServerTemplateList;
+import org.kie.server.integrationtests.category.UnstableOnJenkinsPrBuilder;
 import org.kie.server.integrationtests.config.TestConfig;
 import org.kie.server.services.api.KieControllerNotConnectedException;
 import org.kie.server.services.api.KieServerRegistry;
@@ -85,6 +87,8 @@ public class KieControllerValidationIntegrationTest extends KieControllerManagem
     }
 
     @Test
+    //Added to UnstableOnJenkinsPrBuilder to avoid random failures/timeouts on Jenkins builds
+    @Category({UnstableOnJenkinsPrBuilder.class})
     public void testBadRegistered() throws Exception {
         final String SERVER_TEMPLATE_ID = "test.mode.bad";
         final String SERVER_NAME = "server-name";
@@ -120,6 +124,8 @@ public class KieControllerValidationIntegrationTest extends KieControllerManagem
     }
 
     @Test
+    //Added to UnstableOnJenkinsPrBuilder to avoid random failures/timeouts on Jenkins builds
+    @Category({UnstableOnJenkinsPrBuilder.class})
     public void testGoodRegistered() throws Exception {
         final String SERVER_TEMPLATE_ID = "test.mode.ok";
         final String SERVER_NAME = "server-name";


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

**Thank you for submitting this pull request**

**referenced Pull Requests**: https://github.com/kiegroup/droolsjbpm-integration/pull/2632

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
