### PR TITLE
[7.59.x][JBPM-9959] Add Authorization header for controller Swagger UI requests

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerSwaggerIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerSwaggerIntegrationTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.kie.server.integrationtests.config.TestConfig;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.thoughtworks.xstream.core.util.Base64Encoder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -65,7 +66,7 @@ public class KieControllerSwaggerIntegrationTest extends KieControllerManagement
     
     protected String invokeGet(String docsUri) {
         WebTarget clientRequest = httpClient.target(docsUri);
-        Response response = clientRequest.request().get();
+        Response response = clientRequest.request().header("Authorization", "Basic " + new Base64Encoder().encode((TestConfig.getUsername() + ":" + TestConfig.getPassword()).getBytes())).get();
 
         assertEquals(200, response.getStatus());
         assertNotNull(response.getEntity());


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[JBPM-9959](https://issues.redhat.com/browse/JBPM-9959)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* https://github.com/kiegroup/droolsjbpm-integration/pull/2660

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
