### PR TITLE
Bump apache-karaf from 4.3.2 to 4.3.6 for kie-karaf-itests

### DIFF
--- a/kie-osgi/kie-karaf-itests/pom.xml
+++ b/kie-osgi/kie-karaf-itests/pom.xml
@@ -15,7 +15,7 @@
     <skipTests>true</skipTests>
 
     <java.module.name>org.kie.karaf.itests.main</java.module.name>
-    <version.org.apache.karaf>4.3.2</version.org.apache.karaf>
+    <version.org.apache.karaf>4.3.6</version.org.apache.karaf>
     <!-- use global version property from kie-parent -->
     <!-- <version.org.apache.cxf>3.2.8</version.org.apache.cxf> -->
     <!-- version.org.apache.camel>2.21.5</version.org.apache.camel -->

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/AbstractKarafIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/AbstractKarafIntegrationTest.java
@@ -229,7 +229,7 @@ abstract public class AbstractKarafIntegrationTest {
         options.add(editConfigurationFilePut("etc/system.properties", "patching.disabled", "true"));
         if (!"features-fuse".equals(System.getProperty("kie.features.classifier"))) {
             // when not running on Fuse, we have to configure overrides and add some missing features
-            options.add(editConfigurationFilePut("etc/startup.properties", "mvn:org.ops4j.pax.url/pax-url-wrap/2.6.7/jar/uber", "5"));
+            options.add(editConfigurationFilePut("etc/startup.properties", "mvn:org.ops4j.pax.url/pax-url-wrap/2.6.10/jar/uber", "5"));
             // Camel 2.21 requires Spring 4.3, so it has to be spring-legacy
             options.add(editConfigurationFileExtend("etc/org.apache.karaf.features.cfg",
                     "featuresRepositories", "mvn:org.apache.karaf.features/spring/" + karafVersion + "/xml/features"));


### PR DESCRIPTION
No JIRA but this is an alternative PR for https://github.com/kiegroup/droolsjbpm-integration/pull/2710

This might be just a test. Or replace the above PR.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
