### PR TITLE
fix GenerateANCMojo wrong CompiledNetworkSource import

### DIFF
--- a/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateANCMojo.java
+++ b/kie-maven-plugin/src/main/java/org/kie/maven/plugin/GenerateANCMojo.java
@@ -42,7 +42,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-import org.drools.ancompiler.CompiledNetworkSource;
+import org.drools.ancompiler.CompiledNetworkSources;
 import org.drools.ancompiler.ObjectTypeNodeCompiler;
 import org.drools.compiler.compiler.io.memory.MemoryFile;
 import org.drools.compiler.kproject.ReleaseIdImpl;
@@ -121,11 +121,11 @@ public class GenerateANCMojo extends AbstractDMNValidationAwareMojo {
             for (String kbase : kieContainer.getKieBaseNames()) {
                 InternalKnowledgeBase kieBase = (InternalKnowledgeBase) kieContainer.getKieBase(kbase);
 
-                List<CompiledNetworkSource> ancSourceFiles = ObjectTypeNodeCompiler.compiledNetworkSources(kieBase.getRete());
+                List<CompiledNetworkSources> ancSourceFiles = ObjectTypeNodeCompiler.compiledNetworkSources(kieBase.getRete());
 
                 getLog().info(String.format("Found %d generated files in Knowledge Base %s", ancSourceFiles.size(), kbase));
 
-                for (CompiledNetworkSource generatedFile : ancSourceFiles) {
+                for (CompiledNetworkSources generatedFile : ancSourceFiles) {
                     String className = toClassName(generatedFile.getSourceName());
                     classNameSourceMap.put(className, generatedFile.getSource());
                     getLog().info("Generated Alpha Network class: " + className);


### PR DESCRIPTION
**Thank you for submitting this pull request**

caused by https://github.com/kiegroup/drools/pull/3955

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
