### PR TITLE
[7.67.x] [JBPM-10042] Kie server webc controller is missing cdi-api dependency

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-standalone/pom.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-standalone/pom.xml
@@ -74,7 +74,6 @@
     <dependency>
       <groupId>jakarta.enterprise</groupId>
       <artifactId>jakarta.enterprise.cdi-api</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/kie-server-parent/kie-server-controller/kie-server-controller-standalone/src/main/assembly/assembly-ee7-container.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-standalone/src/main/assembly/assembly-ee7-container.xml
@@ -43,6 +43,7 @@
       <excludes>
         <exclude>org.jboss.resteasy:resteasy-jaxrs</exclude>
         <exclude>jakarta.ws.rs:*</exclude>
+        <exclude>jakarta.enterprise:jakarta.enterprise.cdi-api</exclude>
       </excludes>
       <includes>
         <include>org.kie.server:kie-server-controller-api</include>

--- a/kie-server-parent/kie-server-controller/kie-server-controller-standalone/src/main/assembly/assembly-servlet-container.xml
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-standalone/src/main/assembly/assembly-servlet-container.xml
@@ -50,7 +50,7 @@
         <include>com.sun.xml.bind:jaxb-core</include>
         <include>com.sun.xml.bind:jaxb-impl</include>
         <include>org.slf4j:slf4j-sdk14</include>
-        <include>javax.enterprise:cdi-api</include>
+        <include>jakarta.enterprise:jakarta.enterprise.cdi-api</include>
       </includes>
       <outputDirectory>WEB-INF/lib</outputDirectory>
       <useTransitiveFiltering>true</useTransitiveFiltering>


### PR DESCRIPTION
Signed-off-by: Karel Suta <ksuta@redhat.com>

**Thank you for submitting this pull request**

[JBPM-10042](https://issues.redhat.com/browse/JBPM-10042)

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
