### PR TITLE
[RHPAM-4111]-Certify Spring Boot 2.4.x

### DIFF
--- a/kie-spring-boot/pom.xml
+++ b/kie-spring-boot/pom.xml
@@ -33,7 +33,7 @@
   </modules>
 
   <properties>
-    <version.me.snowdrop.narayana>2.6.1.redhat-00001</version.me.snowdrop.narayana>
+    <version.me.snowdrop.narayana>2.6.1</version.me.snowdrop.narayana>
     <version.org.apache.commons-dbcp2>2.4.0</version.org.apache.commons-dbcp2>
   </properties>
 

--- a/kie-spring-boot/pom.xml
+++ b/kie-spring-boot/pom.xml
@@ -212,6 +212,10 @@
             <groupId>org.jboss.spec.javax.transaction</groupId>
             <artifactId>jboss-transaction-api_1.2_spec</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.apache.geronimo.specs</groupId>
+            <artifactId>geronimo-jms_2.0_spec</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>

--- a/kie-spring-boot/pom.xml
+++ b/kie-spring-boot/pom.xml
@@ -33,7 +33,7 @@
   </modules>
 
   <properties>
-    <version.me.snowdrop.narayana>2.4.1</version.me.snowdrop.narayana>
+    <version.me.snowdrop.narayana>2.6.1.redhat-00001</version.me.snowdrop.narayana>
     <version.org.apache.commons-dbcp2>2.4.0</version.org.apache.commons-dbcp2>
   </properties>
 


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHPAM-4111
Upgraded version of narayana spring boot starter to align with Red Hat supported Spring Boot 2.4.9 version.
This PR should be merged along with - https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1860