### PR TITLE
[DROOLS-6693] upgrade to JavaParser 3.23.1

### DIFF
--- a/kie-osgi/kie-karaf-features/pom.xml
+++ b/kie-osgi/kie-karaf-features/pom.xml
@@ -84,7 +84,7 @@
     <!-- Overwrites for Fuse -->
     <fuse.version.com.h2database>1.3.168</fuse.version.com.h2database>
 
-    <karaf.version.com.github.javaparser>3.10.2</karaf.version.com.github.javaparser>
+    <karaf.version.com.github.javaparser>3.23.1</karaf.version.com.github.javaparser>
 
     <version.org.jboss.logging.jboss-logging>3.4.1.Final</version.org.jboss.logging.jboss-logging>
   </properties>


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/DROOLS-6693