### PR TITLE
[7.59.x] [DROOLS-6842] Fix Karaf integration tests (#2718)

### DIFF
--- a/kie-osgi/kie-karaf-features/pom.xml
+++ b/kie-osgi/kie-karaf-features/pom.xml
@@ -51,6 +51,9 @@
     <karaf.version.org.jboss.jandex>2.2.3.Final</karaf.version.org.jboss.jandex>
     <karaf.version.javax.validation>1.1.0.Final</karaf.version.javax.validation>
 
+    <!-- used by kie-server-client -->
+    <karaf.version.org.apache.servicemix.specs>2.9.1</karaf.version.org.apache.servicemix.specs>
+
     <karaf.version.org.apache.logging.log4j>2.5</karaf.version.org.apache.logging.log4j>
     <!-- used by hibernate-validator -->
     <karaf.version.org.apache.servicemix.specs.jsr303-api>2.4.0</karaf.version.org.apache.servicemix.specs.jsr303-api>
@@ -60,7 +63,8 @@
     <karaf.version.commons-collections4>4.1</karaf.version.commons-collections4>
     <!-- Overwrites with a servicemix version -->
     <karaf.servicemix.version.com.google.protobuf>2.4.1_1</karaf.servicemix.version.com.google.protobuf>
-    <karaf.servicemix.version.com.sun.xml.bind.jaxb>2.2.11_1</karaf.servicemix.version.com.sun.xml.bind.jaxb>
+    <karaf.servicemix.version.com.sun.xml.bind.jaxb>2.3.2_3</karaf.servicemix.version.com.sun.xml.bind.jaxb>
+    <karaf.servicemix.version.com.sun.xml.bind.jaxb.xjc>2.3.2_2</karaf.servicemix.version.com.sun.xml.bind.jaxb.xjc>
     <karaf.servicemix.version.com.thoughtworks.xstream>1.4.10_1</karaf.servicemix.version.com.thoughtworks.xstream>
     <karaf.servicemix.version.com.thoughtworks.xmlpull>1.1.4c_7</karaf.servicemix.version.com.thoughtworks.xmlpull>
     <karaf.servicemix.version.javax.xml.bind.jaxb>2.3_3</karaf.servicemix.version.javax.xml.bind.jaxb>
@@ -79,7 +83,7 @@
     <h2.version>1.4.178</h2.version>
 
     <!-- Camel -->
-    <karaf.version.org.apache.camel>2.21.5</karaf.version.org.apache.camel>
+    <karaf.version.org.apache.camel>2.24.0</karaf.version.org.apache.camel>
 
     <!-- Overwrites for Fuse -->
     <fuse.version.com.h2database>1.3.168</fuse.version.com.h2database>
@@ -184,7 +188,7 @@
       <dependency>
         <groupId>org.apache.servicemix.bundles</groupId>
         <artifactId>org.apache.servicemix.bundles.jaxb-xjc</artifactId>
-        <version>${karaf.servicemix.version.com.sun.xml.bind.jaxb}</version>
+        <version>${karaf.servicemix.version.com.sun.xml.bind.jaxb.xjc}</version>
         <exclusions>
           <exclusion>
             <groupId>javax.xml.stream</groupId>
@@ -206,7 +210,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.servicemix.bundles</groupId>
-        <artifactId>org.apache.servicemix.bundles.jaxb-impl</artifactId>
+        <artifactId>org.apache.servicemix.bundles.jaxb-runtime</artifactId>
         <version>${karaf.servicemix.version.com.sun.xml.bind.jaxb}</version>
         <exclusions>
           <exclusion>
@@ -640,7 +644,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.jaxb-impl</artifactId>
+      <artifactId>org.apache.servicemix.bundles.jaxb-runtime</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features-core.xml
+++ b/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features-core.xml
@@ -104,9 +104,9 @@
     <feature>camel-core</feature>
     <feature>camel-spring</feature>
     <feature>camel-cxf</feature>
-    <feature version="[3.3,3.4)">cxf-specs</feature>
-    <feature version="[3.3,3.4)">cxf-core</feature>
-    <feature version="[3.3,3.4)">cxf-jaxrs</feature>
+    <feature version="[3.3,3.5)">cxf-specs</feature>
+    <feature version="[3.3,3.5)">cxf-core</feature>
+    <feature version="[3.3,3.5)">cxf-jaxrs</feature>
     <bundle>mvn:org.kie/kie-camel/${project.version}</bundle>
   </feature>
 

--- a/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features-fuse.xml
+++ b/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features-fuse.xml
@@ -125,6 +125,8 @@
     <bundle>mvn:org.kie.server/kie-server-client/${version.org.drools.droolsjbpm-integration}</bundle>
     <bundle>mvn:org.kie/kie-dmn-model/${version.org.kie}</bundle> <!-- needed as the kie-server contains DMN client, which uses the kie-dmn-api, which needs kie-dmn-model -->
     <bundle>mvn:org.kie/kie-dmn-api/${version.org.kie}</bundle>   <!-- needed as the kie-server contains DMN client, which uses the kie-dmn-api -->
+    <!-- This bundle will be part of Fuse's kie7-remote-dependencies feature in Fuse 7.11 -->
+    <bundle dependency="true">mvn:org.apache.httpcomponents/httpcore-osgi/${version.org.apache.httpcomponents.httpcore}</bundle>
   </feature>
 
   <feature name="servlet-api-kie" version="${project.version}">

--- a/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features.xml
+++ b/kie-osgi/kie-karaf-features/src/main/filtered-resources/repository/features.xml
@@ -11,8 +11,8 @@
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.antlr/${karaf.servicemix.version.org.antlr}</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xstream-java8/${karaf.servicemix.version.com.thoughtworks.xstream}</bundle>
     <bundle start-level='10'>mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxb-api-2.3/${karaf.servicemix.version.javax.xml.bind.jaxb}</bundle>
-    <bundle start-level='10'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-xjc/${karaf.servicemix.version.com.sun.xml.bind.jaxb}</bundle>
-    <bundle start-level='10'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/${karaf.servicemix.version.com.sun.xml.bind.jaxb}</bundle>
+    <bundle start-level='10'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-xjc/${karaf.servicemix.version.com.sun.xml.bind.jaxb.xjc}</bundle>
+    <bundle start-level='10'>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-runtime/${karaf.servicemix.version.com.sun.xml.bind.jaxb}</bundle>
     <bundle>mvn:org.mvel/mvel2/${version.org.mvel}</bundle>
     <bundle>wrap:mvn:org.eclipse.jdt/ecj/${karaf.version.org.eclipse.jdt}$Bundle-SymbolicName=Eclipse-JDT-Compiler&amp;Bundle-Version=${karaf.version.org.eclipse.jdt}</bundle>
     <bundle>mvn:org.apache.geronimo.specs/geronimo-atinject_1.0_spec/${karaf.version.org.apache.geronimo.specs.atinject}</bundle>
@@ -171,11 +171,12 @@
     <bundle>mvn:org.kie/kie-dmn-api/${version.org.kie}</bundle>   <!-- needed as the kie-server contains DMN client, which uses the kie-dmn-api -->
     <bundle>mvn:org.drools/drools-ruleunit/${version.org.drools}</bundle>
     <bundle>mvn:org.drools/kie-pmml/${version.org.kie}</bundle>
-    <bundle>wrap:mvn:jakarta.ws.rs/jakarta.ws.rs-api/${version.jakarta.ws.rs-api}</bundle>
+    <bundle start-level="10" dependency="true">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxrs-api-2.1/${karaf.version.org.apache.servicemix.specs}</bundle>
     <bundle>mvn:org.apache.commons/commons-lang3/${version.org.apache.commons.lang3}</bundle>
     <bundle>mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/${karaf.version.org.apache.geronimo.specs.jta}</bundle>
     <bundle>mvn:org.apache.geronimo.specs/geronimo-jms_1.1_spec/${karaf.version.org.apache.geronimo.specs.jms}</bundle>
     <bundle>mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.xpp3/${karaf.servicemix.version.com.thoughtworks.xmlpull}</bundle>
+    <bundle>mvn:org.apache.httpcomponents/httpcore-osgi/${version.org.apache.httpcomponents.httpcore}</bundle>
   </feature>
 
   <feature name="servlet-api-kie" version="${project.version}">

--- a/kie-osgi/kie-karaf-itests/pom.xml
+++ b/kie-osgi/kie-karaf-itests/pom.xml
@@ -333,6 +333,9 @@
             <cxf.version>${version.org.apache.cxf}</cxf.version>
             <camel.version>${version.org.apache.camel}</camel.version>
           </systemPropertyVariables>
+          <forkCount>1</forkCount>
+          <reuseForks>false</reuseForks>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
         </configuration>
       </plugin>
     </plugins>
@@ -364,6 +367,9 @@
                 <!--<additional.features.url>mvn:org.jboss.fuse.features/rhba-features/VERSION/xml/features</additional.features.url>-->
                 <!--<karaf.version>4.2.0.fuse-BUILDNUMBER</karaf.version>-->
               </systemPropertyVariables>
+              <forkCount>1</forkCount>
+              <reuseForks>false</reuseForks>
+              <redirectTestOutputToFile>true</redirectTestOutputToFile>
             </configuration>
           </plugin>
         </plugins>

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/camel/kiecamel/KieCamelRemoteIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/camel/kiecamel/KieCamelRemoteIntegrationTest.java
@@ -46,6 +46,7 @@ import org.ops4j.pax.exam.karaf.options.LogLevelOption;
 import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
 import org.ops4j.pax.exam.spi.reactors.PerClass;
 
+import static org.ops4j.pax.exam.CoreOptions.bootDelegationPackages;
 import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.wrappedBundle;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
@@ -166,6 +167,10 @@ public class KieCamelRemoteIntegrationTest extends AbstractKarafIntegrationTest 
 
                 // Option to be used to do remote debugging
 //                  debugConfiguration("5005", true),
+
+                // without this, JAXB model uses annotations from JAXB API bundle, while the runtime itself
+                // comes from the system classloader
+                bootDelegationPackages("javax.xml.bind", "javax.xml.bind.*"),
 
                 AbstractKarafIntegrationTest.loadKieFeatures("drools-module", "drools-decisiontable", "kie-ci", "kie-aries-blueprint", "kie-camel"),
 

--- a/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/KieServerClientKarafIntegrationJaxbIntegrationTest.java
+++ b/kie-osgi/kie-karaf-itests/src/test/java/org/kie/karaf/itest/kieserver/KieServerClientKarafIntegrationJaxbIntegrationTest.java
@@ -16,7 +16,6 @@
 
 package org.kie.karaf.itest.kieserver;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.karaf.itest.AbstractKarafIntegrationTest;
@@ -30,13 +29,13 @@ import org.ops4j.pax.exam.spi.reactors.PerClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.ops4j.pax.exam.CoreOptions.bootDelegationPackages;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.configureConsole;
 import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.logLevel;
 
 
 @RunWith(PaxExamWithWireMock.class)
 @ExamReactorStrategy(PerClass.class)
-@Ignore("DROOLS-6581")
 public class KieServerClientKarafIntegrationJaxbIntegrationTest extends BaseKieServerClientKarafIntegrationTest {
 
     private static final Logger logger = LoggerFactory.getLogger(KieServerClientKarafIntegrationJaxbIntegrationTest.class);
@@ -75,6 +74,10 @@ public class KieServerClientKarafIntegrationJaxbIntegrationTest extends BaseKieS
 
                 // Option to be used to do remote debugging
 //                  debugConfiguration("5005", true),
+
+                // without this, JAXB model uses annotations from JAXB API bundle, while the runtime itself
+                // comes from the system classloader
+                bootDelegationPackages("javax.xml.bind", "javax.xml.bind.*"),
 
                 // Load kie-server-client
                 AbstractKarafIntegrationTest.loadKieFeatures("kie-server-client")

--- a/kie-osgi/kie-karaf-itests/src/test/resources/META-INF/Taskorm.xml
+++ b/kie-osgi/kie-karaf-itests/src/test/resources/META-INF/Taskorm.xml
@@ -976,7 +976,27 @@
         </query>
         <!-- hint name="org.hibernate.timeout" value="200"/ -->
     </named-query>
-      
+    
+     <named-query name="UnescalatedEndDeadlinesByDeployment">
+        <query>
+            select
+            new org.jbpm.services.task.query.DeadlineSummaryImpl(
+            t.id,
+            d.id,
+            d.date)
+            from
+            TaskImpl t,
+            DeadlineImpl d
+            where
+            t.archived = 0 and
+            t.taskData.deploymentId = :deploymentId and
+            d in elements( t.deadlines.endDeadlines ) and
+            d.escalated = 0
+            order by
+            d.date
+        </query>
+        <!-- hint name="org.hibernate.timeout" value="200"/ -->
+    </named-query>
     <named-query name="UnescalatedStartDeadlines">
         <query>
             select
@@ -989,6 +1009,26 @@
             DeadlineImpl d
             where
             t.archived = 0 and
+            d in elements( t.deadlines.startDeadlines ) and
+            d.escalated = 0
+            order by
+            d.date
+        </query>
+        <!-- hint name="org.hibernate.timeout" value="200"/ -->
+    </named-query>
+    <named-query name="UnescalatedStartDeadlinesByDeployment">
+        <query>
+            select
+            new org.jbpm.services.task.query.DeadlineSummaryImpl(
+            t.id,
+            d.id,
+            d.date)
+            from
+            TaskImpl t,
+            DeadlineImpl d
+            where
+            t.archived = 0 and
+            t.taskData.deploymentId = :deploymentId and
             d in elements( t.deadlines.startDeadlines ) and
             d.escalated = 0
             order by

--- a/kie-osgi/kie-karaf-itests/src/test/resources/org.apache.karaf.features.xml
+++ b/kie-osgi/kie-karaf-itests/src/test/resources/org.apache.karaf.features.xml
@@ -2,14 +2,15 @@
 <featuresProcessing xmlns="http://karaf.apache.org/xmlns/features-processing/v1.0.0">
 
     <blacklistedRepositories>
-        <repository>mvn:org.apache.cxf.karaf/apache-cxf/[3.4,*)/xml/features</repository>
+        <repository>mvn:org.apache.cxf.karaf/apache-cxf/[3.2,3.4)/xml/features</repository>
+        <repository>mvn:org.apache.camel.karaf/apache-camel/[2.21.0,2.24)/xml/features</repository>
         <repository>mvn:org.apache.camel.karaf/apache-camel/[2.25.0,*)/xml/features</repository>
     </blacklistedRepositories>
 
     <!-- A list of blacklisted feature identifiers that can't be installed in Karaf and are not part of the distribution -->
     <blacklistedFeatures>
         <feature version="[3,4.5)">spring*</feature>
-        <feature version="[3.4,*)">cxf*</feature>
+        <feature version="[3.2,3.4)">cxf*</feature>
         <feature version="[4,4.3)">aries-blueprint-spring</feature>
     </blacklistedFeatures>
 
@@ -20,6 +21,16 @@
     <bundleReplacements>
         <bundle originalUri="mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javax-websocket-api/[1,2)"
                 replacement="mvn:javax.websocket/javax.websocket-api/1.1" mode="maven" />
+        <bundle originalUri="mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxb-api-2.3/[2,3)"
+                replacement="mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.jaxb-api-2.3/2.3_3" mode="maven" />
+        <bundle originalUri="mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-impl/[2,3)"
+                replacement="mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-runtime/2.3.2_3" mode="maven" />
+        <bundle originalUri="mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-runtime/[2,3)"
+                replacement="mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-runtime/2.3.2_3" mode="maven" />
+        <bundle originalUri="mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-xjc/[2,3)"
+                replacement="mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.jaxb-xjc/2.3.2_2" mode="maven" />
+        <bundle originalUri="mvn:com.sun.activation/jakarta.activation/[1.2,2)"
+                replacement="mvn:com.sun.activation/javax.activation/1.2.0" mode="maven" />
     </bundleReplacements>
 
 </featuresProcessing>

--- a/kie-spring/pom.xml
+++ b/kie-spring/pom.xml
@@ -356,6 +356,7 @@
               !org.drools.container.spring.beans.persistence,
               =javax.persistence.criteria;resolution:=optional,
               =org.jbpm.shared.services.impl;resolution:=optional,
+              javax.persistence.metamodel;resolution:=optional,
               *
             </Import-Package>
             <Export-Package>


### PR DESCRIPTION
[DROOLS-6842] Karaf tests should be run with one dedicated surefire fork

[DROOLS-6842] Adjust Karaf features and test configuration to Camel 2.24.0 and CXF 3.4.x

[DROOLS-6842] Add optional JPA import to kie-spring to fix KieSpringjBPMPersistenceKarafIntegrationTest

[DROOLS-6842][JBPM-9920] Synchronize test-accessible Taskorm.xml with jbpm

[DROOLS-6842][RHPAM-4038] Add required httpcore-osgi bundle to kie-server-client feature

Signed-off-by: Grzegorz Grzybek <gr.grzybek@gmail.com>

* [BAPL-2025] Adjust Karaf features to Fuse 7.10.0.GA

* [DROOLS-6842] JAXB API packages are boot delegated in now working KieServerClientKarafIntegrationJaxbIntegrationTest
