### PR TITLE
[JBPM-10064] - ConfigFileWatcher class should not try to reload a config file when no file has been created

### DIFF
--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/ConfigurationManager.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/ConfigurationManager.java
@@ -125,7 +125,7 @@ public class ConfigurationManager {
         return environment;
     }
 
-    public  synchronized FailedHostInfo disconnectFailedHost(String url) {
+    public synchronized FailedHostInfo disconnectFailedHost(String url) {
         log.info("Server at " + url+ " is now offline");
         FailedHostInfo failedHost = configuration.removeUnavailableServer(url);
         log.debug("Scheduling host checks..."+ failedHost);

--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/repository/ConfigFileWatcher.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/repository/ConfigFileWatcher.java
@@ -50,12 +50,11 @@ public class ConfigFileWatcher implements Runnable {
 
         this.toWatch = Paths.get(toWatch.toString(), "kie-server-router.json");
         try {
-            if(toWatch.toFile().exists()) {
-                lastUpdate = Files.getLastModifiedTime(toWatch).toMillis();
-            } else {
+            if (!toWatch.toFile().exists()) {
                 log.warnv("configuration file does not exist {0} , creating...", this.toWatch);
                 configuration.persist();
             }
+            lastUpdate = Files.getLastModifiedTime(toWatch).toMillis();
         } catch (IOException e) {
             log.error("Unable to read last modified date of routers config file", e);
         } catch (final Exception e) {

--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/repository/FileRepository.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/repository/FileRepository.java
@@ -38,7 +38,7 @@ public class FileRepository implements ConfigRepository {
     }
 
     @Override
-    public void persist(Configuration configuration) {
+    public synchronized void persist(Configuration configuration) {
 
         File configFile = new File(repositoryDir, "kie-server-router.json");
         try (FileOutputStream fos = new FileOutputStream(configFile)) {


### PR DESCRIPTION
**[JBPM-10064](https://issues.redhat.com/browse/JBPM-10064)**: ConfigFileWatcher class should not try to reload a config file when no file has been created

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
