### PR TITLE
JBPM-9286 UI error when parent process instance details have been rem…

### DIFF
--- a/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/QueryServiceImplTest.java
+++ b/kie-server-parent/kie-server-remote/kie-server-client/src/test/java/org/kie/server/client/QueryServiceImplTest.java
@@ -1,0 +1,40 @@
+package org.kie.server.client;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.model.definition.ProcessDefinition;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.junit.Assert.assertEquals;
+
+public class QueryServiceImplTest extends BaseKieServicesClientTest {
+
+    private QueryServicesClient queryServicesClient;
+
+    @Before
+    public void createClient() {
+        config.setCapabilities(Arrays.asList(KieServerConstants.CAPABILITY_BPM));
+        queryServicesClient = KieServicesFactory.newKieServicesClient(config).getServicesClient(QueryServicesClient.class);
+    }
+
+    @Test
+    public void testFindProcessesByIdNotFound() {
+        stubFor(get(urlEqualTo("/"))
+                        .withHeader("Accept", equalTo("application/xml"))
+                        .willReturn(aResponse()
+                                            .withStatus(404)
+                                            .withHeader("Content-Type", "application/xml")
+                                            .withBody("<response type=\"NOTFOUND\" msg= </response>")));
+
+        List<ProcessDefinition> list = queryServicesClient.findProcessesById("Not eixst");
+        assertEquals(0, list.size());
+    }
+}


### PR DESCRIPTION
…oved, add unit test

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[https://issues.redhat.com/browse/JBPM-9286](https://issues.redhat.com/browse/JBPM-9286)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
