### PR TITLE
[JBPM-10057] - Flaky test fix - org.kie.server.router.repository.FileRepositoryTest#testWatchServiceOnLatelyCreatedConfigFile

### DIFF
--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/test/java/org/kie/server/router/repository/FileRepositoryTest.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/test/java/org/kie/server/router/repository/FileRepositoryTest.java
@@ -185,7 +185,9 @@ public class FileRepositoryTest {
     public void testWatchServiceOnLatelyCreatedConfigFile() throws Exception {
         ScheduledExecutorService executorService = Executors.newScheduledThreadPool(8);
         // Start watcher service with not existing config file
-        File repositoryDirectory = new File("target" + File.separator + UUID.randomUUID().toString());
+        String fileDir = "target" + File.separator + UUID.randomUUID().toString();
+        System.setProperty(KieServerRouterConstants.ROUTER_REPOSITORY_DIR, fileDir);
+        File repositoryDirectory = new File(fileDir);
         repositoryDirectory.mkdirs();
 
         System.setProperty(KieServerRouterConstants.CONFIG_FILE_WATCHER_ENABLED, "true");
@@ -219,9 +221,7 @@ public class FileRepositoryTest {
         ContainerInfo containerInfo = new ContainerInfo("test1.0", "test", "org.kie:test:1.0");
         config.addContainerInfo(containerInfo);
 
-        synchronized (configurationManager) {
-            repoWithWatcher.persist(config);
-        }
+        repoWithWatcher.persist(config);
 
         // delay it a bit for the watcher to be triggered
         latch.await(5, TimeUnit.SECONDS);
@@ -294,10 +294,7 @@ public class FileRepositoryTest {
         ContainerInfo containerInfo = new ContainerInfo("test1.0", "test", "org.kie:test:1.0");
         config.addContainerInfo(containerInfo);
 
-        synchronized (configurationManager) {
-            repoWithWatcher.persist(config);
-        }
-
+        repoWithWatcher.persist(config);
 
         File serverStateFile = new File(repositoryDirectory, "kie-server-router" + ".json");
 


### PR DESCRIPTION
**[JBPM-10057](https://issues.redhat.com/browse/JBPM-10057)**: Flaky test fix - org.kie.server.router.repository.FileRepositoryTest#testWatchServiceOnLatelyCreatedConfigFile 

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
