### PR TITLE
RHPAM-4455 ssl.insecure to maven-invoker-plugin invoker.properties

### DIFF
--- a/kie-integration-test-coverage/kie-maven-plugin-default-execmodel-tests/kjar-with-instrumentation-default-execmodel-wrapper/src/test/resources/kjar-with-instrumentation-default-execmodel/invoker.properties
+++ b/kie-integration-test-coverage/kie-maven-plugin-default-execmodel-tests/kjar-with-instrumentation-default-execmodel-wrapper/src/test/resources/kjar-with-instrumentation-default-execmodel/invoker.properties
@@ -1,0 +1,6 @@
+# A comma or space separated list of goals/phases to execute, may
+# specify an empty list to execute the default goal of the IT project.
+# Environment variables used by maven plugins can be added here
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
+# Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
+#invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-integration-test-coverage/kie-maven-plugin-no-execmodel-tests/kjar-with-instrumentation-no-execmodel-wrapper/src/test/resources/kjar-with-instrumentation-no-execmodel/invoker.properties
+++ b/kie-integration-test-coverage/kie-maven-plugin-no-execmodel-tests/kjar-with-instrumentation-no-execmodel-wrapper/src/test/resources/kjar-with-instrumentation-no-execmodel/invoker.properties
@@ -1,0 +1,6 @@
+# A comma or space separated list of goals/phases to execute, may
+# specify an empty list to execute the default goal of the IT project.
+# Environment variables used by maven plugins can be added here
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
+# Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
+#invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-integration-test-coverage/kie-maven-plugin-separate-model-tests/kjar-with-separate-instrumentation-wrapper/src/test/resources/kjar-with-separate-instrumentation/invoker.properties
+++ b/kie-integration-test-coverage/kie-maven-plugin-separate-model-tests/kjar-with-separate-instrumentation-wrapper/src/test/resources/kjar-with-separate-instrumentation/invoker.properties
@@ -1,0 +1,6 @@
+# A comma or space separated list of goals/phases to execute, may
+# specify an empty list to execute the default goal of the IT project.
+# Environment variables used by maven plugins can be added here
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
+# Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
+#invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-integration-test-coverage/kie-maven-plugin-separate-model-tests/model-wrapper/src/test/resources/model/invoker.properties
+++ b/kie-integration-test-coverage/kie-maven-plugin-separate-model-tests/model-wrapper/src/test/resources/model/invoker.properties
@@ -1,0 +1,6 @@
+# A comma or space separated list of goals/phases to execute, may
+# specify an empty list to execute the default goal of the IT project.
+# Environment variables used by maven plugins can be added here
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
+# Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
+#invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-default/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-default/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean package verify
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-yes-generate/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-10-yes-generate/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean package verify
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-default/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-default/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean package verify
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-yes-generate/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-11-yes-generate/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean package verify
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-12/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean package verify
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-13/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-13/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean package verify
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-2/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-2/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean package verify
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-3/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-3/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean package verify
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-4/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-4/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean package verify
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-5/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-5/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean package verify
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-6/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-6/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean package verify
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-exec-model/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean package verify
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-no-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-7-no-exec-model/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean package verify
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-exec-model/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean package verify
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-8-no-exec-model/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean package verify
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-exec-model/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean package verify
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-no-exec-model/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-9-no-exec-model/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean package verify
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean install
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-common/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-common/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean install
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000

--- a/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/invoker.properties
+++ b/kie-maven-plugin/src/it/kie-maven-plugin-test-kjar-setup/kie-maven-plugin-test-kjar-parent/invoker.properties
@@ -2,5 +2,6 @@
 # specify an empty list to execute the default goal of the IT project.
 # Environment variables used by maven plugins can be added here
 invoker.goals = clean install
+invoker.mavenOpts = -Dmaven.wagon.http.ssl.insecure=true
 # Uncomment the following to debug invoker. Do note that you have to connect the remote debugger after "maven-invoker-plugin:3.2.0:run" has been print on console
 #invoker.mavenOpts=-Xdebug -Xnoagent -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000


### PR DESCRIPTION
the `org.w3c.dom.ElementTraversal` class is not present for jdk8, so we force org.w3c:dom dependency to be present.
As soon as we agree this is the right proposal, I will propagate it to `7.67.x` and `7.67.x-blue` branches
Built and tested either with JDK11 and 8.

**JIRA**: 
https://issues.redhat.com/browse/RHPAM-4455

**referenced Pull Requests**: 

* https://github.com/kiegroup/kie-wb-distributions/pull/1173
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2023
* https://github.com/kiegroup/kie-wb-common/pull/3755
* https://github.com/kiegroup/droolsjbpm-integration/pull/2835

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
