### PR TITLE
[7.67.x][RHPAM-4028] Add CountDefinition to ServiceResponse

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/ServiceResponse.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/model/ServiceResponse.java
@@ -65,6 +65,7 @@ import org.kie.server.api.model.cases.CaseStage;
 import org.kie.server.api.model.cases.CaseStageDefinition;
 import org.kie.server.api.model.cases.CaseStageList;
 import org.kie.server.api.model.definition.AssociatedEntitiesDefinition;
+import org.kie.server.api.model.definition.CountDefinition;
 import org.kie.server.api.model.definition.ProcessDefinition;
 import org.kie.server.api.model.definition.ProcessDefinitionList;
 import org.kie.server.api.model.definition.QueryDefinition;
@@ -201,7 +202,8 @@ public class ServiceResponse<T> implements KieServiceResponse<T> {
             @XmlElement(name = "query-definitions", type = QueryDefinitionList.class),
             @XmlElement(name = "document-instance", type = DocumentInstance.class),
             @XmlElement(name = "document-instance-list", type = DocumentInstanceList.class),
-
+            @XmlElement(name =  "count-definition", type = CountDefinition.class),
+            
             // optaplanner entities
             @XmlElement(name = "solver-instance", type = SolverInstance.class),
             @XmlElement(name = "solver-instance-list", type = SolverInstanceList.class),

--- a/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/main/java/org/kie/server/remote/rest/jbpm/docs/ParameterSamples.java
+++ b/kie-server-parent/kie-server-remote/kie-server-rest/kie-server-rest-jbpm/src/main/java/org/kie/server/remote/rest/jbpm/docs/ParameterSamples.java
@@ -711,9 +711,7 @@ public class ParameterSamples {
             "}";
     
     public static final String COUNT_PROCESS_INSTANCES_RESPONSE_JSON = "{\n" +
-            "  \"count\": {\n" +
-            "      \"count\": 150\n" +
-            "  }\n" +
+            "  \"count\": 150\n" +
             "}";
     
     public static final String QUERY_DEF_LIST_RESPONSE_JSON = "{\n" + 


### PR DESCRIPTION
Signed-off-by: ruromero <rromerom@redhat.com>

**JIRA**: 
[RHPAM-4028](https://issues.redhat.com/browse/RHPAM-4028)

**referenced Pull Requests**:

* follow up on https://github.com/kiegroup/droolsjbpm-integration/pull/2745
