### PR TITLE
[JBPM-10064] - ConfigFileWatcher class should not try to reload a config file when no file has been created

### DIFF
--- a/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/repository/ConfigFileWatcher.java
+++ b/kie-server-parent/kie-server-router/kie-server-router-proxy/src/main/java/org/kie/server/router/repository/ConfigFileWatcher.java
@@ -50,12 +50,11 @@ public class ConfigFileWatcher implements Runnable {
 
         this.toWatch = Paths.get(toWatch.toString(), "kie-server-router.json");
         try {
-            if(toWatch.toFile().exists()) {
-                lastUpdate = Files.getLastModifiedTime(toWatch).toMillis();
-            } else {
+            if (!toWatch.toFile().exists()) {
                 log.warnv("configuration file does not exist {0} , creating...", this.toWatch);
                 configuration.persist();
             }
+            lastUpdate = Files.getLastModifiedTime(toWatch).toMillis();
         } catch (IOException e) {
             log.error("Unable to read last modified date of routers config file", e);
         } catch (final Exception e) {


### PR DESCRIPTION
Backport of https://github.com/kiegroup/droolsjbpm-integration/pull/2777/