### PR TITLE
[DROOLS-7056] NullPointerException when sending DeleteCommand for non…

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/StatefulSessionUsageIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-drools/src/test/java/org/kie/server/integrationtests/drools/StatefulSessionUsageIntegrationTest.java
@@ -424,4 +424,25 @@ public class StatefulSessionUsageIntegrationTest extends DroolsKieServerBaseInte
         assertEquals("Expected surname to be set to 'Lord Vader'",
                      PERSON_EXPECTED_SURNAME_AFTER_UPDATE, KieServerReflections.valueOf(returnedPerson, PERSON_SURNAME_FIELD));
     }
+
+    @Test
+    public void testInsertDisposeDelete() {
+        // DROOLS-7056
+        // Insert
+        Object person = createInstance(PERSON_CLASS_NAME, PERSON_NAME, "");
+        Command<?> insertCommand = commandsFactory.newInsert(person, PERSON_1_OUT_IDENTIFIER);
+        ServiceResponse<ExecutionResults> reply = ruleClient.executeCommandsWithResults(CONTAINER_ID, insertCommand);
+        assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
+        FactHandle factHandle = (FactHandle) reply.getResult().getFactHandle(PERSON_1_OUT_IDENTIFIER);
+
+        // Dispose
+        Command<?> disposeCommand = commandsFactory.newDispose();
+        reply = ruleClient.executeCommandsWithResults(CONTAINER_ID, disposeCommand);
+        assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType());
+
+        // Delete : It means creating a new ksession and deleting a non-existing factHandle
+        Command<?> deleteCommand = commandsFactory.newDelete(factHandle);
+        reply = ruleClient.executeCommandsWithResults(CONTAINER_ID, deleteCommand);
+        assertEquals(ServiceResponse.ResponseType.SUCCESS, reply.getType()); // No error
+    }
 }


### PR DESCRIPTION
…-existing fact

**JIRA**: 
https://issues.redhat.com/browse/DROOLS-7056

**referenced Pull Requests**: 
* https://github.com/kiegroup/drools/pull/4524

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
