### PR TITLE
JBPM-10079 ClassCastException when submitting a form in kie-server containing date process variable

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
@@ -235,10 +235,16 @@ public class JSONMarshaller implements Marshaller {
         if (classes == null) {
             classes = new HashSet<Class<?>>();
         }
+
         // add byte array handling support to allow byte[] to be send as payload
         classes.add(JaxbByteArray.class);
+
         if (!formatDate) {
             classes.add(Date.class);
+            classes.add(java.time.LocalDateTime.class);
+            classes.add(java.time.LocalTime.class);
+            classes.add(java.time.OffsetDateTime.class);
+            classes.add(java.time.LocalDate.class);
         }
 
         List<NamedType> customClasses = prepareCustomClasses(classes);

--- a/kie-server-parent/kie-server-api/src/test/resources/supportedDateType.json
+++ b/kie-server-parent/kie-server-api/src/test/resources/supportedDateType.json
@@ -1,0 +1,40 @@
+{
+  "bbdate": {
+    "java.time.LocalDateTime": "2022-05-19T10:00"
+  },
+  "bdate": {
+    "java.time.LocalDateTime": "2022-05-19T00:00"
+  },
+  "localdate": {
+    "java.time.LocalDate": "2022-05-19"
+  },
+  "localtime": {
+    "java.time.LocalTime": "17:32"
+  },
+  "name": "",
+  "offsetDateTime": {
+    "java.time.OffsetDateTime": "2007-12-03T10:15:30+01:00"
+  },
+  "sqldate": {
+    "org.kie.server.api.marshalling.SupportedlDate": {
+      "utildate": {
+        "java.util.Date": "2022-05-21"
+      },
+      "localDate": {
+        "java.time.LocalDate": "2022-05-19T00:00"
+      },
+      "localDateTime": {
+        "java.time.LocalDateTime": "2022-05-19T10:00"
+      },
+      "localTime": {
+        "java.time.LocalTime": "17:32"
+      },
+      "offsetDateTime": {
+        "java.time.OffsetDateTime": "2007-12-03T10:15:30+01:00"
+      }
+    }
+  },
+  "utildate": {
+    "java.util.Date": "2022-05-21"
+  }
+}

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/resources/form-templates-providers/bootstrap/input-form-group-template.html
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/resources/form-templates-providers/bootstrap/input-form-group-template.html
@@ -60,7 +60,7 @@
 	<#if item.required>
 	<strong style="color: red">*</strong>
 	</#if>
-    <input id="${item.id}" name="${item.name}" type="date" class="form-control" value="${item.value}" ${(item.required)?string('required', '')} pattern="${item.pattern}"/>    
+    <input id="${item.id}" name="${item.name}" type="date" class="form-control" value="${item.value}" ${(item.required)?string('required', '')} ${(item.readOnly)?string('disabled', '')}"/>
 </div>
 <#elseif item.type == "datetime-local">
 <div class="form-group">

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/resources/form-templates-providers/js/kieserver-ui.js
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/resources/form-templates-providers/js/kieserver-ui.js
@@ -556,11 +556,36 @@ function closeCreationForm(fieldId) {
 	currentRow = null;
 }
 
-function getLocalDateWithoutTime(elementId) {
+function getFormattedLocalDateTime(jsondate) {
+	return {'java.time.LocalDateTime': jsondate};
+}
+
+function getFormattedUtilDate(jsondate) {
+	return {'java.util.Date': jsondate};
+}
+
+function getFormattedLocalDate(jsondate) {
+	return {'java.time.LocalDate': jsondate};
+}
+
+function getFormattedLocalTime(jsondate) {
+	return {'java.time.LocalTime': jsondate};
+}
+
+function getFormattedOffsetDateTime(jsondate) {
+	return {'java.time.OffsetDateTime': jsondate};
+}
+
+function getDate(elementId, getDateValueByType) {
+	var value = document.getElementById(elementId).value;
+	return getDateValueByType(value);
+}
+
+function getDateWithoutTime(elementId, getDateValueByType) {
 	var value = document.getElementById(elementId).value;
 	if (value === '') {
-		return value;
+		return getDateValueByType(value);
 	} else {
-		return value + 'T00:00';
+		return getDateValueByType(value + 'T00:00');
 	}
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/resources/form-templates-providers/patternfly/input-form-group-template.html
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/resources/form-templates-providers/patternfly/input-form-group-template.html
@@ -59,7 +59,7 @@
 	<#if item.required>
 	<strong style="color: red">*</strong>
 	</#if>
-    <input id="${item.id}" name="${item.name}" type="date" class="form-control" value="${item.value}" ${(item.required)?string('required', '')} pattern="${item.pattern}"/>    
+    <input id="${item.id}" name="${item.name}" type="date" class="form-control" value="${item.value}" ${(item.required)?string('required', '')} ${(item.readOnly)?string('disabled', '')}"/>
 </div>
 <#elseif item.type == "datetime-local">
 <div class="form-group">

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/java/org/kie/server/services/jbpm/ui/form/render/BootstrapFormRendererTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/java/org/kie/server/services/jbpm/ui/form/render/BootstrapFormRendererTest.java
@@ -34,7 +34,7 @@ public class BootstrapFormRendererTest {
 
         BootstrapFormRenderer bootstrapFormRenderer = new BootstrapFormRenderer();
         String outString = bootstrapFormRenderer.renderProcess("test-containerId", processAssetDesc, form);
-        assertThat(outString).contains("'dateBirth' : String(getLocalDateWithoutTime('field_1703386699666296E12') )");
+        assertThat(outString).contains("'dateBirth' : getDateWithoutTime('field_1703386699666296E12',getFormattedLocalDateTime)");
         assertThat(outString).contains("<input id=\"field_1703386699666296E12\" name=\"dateBirth\" type=\"date\" class=\"form-control\" value=");
     }
 
@@ -49,7 +49,24 @@ public class BootstrapFormRendererTest {
         BootstrapFormRenderer bootstrapFormRenderer = new BootstrapFormRenderer();
         String outString = bootstrapFormRenderer.renderProcess("test-containerId", processAssetDesc, form);
 
-        assertThat(outString).contains("'dateBirth' : String(document.getElementById('field_1703386699666296E12').value)");
+        assertThat(outString).contains("getDate('field_1703386699666296E12',getFormattedLocalDateTime)");
         assertThat(outString).contains("<input id=\"field_1703386699666296E12\" name=\"dateBirth\" type=\"datetime-local\" class=\"form-control\" value=");
+    }
+
+    @Test
+    public void testProcessFormRendererWithSupportedDateType() {
+        FormReader reader = new FormReader();
+
+        FormInstance form = reader.readFromStream(this.getClass().getResourceAsStream("/date-type-check-form.json"));
+        ProcessAssetDesc processAssetDesc = new ProcessAssetDesc();
+        processAssetDesc.setId("test-id");
+
+        BootstrapFormRenderer bootstrapFormRenderer = new BootstrapFormRenderer();
+        String outString = bootstrapFormRenderer.renderProcess("test-containerId", processAssetDesc, form);
+        assertThat(outString).contains("'utildate' : getDate('field_6682',getFormattedUtilDate)");
+        assertThat(outString).contains("'localdate' : getDate('field_1147',getFormattedLocalDate)");
+        assertThat(outString).contains("'localdatetime' : getDate('field_778156',getFormattedLocalDateTime)");
+        assertThat(outString).contains("'localtime' : getDate('field_032',getFormattedLocalTime)");
+        assertThat(outString).contains("'offsetdatetime' : getDate('field_9077',getFormattedOffsetDateTime)");
     }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/java/org/kie/server/services/jbpm/ui/form/render/FormRendererTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/java/org/kie/server/services/jbpm/ui/form/render/FormRendererTest.java
@@ -309,7 +309,7 @@ public class FormRendererTest {
         assertThat(renderedForm).isNotNull()
                                 .containsIgnoringCase("value=\"2020-12-01T23:11:00\"")
                                 .containsIgnoringCase("value=\"2020-12-01\"")
-                                .containsIgnoringCase("value=\"2020-12-01T00:00:00.000\"")
+                                .containsIgnoringCase("value=\"2020-12-01\"")
                                 .containsIgnoringCase("value=\"12:01:00\"");
 
         writeToFile("testRenderOfBasicTaskFormWithSelectRadioGroupAndData.html", renderedForm);

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/resources/date-type-check-form.json
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/test/resources/date-type-check-form.json
@@ -1,0 +1,286 @@
+{
+  "id": "430f9ea2-c461-4c97-b5e5-fe14b0cc629a",
+  "name": "sqlDateForm",
+  "model": {
+    "source": "INTERNAL",
+    "className": "com.asf.date_test.SqlDate",
+    "name": "SqlDate",
+    "properties": [
+      {
+        "name": "utildate",
+        "typeInfo": {
+          "type": "BASE",
+          "className": "java.util.Date",
+          "multiple": false
+        },
+        "metaData": {
+          "entries": []
+        }
+      },
+      {
+        "name": "localdate",
+        "typeInfo": {
+          "type": "BASE",
+          "className": "java.time.LocalDate",
+          "multiple": false
+        },
+        "metaData": {
+          "entries": []
+        }
+      },
+      {
+        "name": "localdatetime",
+        "typeInfo": {
+          "type": "BASE",
+          "className": "java.time.LocalDateTime",
+          "multiple": false
+        },
+        "metaData": {
+          "entries": []
+        }
+      },
+      {
+        "name": "localtime",
+        "typeInfo": {
+          "type": "BASE",
+          "className": "java.time.LocalTime",
+          "multiple": false
+        },
+        "metaData": {
+          "entries": []
+        }
+      },
+      {
+        "name": "offsetdatetime",
+        "typeInfo": {
+          "type": "BASE",
+          "className": "java.time.OffsetDateTime",
+          "multiple": false
+        },
+        "metaData": {
+          "entries": []
+        }
+      }
+    ],
+    "formModelType": "org.kie.workbench.common.forms.data.modeller.model.DataObjectFormModel"
+  },
+  "fields": [
+    {
+      "placeHolder": "utildate",
+      "showTime": true,
+      "id": "field_6682",
+      "name": "a",
+      "label": "utildate",
+      "required": false,
+      "readOnly": false,
+      "validateOnChange": true,
+      "helpMessage": "",
+      "binding": "utildate",
+      "standaloneClassName": "java.util.Date",
+      "code": "DatePicker",
+      "serializedFieldClassName": "org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.definition.DatePickerFieldDefinition"
+    },
+    {
+      "placeHolder": "localdatetime",
+      "showTime": true,
+      "id": "field_778156",
+      "name": "localdatetime",
+      "label": "C",
+      "required": false,
+      "readOnly": false,
+      "validateOnChange": true,
+      "helpMessage": "",
+      "binding": "localdatetime",
+      "standaloneClassName": "java.time.LocalDateTime",
+      "code": "DatePicker",
+      "serializedFieldClassName": "org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.definition.DatePickerFieldDefinition"
+    },
+    {
+      "placeHolder": "localdate",
+      "showTime": true,
+      "id": "field_1147",
+      "name": "localdate",
+      "label": "B",
+      "required": false,
+      "readOnly": false,
+      "validateOnChange": true,
+      "helpMessage": "",
+      "binding": "localdate",
+      "standaloneClassName": "java.time.LocalDate",
+      "code": "DatePicker",
+      "serializedFieldClassName": "org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.definition.DatePickerFieldDefinition"
+    },
+    {
+      "placeHolder": "localtime",
+      "showTime": true,
+      "id": "field_032",
+      "name": "localtime",
+      "label": "D",
+      "required": false,
+      "readOnly": false,
+      "validateOnChange": true,
+      "helpMessage": "",
+      "binding": "localtime",
+      "standaloneClassName": "java.time.LocalTime",
+      "code": "DatePicker",
+      "serializedFieldClassName": "org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.definition.DatePickerFieldDefinition"
+    },
+    {
+      "placeHolder": "offsetdatetime",
+      "showTime": true,
+      "id": "field_9077",
+      "name": "offsetdatetime",
+      "label": "E",
+      "required": false,
+      "readOnly": false,
+      "validateOnChange": true,
+      "helpMessage": "",
+      "binding": "offsetdatetime",
+      "standaloneClassName": "java.time.OffsetDateTime",
+      "code": "DatePicker",
+      "serializedFieldClassName": "org.kie.workbench.common.forms.fields.shared.fieldTypes.basic.datePicker.definition.DatePickerFieldDefinition"
+    }
+  ],
+  "layoutTemplate": {
+    "version": 3,
+    "style": "FLUID",
+    "layoutProperties": {},
+    "rows": [
+      {
+        "height": "12",
+        "properties": {},
+        "layoutColumns": [
+          {
+            "span": "12",
+            "height": "12",
+            "properties": {},
+            "rows": [],
+            "layoutComponents": [
+              {
+                "dragTypeName": "org.kie.workbench.common.forms.editor.client.editor.rendering.EditorFieldLayoutComponent",
+                "properties": {
+                  "field_id": "field_6682",
+                  "form_id": "430f9ea2-c461-4c97-b5e5-fe14b0cc629a"
+                },
+                "parts": [
+                  {
+                    "partId": "Field Label",
+                    "cssProperties": {}
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "height": "12",
+        "properties": {},
+        "layoutColumns": [
+          {
+            "span": "12",
+            "height": "12",
+            "properties": {},
+            "rows": [],
+            "layoutComponents": [
+              {
+                "dragTypeName": "org.kie.workbench.common.forms.editor.client.editor.rendering.EditorFieldLayoutComponent",
+                "properties": {
+                  "field_id": "field_1147",
+                  "form_id": "430f9ea2-c461-4c97-b5e5-fe14b0cc629a"
+                },
+                "parts": [
+                  {
+                    "partId": "Field Label",
+                    "cssProperties": {}
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "height": "12",
+        "properties": {},
+        "layoutColumns": [
+          {
+            "span": "12",
+            "height": "12",
+            "properties": {},
+            "rows": [],
+            "layoutComponents": [
+              {
+                "dragTypeName": "org.kie.workbench.common.forms.editor.client.editor.rendering.EditorFieldLayoutComponent",
+                "properties": {
+                  "field_id": "field_778156",
+                  "form_id": "430f9ea2-c461-4c97-b5e5-fe14b0cc629a"
+                },
+                "parts": [
+                  {
+                    "partId": "Field Label",
+                    "cssProperties": {}
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "height": "12",
+        "properties": {},
+        "layoutColumns": [
+          {
+            "span": "12",
+            "height": "12",
+            "properties": {},
+            "rows": [],
+            "layoutComponents": [
+              {
+                "dragTypeName": "org.kie.workbench.common.forms.editor.client.editor.rendering.EditorFieldLayoutComponent",
+                "properties": {
+                  "field_id": "field_032",
+                  "form_id": "430f9ea2-c461-4c97-b5e5-fe14b0cc629a"
+                },
+                "parts": [
+                  {
+                    "partId": "Field Label",
+                    "cssProperties": {}
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "height": "12",
+        "properties": {},
+        "layoutColumns": [
+          {
+            "span": "12",
+            "height": "12",
+            "properties": {},
+            "rows": [],
+            "layoutComponents": [
+              {
+                "dragTypeName": "org.kie.workbench.common.forms.editor.client.editor.rendering.EditorFieldLayoutComponent",
+                "properties": {
+                  "field_id": "field_9077",
+                  "form_id": "430f9ea2-c461-4c97-b5e5-fe14b0cc629a"
+                },
+                "parts": [
+                  {
+                    "partId": "Field Label",
+                    "cssProperties": {}
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[https://issues.redhat.com/browse/JBPM-10079](https://issues.redhat.com/browse/JBPM-10079)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
