### PR TITLE
[JBPM-10041] Router should disconnect also servers throwing SSLException or subclasses

### DIFF
--- a/kie-server-parent/kie-server-router/README.md
+++ b/kie-server-parent/kie-server-router/README.md
@@ -1,8 +1,8 @@
 KIE Server Router
 ==========================
 
-## TSL support
-To start the router with TSL support, start it with following command: 
+## TLS support
+To start the router with TLS support, start it with following command: 
 ```
 java -Dorg.kie.server.router.tls.keystore=PATH_TO_YOUR_KEYSTORE 
      -Dorg.kie.server.router.tls.keystore.password=YOUR_KEYSTORE_PASSWD 

--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/handlers/AbstractAggregateHttpHandler.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/handlers/AbstractAggregateHttpHandler.java
@@ -31,6 +31,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import javax.net.ssl.SSLException;
+
 import org.jboss.logging.Logger;
 import org.kie.server.router.ConfigurationManager;
 import org.kie.server.router.proxy.aggragate.ResponseAggregator;
@@ -252,7 +254,7 @@ public abstract class AbstractAggregateHttpHandler implements HttpHandler {
     }
 
     protected void removeHostOnException(String url, Exception e) {
-        if (e instanceof SocketException || e instanceof UnknownHostException) {
+        if (e instanceof SocketException || e instanceof UnknownHostException || e instanceof SSLException) {
             configurationManager.disconnectFailedHost(url);
             log.warn("Removed host '" + url + "' due to its unavailability (cause " + e.getMessage() + ")");
         }


### PR DESCRIPTION
**JIRA**: [JBPM-10041](https://issues.redhat.com/browse/JBPM-10041)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
