### PR TITLE
[JBPM-10092] added alias to kie-ctrl:create-container and kie-ctrl:de…

### DIFF
--- a/kie-server-parent/kie-server-controller-plugin/README.md
+++ b/kie-server-parent/kie-server-controller-plugin/README.md
@@ -318,6 +318,7 @@ Parameters are:
 | templateId         | null                          | true      | kie-ctrl.template-id         | String          |
 | templateName       | ${templateId}                 | false     | kie-ctrl.template-name       | String          |
 | container          | ${project.GAV}                | false     | kie-ctrl.container           | String          |
+| alias              | ${container}                  | false     | kie-ctrl.alias               | String          |
 | runtimeStrategy    | null                          | false     | kie-ctrl.runtime-strategy    | String          |
 | kbase              | null                          | false     | kie-ctrl.kbase               | String          |
 | ksession           | null                          | false     | kie-ctrl.ksession            | String          |
@@ -476,6 +477,7 @@ Parameters are:
 | templateId           | null                          | true      | kie-ctrl.template-id          | String          |
 | templateName         | ${templateId}                 | false     | kie-ctrl.template-name        | String          |
 | container            | ${project.GAV}                | false     | kie-ctrl.container            | String          |
+| alias                | ${container}                  | false     | kie-ctrl.alias                | String          |
 | runtimeStrategy      | null                          | false     | kie-ctrl.runtime-strategy     | String          |
 | kbase                | null                          | false     | kie-ctrl.kbase                | String          |
 | ksession             | null                          | false     | kie-ctrl.ksession             | String          |

--- a/kie-server-parent/kie-server-controller-plugin/src/main/java/org/kie/server/controller/builder/ContainerBuilder.java
+++ b/kie-server-parent/kie-server-controller-plugin/src/main/java/org/kie/server/controller/builder/ContainerBuilder.java
@@ -33,6 +33,8 @@ public class ContainerBuilder {
 
     private String id;
 
+    private String alias;
+
     @NotEmpty
     private String groupId;
 
@@ -56,6 +58,11 @@ public class ContainerBuilder {
     // if container name is not defined by default we use maven GAV
     public String getId() {
         return (id != null) ? id : getGAV();
+    }
+
+    // if container alias is not defined by default we use id
+    public String getAlias() {
+        return (alias != null) ? alias : getId();
     }
 
     public ContainerSpec build(String templateId, String templateName) {
@@ -84,7 +91,7 @@ public class ContainerBuilder {
         ReleaseId releasedId = new ReleaseId(groupId, artifactId, version);
 
         return new ContainerSpec(
-            getId(), getId(),
+            getId(), getAlias(),
             new ServerTemplateKey(templateId, templateName),
             releasedId, KieContainerStatus.STOPPED, configs
         );
@@ -107,6 +114,11 @@ public class ContainerBuilder {
 
     public ContainerBuilder id(String id) {
         this.id = id;
+        return this;
+    }
+
+    public ContainerBuilder alias(String alias) {
+        this.alias = alias;
         return this;
     }
 

--- a/kie-server-parent/kie-server-controller-plugin/src/main/java/org/kie/server/controller/plugin/CreateContainerMojo.java
+++ b/kie-server-parent/kie-server-controller-plugin/src/main/java/org/kie/server/controller/plugin/CreateContainerMojo.java
@@ -41,6 +41,9 @@ public class CreateContainerMojo extends KieControllerMojo {
     @Parameter(property = "kie-ctrl.container")
     protected String container;
 
+    @Parameter(property = "kie-ctrl.alias")
+    protected String alias;
+
     @Parameter(defaultValue = "${project}", readonly = true)
     protected MavenProject project;
 
@@ -75,6 +78,7 @@ public class CreateContainerMojo extends KieControllerMojo {
         ContainerBuilder containerBuilder =
             ContainerBuilder.create(project.getGroupId(), project.getArtifactId(), project.getVersion())
                 .id(container)
+                .alias(alias)
                 .runtimeStrategy(runtimeStrategy)
                 .kbase(kbase)
                 .ksession(ksession)

--- a/kie-server-parent/kie-server-controller-plugin/src/main/java/org/kie/server/controller/plugin/DeployContainerMojo.java
+++ b/kie-server-parent/kie-server-controller-plugin/src/main/java/org/kie/server/controller/plugin/DeployContainerMojo.java
@@ -46,6 +46,9 @@ public class DeployContainerMojo extends KieControllerMojo {
     @Parameter(property = "kie-ctrl.container")
     protected String container;
 
+    @Parameter(property = "kie-ctrl.alias")
+    protected String alias;
+
     @Parameter(defaultValue = "${project}", readonly = true)
     protected MavenProject project;
 
@@ -88,6 +91,7 @@ public class DeployContainerMojo extends KieControllerMojo {
         ContainerBuilder containerBuilder =
             ContainerBuilder.create(project.getGroupId(), project.getArtifactId(), project.getVersion())
                 .id(container)
+                .alias(alias)
                 .runtimeStrategy(runtimeStrategy)
                 .kbase(kbase)
                 .ksession(ksession)


### PR DESCRIPTION
Specify different container alias than the container name on kie-ctrl:create-container on kie-server-controller-plugin.

Add a property alias for kie-ctrl:create-container and kie-ctrl:deploy-container

[link][([JBPM-10092)](https://issues.redhat.com/browse/JBPM-10092)