### PR TITLE
[RHPAM-3988] Make the kieservice client timeout value configurable in RestKieServicesClientProvider used by controller

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
@@ -91,6 +91,7 @@ public class KieServerConstants {
     public static final String CFG_KIE_CONTROLLER_USER = "org.kie.server.controller.user";
     public static final String CFG_KIE_CONTROLLER_PASSWORD = "org.kie.server.controller.pwd";
     public static final String CFG_KIE_CONTROLLER_TOKEN = "org.kie.server.controller.token";
+    public static final String CFG_KIE_CONTROLLER_TIMEOUT = "org.kie.server.controller.timeout";
 
     // non kie server parameters but used by its extensions etc
     public static final String CFG_HT_CALLBACK = "org.jbpm.ht.callback";

--- a/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/client/RestKieServicesClientProvider.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-impl/src/main/java/org/kie/server/controller/impl/client/RestKieServicesClientProvider.java
@@ -33,7 +33,7 @@ public class RestKieServicesClientProvider implements KieServicesClientProvider 
     @Override
     public KieServicesClient get(String url) {
         KieServicesConfiguration configuration = KieServicesFactory.newRestConfiguration(url, getUser(), getPassword());
-        configuration.setTimeout(60000);
+        configuration.setTimeout(getTimeout());
 
         configuration.setMarshallingFormat(MarshallingFormat.JSON);
 
@@ -58,6 +58,14 @@ public class RestKieServicesClientProvider implements KieServicesClientProvider 
 
     protected String getToken() {
         return System.getProperty(KieServerConstants.CFG_KIE_TOKEN);
+    }
+
+    protected Long getTimeout()  {
+        try {
+           return Long.parseLong(System.getProperty(KieServerConstants.CFG_KIE_CONTROLLER_TIMEOUT, "60000"));
+        } catch (NumberFormatException ex) {
+           throw new RuntimeException("An invalid value is specified for system property "+KieServerConstants.CFG_KIE_CONTROLLER_TIMEOUT, ex);
+        }
     }
 
     @Override


### PR DESCRIPTION
[link](https://issues.redhat.com/browse/RHPAM-3988)
