### PR TITLE
Remove index from parameterized Kie server integration tests

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/RenderFormServiceIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/RenderFormServiceIntegrationTest.java
@@ -70,7 +70,7 @@ public class RenderFormServiceIntegrationTest extends KieServerBaseIntegrationTe
     @ClassRule
     public static ExternalResource StaticResource = new DBExternalResource();
     
-    @Parameterized.Parameters(name = "{index}: {0}")
+    @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration restConfiguration = createKieServicesRestConfiguration();
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/RestJmsSharedBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/RestJmsSharedBaseIntegrationTest.java
@@ -44,7 +44,7 @@ import org.kie.server.integrationtests.shared.KieServerReflections;
 @RunWith(Parameterized.class)
 public abstract class RestJmsSharedBaseIntegrationTest extends KieServerBaseIntegrationTest {
 
-    @Parameterized.Parameters(name = "{index}: {0} {1}")
+    @Parameterized.Parameters(name = "{0} {1}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration restConfiguration = createKieServicesRestConfiguration();
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/RestOnlyBaseIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/main/java/org/kie/server/integrationtests/shared/basetests/RestOnlyBaseIntegrationTest.java
@@ -36,7 +36,7 @@ import org.kie.server.integrationtests.config.TestConfig;
 @RunWith(Parameterized.class)
 public abstract class RestOnlyBaseIntegrationTest extends KieServerBaseIntegrationTest {
 
-    @Parameterized.Parameters(name = "{index}: {0} {1}")
+    @Parameterized.Parameters(name = "{0} {1}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration restConfiguration = createKieServicesRestConfiguration();
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/jms/ContainerJmsResponseHandlerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-common/src/test/java/org/kie/server/integrationtests/common/jms/ContainerJmsResponseHandlerIntegrationTest.java
@@ -53,7 +53,7 @@ public class ContainerJmsResponseHandlerIntegrationTest extends RestJmsSharedBas
     private static final ReleaseId RELEASE_ID_1 = new ReleaseId("org.kie.server.testing", "container-crud-tests1", "2.1.0.GA");
     private static final ReleaseId RELEASE_ID_2 = new ReleaseId("org.kie.server.testing", "container-crud-tests1", "2.1.1.GA");
 
-    @Parameterized.Parameters(name = "{index}: {0}")
+    @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration jmsConfiguration = createKieServicesJmsConfiguration();
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/WebSocketKieControllerManagementIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/WebSocketKieControllerManagementIntegrationTest.java
@@ -47,7 +47,7 @@ public class WebSocketKieControllerManagementIntegrationTest extends KieControll
         assertNotNull(e.getMessage());
     }
 
-    @Parameterized.Parameters(name = "{index}: {0} {1}")
+    @Parameterized.Parameters(name = "{0} {1}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration restConfiguration = createKieServicesRestConfiguration();
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/WebSocketKieControllerRuleCapabilitiesIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/WebSocketKieControllerRuleCapabilitiesIntegrationTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class WebSocketKieControllerRuleCapabilitiesIntegrationTest extends KieControllerRuleCapabilitiesIntegrationTest<KieServerControllerClientException> {
 
-    @Parameterized.Parameters(name = "{index}: {0} {1}")
+    @Parameterized.Parameters(name = "{0} {1}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration restConfiguration = createKieServicesRestConfiguration();
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/WebSocketKieControllerRuntimeManagementIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/WebSocketKieControllerRuntimeManagementIntegrationTest.java
@@ -40,7 +40,7 @@ public class WebSocketKieControllerRuntimeManagementIntegrationTest extends KieC
         assertThat(e.getMessage()).isNotNull();
     }
 
-    @Parameterized.Parameters(name = "{index}: {0} {1}")
+    @Parameterized.Parameters(name = "{0} {1}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration restConfiguration = createKieServicesRestConfiguration();
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/JsonTypeInfoIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/JsonTypeInfoIntegrationTest.java
@@ -54,7 +54,7 @@ public class JsonTypeInfoIntegrationTest extends DroolsKieServerBaseIntegrationT
 
     private static ClassLoader kjarClassLoader;
 
-    @Parameterized.Parameters(name = "{index}: {0} {1}")
+    @Parameterized.Parameters(name = "{0} {1}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration restConfiguration = createKieServicesRestConfiguration();
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/JsonTypeInfoUpdateIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/JsonTypeInfoUpdateIntegrationTest.java
@@ -56,7 +56,7 @@ public class JsonTypeInfoUpdateIntegrationTest extends DroolsKieServerBaseIntegr
 
     private static ClassLoader kjarClassLoader;
 
-    @Parameterized.Parameters(name = "{index}: {0} {1}")
+    @Parameterized.Parameters(name = "{0} {1}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration restConfiguration = createKieServicesRestConfiguration();
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/jms/DroolsJmsResponseHandlerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/jms/DroolsJmsResponseHandlerIntegrationTest.java
@@ -61,7 +61,7 @@ public class DroolsJmsResponseHandlerIntegrationTest extends DroolsKieServerBase
     private static final String LIST_NAME = "list";
     private static final String LIST_OUTPUT_NAME = "output-list";
 
-    @Parameterized.Parameters(name = "{index}: {0}")
+    @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration jmsConfiguration = createKieServicesJmsConfiguration();
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/KieServerContainerListFilteringIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/KieServerContainerListFilteringIntegrationTest.java
@@ -105,7 +105,7 @@ public class KieServerContainerListFilteringIntegrationTest extends RestJmsShare
         client.createContainer(CONTAINER_ID_3, new KieContainerResource(CONTAINER_ID_3, releaseId3));
     }
 
-    @Parameterized.Parameters(name = "{index}: {0} {1} {2} {3} {4}")
+    @Parameterized.Parameters(name = "{0} {1} {2} {3} {4}")
     public static Collection<Object[]> data() {
 
         Collection<Object[]> testData = new ArrayList<Object[]>(Arrays.asList(new Object[][]

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/TimerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/TimerIntegrationTest.java
@@ -40,7 +40,7 @@ public class TimerIntegrationTest extends JbpmKieServerBaseIntegrationTest {
     private static ReleaseId releaseId = new ReleaseId("org.kie.server.testing", "timer-project",
             "1.0.0.Final");
 
-    @Parameterized.Parameters(name = "{index}: {0} {1} {2}")
+    @Parameterized.Parameters(name = "{0} {1} {2}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration configuration = createKieServicesRestConfiguration();
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskEscalationIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/UserTaskEscalationIntegrationTest.java
@@ -87,7 +87,7 @@ public class UserTaskEscalationIntegrationTest extends JbpmKieServerBaseIntegrat
 
     private Wiser wiser;
 
-    @Parameterized.Parameters(name = "{index}: {0} {1}")
+    @Parameterized.Parameters(name = "{0} {1}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration configuration = createKieServicesRestConfiguration();
 

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsResponseHandlerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsResponseHandlerIntegrationTest.java
@@ -66,7 +66,7 @@ public class JmsResponseHandlerIntegrationTest extends JbpmKieServerBaseIntegrat
 
     private static final ReleaseId RELEASE_ID = new ReleaseId("org.kie.server.testing", "definition-project", "1.0.0.Final");
 
-    @Parameterized.Parameters(name = "{index}: {0}")
+    @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration jmsConfiguration = createKieServicesJmsConfiguration();
         Collection<Object[]> parameterData = new ArrayList<>(Arrays.asList(new Object[][]{

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsTransactionsIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-jbpm/src/test/java/org/kie/server/integrationtests/jbpm/jms/JmsTransactionsIntegrationTest.java
@@ -56,22 +56,26 @@ public class JmsTransactionsIntegrationTest extends JbpmKieServerBaseIntegration
 
     private static final ReleaseId RELEASE_ID = new ReleaseId("org.kie.server.testing", "definition-project", "1.0.0.Final");
 
-    @Parameterized.Parameters(name = "{index}: {0}")
+    @Parameterized.Parameters(name = "{0} {3}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration jmsConfiguration = createKieServicesJmsConfiguration();
 
         return new ArrayList<>(Arrays.asList(new Object[][]{
-                {MarshallingFormat.JAXB, jmsConfiguration, new FireAndForgetResponseHandler()},
-                {MarshallingFormat.JAXB, jmsConfiguration, new AsyncResponseHandler(new BlockingResponseCallback(null))},
-                {MarshallingFormat.JSON, jmsConfiguration, new FireAndForgetResponseHandler()},
-                {MarshallingFormat.JSON, jmsConfiguration, new AsyncResponseHandler(new BlockingResponseCallback(null))},
-                {MarshallingFormat.XSTREAM, jmsConfiguration, new FireAndForgetResponseHandler()},
-                {MarshallingFormat.XSTREAM, jmsConfiguration, new AsyncResponseHandler(new BlockingResponseCallback(null))}
+                {MarshallingFormat.JAXB, jmsConfiguration, new FireAndForgetResponseHandler(), "FireAndForgetResponseHandler"},
+                {MarshallingFormat.JAXB, jmsConfiguration, new AsyncResponseHandler(new BlockingResponseCallback(null)), "AsyncResponseHandler"},
+                {MarshallingFormat.JSON, jmsConfiguration, new FireAndForgetResponseHandler(), "FireAndForgetResponseHandler"},
+                {MarshallingFormat.JSON, jmsConfiguration, new AsyncResponseHandler(new BlockingResponseCallback(null)), "AsyncResponseHandler"},
+                {MarshallingFormat.XSTREAM, jmsConfiguration, new FireAndForgetResponseHandler(), "FireAndForgetResponseHandler"},
+                {MarshallingFormat.XSTREAM, jmsConfiguration, new AsyncResponseHandler(new BlockingResponseCallback(null)), "AsyncResponseHandler"}
         }));
     }
 
     @Parameterized.Parameter(2)
     public ResponseHandler responseHandler;
+
+    // Needed for logging purposes to identify distinct parameterized runs
+    @Parameterized.Parameter(3)
+    public String responseHandlerName;
 
     private ConnectionFactoryProxy connectionFactory;
     private UserTransaction transaction;

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/jms/OptaPlannerJmsResponseHandlerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-optaplanner/src/test/java/org/kie/server/integrationtests/optaplanner/jms/OptaPlannerJmsResponseHandlerIntegrationTest.java
@@ -70,7 +70,7 @@ public class OptaPlannerJmsResponseHandlerIntegrationTest extends OptaplannerKie
 
     private static final long EXTENDED_TIMEOUT = 300_000L;
 
-    @Parameterized.Parameters(name = "{index}: {0}")
+    @Parameterized.Parameters(name = "{0}")
     public static Collection<Object[]> data() {
         KieServicesConfiguration jmsConfiguration = createKieServicesJmsConfiguration();
 


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

**Thank you for submitting this pull request**

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
