### PR TITLE
[JBPM-9948] Adding Date classes support in forms

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/AbstractFormRenderer.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/AbstractFormRenderer.java
@@ -29,10 +29,10 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.LinkedHashMap;
-import java.util.Optional;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -383,10 +383,10 @@ public abstract class AbstractFormRenderer implements FormRenderer {
                         }
                         
                         // handle regular fields in the form 
-                        String fieldType = inputTypes.get(field.getCode());
+                        String fieldType = getFieldType(field);
                         if (fieldType != null) {
                                                     
-                            String jsType = getFieldType(field.getType());
+                            String jsType = getJSFieldType(field.getType());
                             
                             item.setId(field.getId());
                             item.setName(nonNull(field.getName()));
@@ -492,7 +492,31 @@ public abstract class AbstractFormRenderer implements FormRenderer {
                 .append(",");
         }        
     }
-    
+
+    private String getFieldType(FormField field) {
+        String type = inputTypes.get(field.getCode());
+        switch (type) {
+            case "documentCollection":
+            case "multipleSelector":
+            case "multipleInput":
+                return type;
+             default: 
+                 switch (field.getType()) {
+                     case "java.time.LocalDateTime":
+                     case "java.util.Date":
+                     case "java.sql.Date":
+                     case "java.sql.Timestamp":
+                         return "datetime-local";
+                     case "java.time.LocalTime":
+                         return "time";
+                     case "java.time.OffsetDateTime":
+                         return "datetime";
+                     default: 
+                         return type;
+                 }
+        }
+    }
+
     protected void handleSubForm(FormInstance topLevelForm, 
             FormField field, 
             Map<String, Object> inputs, 
@@ -552,7 +576,7 @@ public abstract class AbstractFormRenderer implements FormRenderer {
         for (TableInfo tableInfo : field.getTableInfo()) {
         
             FormField nestedField = nestedForm.getFieldByBinding(tableInfo.getProperty());
-            String jsType = getFieldType(nestedField.getType());
+            String jsType = getJSFieldType(nestedField.getType());
             tableInfo.setType(jsType);
         }
                                     
@@ -670,14 +694,14 @@ public abstract class AbstractFormRenderer implements FormRenderer {
         jsonTemplate.append("'")
                     .append(name)
                     .append("' : ")
-                    .append(getFieldType(type))
+                    .append(getJSFieldType(type))
                     .append(appendExtractionExpression(type, name, id, jsType))
                     .append(wrapEndFieldType(type))
                     .append(",");
 
     }
 
-    protected String getFieldType(String type) {
+    protected String getJSFieldType(String type) {
 
         if (type.contains("Integer") || type.contains("Double") || type.contains("Float")) {
             return "Number(";

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/FormReader.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/FormReader.java
@@ -18,6 +18,9 @@ package org.kie.server.services.jbpm.ui.form.render;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Map;
 
@@ -27,6 +30,9 @@ import org.kie.server.services.jbpm.ui.form.render.model.LayoutRow;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
 public class FormReader {
 
@@ -34,8 +40,11 @@ public class FormReader {
     
     
     public FormReader() {
+        final String pattern = "yyyy-MM-dd";
         this.mapper = new ObjectMapper();
-        this.mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        JavaTimeModule module = new JavaTimeModule();
+        module.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(DateTimeFormatter.ofPattern(pattern)));
+        mapper.registerModule(module).configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false).setDateFormat(new SimpleDateFormat(pattern));
     }
     
     public FormInstance readFromString(String formStructure) {

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/FormReader.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/FormReader.java
@@ -19,8 +19,6 @@ package org.kie.server.services.jbpm.ui.form.render;
 import java.io.IOException;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Collections;
 import java.util.Map;
 
@@ -31,8 +29,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
 public class FormReader {
 
@@ -40,11 +36,8 @@ public class FormReader {
     
     
     public FormReader() {
-        final String pattern = "yyyy-MM-dd";
-        this.mapper = new ObjectMapper();
-        JavaTimeModule module = new JavaTimeModule();
-        module.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(DateTimeFormatter.ofPattern(pattern)));
-        mapper.registerModule(module).configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false).setDateFormat(new SimpleDateFormat(pattern));
+        this.mapper = new ObjectMapper().findAndRegisterModules().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                                        .setDateFormat(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS"));
     }
     
     public FormInstance readFromString(String formStructure) {

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/java/org/kie/server/services/jbpm/ui/form/render/FormRendererTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/java/org/kie/server/services/jbpm/ui/form/render/FormRendererTest.java
@@ -234,83 +234,67 @@ public class FormRendererTest {
         assertThat(renderedForm).isNotNull();
         writeToFile("testRenderOfBasicFormWithSelectRadioGroup.html", renderedForm);
     }
-    
-    
-    
-    private static abstract class BaseTestPojo {
+
+    private static class TestPojo {
+
         private String selection;
         private String radio;
         private float decimal;
         private String hwSpec_;
-        
-        public String getSelection() {
-            return selection;
-        }
-        
-        public String getRadio() {
-            return radio;
-        }
-        
-        public float getDecimal() {
-            return decimal;
-        }
-        
-        public String getHwSpec_() {
-            return hwSpec_;
-        }
-        
-        
-        protected BaseTestPojo(String selection, String radio, float decimal, String hwSpec_) {
+        private Date date_;
+        private LocalDate localDate_;
+        private LocalDateTime localDateTime_;
+        private LocalTime time_;
+
+        public TestPojo(String selection, String radio, float decimal, String hwSpec_, Date date_, LocalDate localDate_, LocalDateTime localDateTime_, LocalTime time_) {
             this.selection = selection;
             this.radio = radio;
             this.decimal = decimal;
             this.hwSpec_ = hwSpec_;
+            this.date_ = date_;
+            this.localDate_ = localDate_;
+            this.localDateTime_ = localDateTime_;
+            this.time_ = time_;
+        }
+
+        public String getSelection() {
+            return selection;
+        }
+
+        public String getRadio() {
+            return radio;
+        }
+
+        public float getDecimal() {
+            return decimal;
+        }
+
+        public String getHwSpec_() {
+            return hwSpec_;
+        }
+
+        public LocalDate getLocalDate_() {
+            return localDate_;
+        }
+
+        public LocalDateTime getLocalDateTime_() {
+            return localDateTime_;
+        }
+
+        public Date getDate_() {
+            return date_;
+        }
+
+        public LocalTime getTime_() {
+            return time_;
         }
     }
-    
-    private class TestDatePojo extends BaseTestPojo{
-        
-        protected TestDatePojo(String selection, String radio, float decimal, String hwSpec_, Date startDate_) {
-            super(selection, radio, decimal, hwSpec_);
-            this.startDate_ = startDate_;
-        }
 
-        private Date startDate_;
+    @Test
+    public void testRenderOfBasicTaskFormWithSelectRadioGroupAndData() {
 
-        public Date getStartDate_() {
-            return startDate_;
-        }
-    }
-    
-    private class TestLocalDatePojo extends BaseTestPojo{
-        
-        protected TestLocalDatePojo(String selection, String radio, float decimal, String hwSpec_, LocalDate startDate_) {
-            super(selection, radio, decimal, hwSpec_);
-            this.startDate_ = startDate_;
-        }
-
-        private LocalDate startDate_;
-
-        public LocalDate getStartDate_() {
-            return startDate_;
-        }
-    }
-    
-    private class TestLocalDateTimePojo extends BaseTestPojo{
-        
-        protected TestLocalDateTimePojo(String selection, String radio, float decimal, String hwSpec_, LocalDateTime startDate_) {
-            super(selection, radio, decimal, hwSpec_);
-            this.startDate_ = startDate_;
-        }
-
-        private LocalDateTime startDate_;
-
-        public LocalDateTime getStartDate_() {
-            return startDate_;
-        }
-    }
-    
-    private void testRenderOfBasicTaskFormWithSelectRadioGroupAndData (BaseTestPojo pojo) {
+        TestPojo pojo = new TestPojo("another", "radio2", 123.5f, "name####123####111####id", new GregorianCalendar(2020, 11, 1).getTime(),
+                                     LocalDate.of(2020, 12, 1), LocalDateTime.of(LocalDate.of(2020, 12, 1), LocalTime.of(23, 11)), LocalTime.of(12, 1));
         FormReader reader = new FormReader();
 
         FormInstance form = reader.readFromStream(this.getClass().getResourceAsStream("/various-fields-taskform.json"));
@@ -322,28 +306,15 @@ public class FormRendererTest {
         Task task = newTask(0L, "Ready");
 
         String renderedForm = renderer.renderTask("", task, form, inputs, outputs);
-        assertThat(renderedForm).isNotNull();
-        assertThat(renderedForm).contains("value=\"2020-12-01\"");
+        assertThat(renderedForm).isNotNull()
+                                .containsIgnoringCase("value=\"2020-12-01T23:11:00\"")
+                                .containsIgnoringCase("value=\"2020-12-01\"")
+                                .containsIgnoringCase("value=\"2020-12-01T00:00:00.000\"")
+                                .containsIgnoringCase("value=\"12:01:00\"");
 
         writeToFile("testRenderOfBasicTaskFormWithSelectRadioGroupAndData.html", renderedForm);
-
     }
 
-    @Test
-    public void testRenderOfBasicTaskFormWithSelectRadioGroupAndDataForDate() {
-        testRenderOfBasicTaskFormWithSelectRadioGroupAndData(new TestDatePojo("another", "radio2", 123.5f, "name####123####111####id", new GregorianCalendar(2020, 11, 1).getTime()));
-    }
-
-    @Test
-    public void testRenderOfBasicTaskFormWithSelectRadioGroupAndDataForLocalDate() {
-        testRenderOfBasicTaskFormWithSelectRadioGroupAndData(new TestLocalDatePojo("another", "radio2", 123.5f, "name####123####111####id", LocalDate.of(2020, 12, 1)));
-    }
-
-    @Test
-    public void testRenderOfBasicTaskFormWithSelectRadioGroupAndDataForLocalDateTime() {
-        testRenderOfBasicTaskFormWithSelectRadioGroupAndData(new TestLocalDateTimePojo("another", "radio2", 123.5f, "name####123####111####id", LocalDateTime.of(LocalDate.of(2020, 12, 1), LocalTime.now())));
-    }
-    
     @Test
     public void testRenderOfMultiSubFormNoData() {
                         

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/java/org/kie/server/services/jbpm/ui/form/render/FormRendererTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/java/org/kie/server/services/jbpm/ui/form/render/FormRendererTest.java
@@ -22,9 +22,15 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -229,26 +235,113 @@ public class FormRendererTest {
         writeToFile("testRenderOfBasicFormWithSelectRadioGroup.html", renderedForm);
     }
     
-    @Test
-    public void testRenderOfBasicTaskFormWithSelectRadioGroupAndData() {
+    
+    
+    private static abstract class BaseTestPojo {
+        private String selection;
+        private String radio;
+        private float decimal;
+        private String hwSpec_;
         
+        public String getSelection() {
+            return selection;
+        }
+        
+        public String getRadio() {
+            return radio;
+        }
+        
+        public float getDecimal() {
+            return decimal;
+        }
+        
+        public String getHwSpec_() {
+            return hwSpec_;
+        }
+        
+        
+        protected BaseTestPojo(String selection, String radio, float decimal, String hwSpec_) {
+            this.selection = selection;
+            this.radio = radio;
+            this.decimal = decimal;
+            this.hwSpec_ = hwSpec_;
+        }
+    }
+    
+    private class TestDatePojo extends BaseTestPojo{
+        
+        protected TestDatePojo(String selection, String radio, float decimal, String hwSpec_, Date startDate_) {
+            super(selection, radio, decimal, hwSpec_);
+            this.startDate_ = startDate_;
+        }
+
+        private Date startDate_;
+
+        public Date getStartDate_() {
+            return startDate_;
+        }
+    }
+    
+    private class TestLocalDatePojo extends BaseTestPojo{
+        
+        protected TestLocalDatePojo(String selection, String radio, float decimal, String hwSpec_, LocalDate startDate_) {
+            super(selection, radio, decimal, hwSpec_);
+            this.startDate_ = startDate_;
+        }
+
+        private LocalDate startDate_;
+
+        public LocalDate getStartDate_() {
+            return startDate_;
+        }
+    }
+    
+    private class TestLocalDateTimePojo extends BaseTestPojo{
+        
+        protected TestLocalDateTimePojo(String selection, String radio, float decimal, String hwSpec_, LocalDateTime startDate_) {
+            super(selection, radio, decimal, hwSpec_);
+            this.startDate_ = startDate_;
+        }
+
+        private LocalDateTime startDate_;
+
+        public LocalDateTime getStartDate_() {
+            return startDate_;
+        }
+    }
+    
+    private void testRenderOfBasicTaskFormWithSelectRadioGroupAndData (BaseTestPojo pojo) {
         FormReader reader = new FormReader();
-        
+
         FormInstance form = reader.readFromStream(this.getClass().getResourceAsStream("/various-fields-taskform.json"));
         assertThat(form).isNotNull();
-        
-        Map<String, Object> inputs = new HashMap<>();
-        inputs.put("selection", "another");
-        inputs.put("radio", "radio2");
-        inputs.put("decimal", 123.5);
-        inputs.put("hwSpec_", "name####123####111####id");
-        Map<String, Object> outputs = new HashMap<>();
-        
+
+        Map<String, Object> inputs = reader.extractValues(pojo);
+        Map<String, Object> outputs = Collections.emptyMap();
+
         Task task = newTask(0L, "Ready");
-        
+
         String renderedForm = renderer.renderTask("", task, form, inputs, outputs);
         assertThat(renderedForm).isNotNull();
+        assertThat(renderedForm).contains("value=\"2020-12-01\"");
+
         writeToFile("testRenderOfBasicTaskFormWithSelectRadioGroupAndData.html", renderedForm);
+
+    }
+
+    @Test
+    public void testRenderOfBasicTaskFormWithSelectRadioGroupAndDataForDate() {
+        testRenderOfBasicTaskFormWithSelectRadioGroupAndData(new TestDatePojo("another", "radio2", 123.5f, "name####123####111####id", new GregorianCalendar(2020, 11, 1).getTime()));
+    }
+
+    @Test
+    public void testRenderOfBasicTaskFormWithSelectRadioGroupAndDataForLocalDate() {
+        testRenderOfBasicTaskFormWithSelectRadioGroupAndData(new TestLocalDatePojo("another", "radio2", 123.5f, "name####123####111####id", LocalDate.of(2020, 12, 1)));
+    }
+
+    @Test
+    public void testRenderOfBasicTaskFormWithSelectRadioGroupAndDataForLocalDateTime() {
+        testRenderOfBasicTaskFormWithSelectRadioGroupAndData(new TestLocalDateTimePojo("another", "radio2", 123.5f, "name####123####111####id", LocalDateTime.of(LocalDate.of(2020, 12, 1), LocalTime.now())));
     }
     
     @Test

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/resources/various-fields-taskform.json
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/resources/various-fields-taskform.json
@@ -69,6 +69,22 @@
 						}
 					]
 				}
+			},
+			{
+				"name": "startDate_",
+				"typeInfo": {
+					"type": "BASE",
+					"className": "java.time.LocalDateTime",
+					"multiple": false
+				},
+				"metaData": {
+					"entries": [
+						{
+							"name": "field-readOnly",
+							"value": false
+						}
+					]
+				}
 			}
 		],
 		"formModelType": "org.kie.workbench.common.forms.jbpm.model.authoring.task.TaskFormModel"
@@ -137,7 +153,8 @@
 			"readOnly": false,
 			"validateOnChange": true,
 			"helpMessage": "",
-			"standaloneClassName": "java.util.Date",
+			"binding": "startDate_", 
+			"standaloneClassName": "java.time.LocalDateTime",
 			"code": "DatePicker",
 			"serializedFieldClassName": "org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.definition.DatePickerFieldDefinition"
 		},

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/resources/various-fields-taskform.json
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/resources/various-fields-taskform.json
@@ -69,22 +69,6 @@
 						}
 					]
 				}
-			},
-			{
-				"name": "startDate_",
-				"typeInfo": {
-					"type": "BASE",
-					"className": "java.time.LocalDateTime",
-					"multiple": false
-				},
-				"metaData": {
-					"entries": [
-						{
-							"name": "field-readOnly",
-							"value": false
-						}
-					]
-				}
 			}
 		],
 		"formModelType": "org.kie.workbench.common.forms.jbpm.model.authoring.task.TaskFormModel"
@@ -147,15 +131,60 @@
 			"placeHolder": "DatePicker",
 			"showTime": true,
 			"id": "field_07004",
-			"name": "mydate",
-			"label": "DatePicker",
+			"name": "myLocalDateTime",
+			"label": "LocalDatetime",
 			"required": false,
 			"readOnly": false,
 			"validateOnChange": true,
 			"helpMessage": "",
-			"binding": "startDate_", 
+			"binding": "localDateTime_", 
 			"standaloneClassName": "java.time.LocalDateTime",
 			"code": "DatePicker",
+			"serializedFieldClassName": "org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.definition.DatePickerFieldDefinition"
+		},
+		{
+			"placeHolder": "DatePicker",
+			"showTime": true,
+			"id": "field_07005",
+			"name": "myLocalDate",
+			"label": "LocalDate",
+			"required": false,
+			"readOnly": false,
+			"validateOnChange": true,
+			"helpMessage": "",
+			"binding": "localDate_", 
+			"standaloneClassName": "java.time.LocalDate",
+			"code": "DatePicker",
+			"serializedFieldClassName": "org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.definition.DatePickerFieldDefinition"
+		},
+		{
+			"placeHolder": "DatePicker",
+			"showTime": true,
+			"id": "field_07006",
+			"name": "myDate",
+			"label": "Date",
+			"required": false,
+			"readOnly": false,
+			"validateOnChange": true,
+			"helpMessage": "",
+			"binding": "date_", 
+			"standaloneClassName": "java.util.Date",
+			"code": "DatePicker",
+			"serializedFieldClassName": "org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.definition.DatePickerFieldDefinition"
+		},
+		{
+			"placeHolder": "DatePicker",
+			"showTime": true,
+			"id": "field_07007",
+			"label": "Time",
+			"name": "myTime",
+			"required": false,
+			"readOnly": false,
+			"validateOnChange": true,
+			"helpMessage": "",
+			"binding": "time_",
+			"code": "DatePicker", 
+			"standaloneClassName": "java.time.LocalTime",
 			"serializedFieldClassName": "org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.definition.DatePickerFieldDefinition"
 		},
 		{
@@ -330,6 +359,81 @@
 								"dragTypeName": "org.kie.workbench.common.forms.editor.client.editor.rendering.EditorFieldLayoutComponent",
 								"properties": {
 									"field_id": "field_07004",
+									"form_id": "6feb5a08-3144-488e-9afa-17d52b899a7b"
+								}
+							}
+						]
+					}
+				]
+			},
+			{
+				"height": "12",
+				"properties": {
+					
+				},
+				"layoutColumns": [
+					{
+						"span": "12",
+						"height": "12",
+						"properties": {
+							
+						},
+						"rows": [],
+						"layoutComponents": [
+							{
+								"dragTypeName": "org.kie.workbench.common.forms.editor.client.editor.rendering.EditorFieldLayoutComponent",
+								"properties": {
+									"field_id": "field_07005",
+									"form_id": "6feb5a08-3144-488e-9afa-17d52b899a7b"
+								}
+							}
+						]
+					}
+				]
+			},
+			{
+				"height": "12",
+				"properties": {
+					
+				},
+				"layoutColumns": [
+					{
+						"span": "12",
+						"height": "12",
+						"properties": {
+							
+						},
+						"rows": [],
+						"layoutComponents": [
+							{
+								"dragTypeName": "org.kie.workbench.common.forms.editor.client.editor.rendering.EditorFieldLayoutComponent",
+								"properties": {
+									"field_id": "field_07006",
+									"form_id": "6feb5a08-3144-488e-9afa-17d52b899a7b"
+								}
+							}
+						]
+					}
+				]
+			},
+			{
+				"height": "12",
+				"properties": {
+					
+				},
+				"layoutColumns": [
+					{
+						"span": "12",
+						"height": "12",
+						"properties": {
+							
+						},
+						"rows": [],
+						"layoutComponents": [
+							{
+								"dragTypeName": "org.kie.workbench.common.forms.editor.client.editor.rendering.EditorFieldLayoutComponent",
+								"properties": {
+									"field_id": "field_07007",
 									"form_id": "6feb5a08-3144-488e-9afa-17d52b899a7b"
 								}
 							}


### PR DESCRIPTION
Added support for java 8 date/time classes in the mapper used to extract parameters. 
In order the browser to render dates properly, the html page returned by form rest API should contain the proper type, Date for LocalDate and DateTime-Local for LocalDateTime and Date

**Merge with** 
https://github.com/kiegroup/kie-wb-common/pull/3706

**JIRA**:

[link](https://issues.redhat.com/browse/JBPM-9948)
