### PR TITLE
Ensure elytron is on the classpath before using it

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/pom.xml
@@ -214,22 +214,4 @@
     </dependency>
 
   </dependencies>
-
-  <profiles>
-    <profile>
-      <id>tomcat9</id>
-      <activation>
-        <property>
-          <name>container.profile</name>
-          <value>tomcat9</value>
-        </property>
-      </activation>
-      <dependencies>
-        <dependency>
-          <groupId>org.wildfly.security</groupId>
-          <artifactId>wildfly-elytron-auth-server</artifactId>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 </project>

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/security/ElytronIdentityProvider.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/security/ElytronIdentityProvider.java
@@ -30,7 +30,13 @@ public class ElytronIdentityProvider
         extends BaseIdentityProvider {
 
     public static boolean available() {
-        return SecurityDomain.getCurrent() != null;
+        try {
+            // ensure SecurityDomain is on classpath, if not directly return false
+            Class.forName("org.wildfly.security.auth.server.SecurityDomain");
+            return SecurityDomain.getCurrent() != null;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
     }
 
     @Override

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/security/ElytronUserGroupAdapter.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/main/java/org/kie/server/services/jbpm/security/ElytronUserGroupAdapter.java
@@ -53,28 +53,24 @@ public class ElytronUserGroupAdapter implements UserGroupAdapter {
         String userName = getUserName();
         logger.debug("Identifier Elytron as {}", userId);
 
-        if (isActive()) {
-            if (userName == null) {
-                return new ArrayList<>();
-            }
+        if (!isActive() || userName == null) {
+            return new ArrayList<>();
+        }
 
-            if (userId.equals(userName)) {
-                logger.debug("User identified as {} but auth as {}", userId, userName);
-                return toPrincipalRoles(userId);
-            } else {
-                try {
-                    if (runAsPrincipalExists(userId)) {
-                        logger.debug("Executing run as {}", userId);
-                        return toRunAsPrincipalRoles(userId, true);
-                    } else {
-                        return new ArrayList<>();
-                    }
-                } catch (Exception e) {
-                    if (e.getClass().isAssignableFrom(authorizationFailureExceptionClass)) {
-                        return toRunAsPrincipalRoles(userId, false);
-                    } else if (e instanceof RealmUnavailableException || e instanceof SecurityException) {
-                        return new ArrayList<>();
-                    }
+        if (userId.equals(userName)) {
+            logger.debug("User identified as {} but auth as {}", userId, userName);
+            return toPrincipalRoles(userId);
+        } else {
+            try {
+                if (runAsPrincipalExists(userId)) {
+                    logger.debug("Executing run as {}", userId);
+                    return toRunAsPrincipalRoles(userId, true);
+                }
+            } catch (Exception e) {
+                logger.debug("Run as {} failed", userId);
+                if (e.getClass().isAssignableFrom(authorizationFailureExceptionClass)) {
+                    logger.debug("Executing run as {} without authorization", userId);
+                    return toRunAsPrincipalRoles(userId, false);
                 }
             }
         }

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/test/java/org/kie/server/services/jbpm/security/ElytronUserGroupAdapterTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/test/java/org/kie/server/services/jbpm/security/ElytronUserGroupAdapterTest.java
@@ -16,17 +16,20 @@
 
 package org.kie.server.services.jbpm.security;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.powermock.reflect.Whitebox;
 import org.wildfly.security.auth.server.RealmUnavailableException;
+import org.wildfly.security.authz.AuthorizationFailureException;
 
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.lenient;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -46,8 +49,9 @@ public class ElytronUserGroupAdapterTest {
 
     @Test
     public void testNoSecurityContext() {
-        when(adapter.isActive()).thenReturn(true);
-        when(adapter.getGroupsForUser(Mockito.anyObject())).thenCallRealMethod();
+        setAuthorizationFailureExceptionClass();
+        when(adapter.isActive()).thenCallRealMethod();
+        when(adapter.getGroupsForUser(Mockito.anyString())).thenCallRealMethod();
         when(adapter.getUserName()).thenReturn(null);
         List<String> roles = adapter.getGroupsForUser(USER_ID);
 
@@ -58,8 +62,9 @@ public class ElytronUserGroupAdapterTest {
 
     @Test
     public void testSecurityContextNoIdentity() {
-        when(adapter.isActive()).thenReturn(true);
-        when(adapter.getGroupsForUser(Mockito.anyObject())).thenCallRealMethod();
+        setAuthorizationFailureExceptionClass();
+        when(adapter.isActive()).thenCallRealMethod();
+        when(adapter.getGroupsForUser(Mockito.anyString())).thenCallRealMethod();
         when(adapter.getUserName()).thenReturn(USER_ID);
 
         List<String> roles = adapter.getGroupsForUser(USER_ID);
@@ -71,8 +76,9 @@ public class ElytronUserGroupAdapterTest {
 
     @Test
     public void testSecurityForWrongUser() throws RealmUnavailableException {
-        when(adapter.isActive()).thenReturn(true);
-        when(adapter.getGroupsForUser(Mockito.anyObject())).thenCallRealMethod();
+        setAuthorizationFailureExceptionClass();
+        when(adapter.isActive()).thenCallRealMethod();
+        when(adapter.getGroupsForUser(Mockito.anyString())).thenCallRealMethod();
         when(adapter.getUserName()).thenReturn(USER_ID);
         when(adapter.runAsPrincipalExists(WRONG_USER_ID)).thenReturn(true);
         when(adapter.toRunAsPrincipalRoles(WRONG_USER_ID, true)).thenReturn(Arrays.asList(ROLE_1, ROLE_2));
@@ -87,10 +93,11 @@ public class ElytronUserGroupAdapterTest {
 
     @Test
     public void testSecurityForLoggedUser() {
-        when(adapter.isActive()).thenReturn(true);
-        when(adapter.getGroupsForUser(Mockito.anyObject())).thenCallRealMethod();
+        setAuthorizationFailureExceptionClass();
+        when(adapter.isActive()).thenCallRealMethod();
+        when(adapter.getGroupsForUser(Mockito.anyString())).thenCallRealMethod();
         when(adapter.getUserName()).thenReturn(USER_ID);
-        when(adapter.toPrincipalRoles(Mockito.anyObject())).thenReturn(Arrays.asList(ROLE_1, ROLE_2, ROLE_3));
+        when(adapter.toPrincipalRoles(Mockito.anyString())).thenReturn(Arrays.asList(ROLE_1, ROLE_2, ROLE_3));
 
         List<String> roles = adapter.getGroupsForUser(USER_ID);
 
@@ -99,4 +106,43 @@ public class ElytronUserGroupAdapterTest {
                 .hasSize(3)
                 .contains(ROLE_1, ROLE_2, ROLE_3);
     }
+
+    @Test
+    public void testSecurityOnRealmUnavailable() throws RealmUnavailableException {
+        setAuthorizationFailureExceptionClass();
+        when(adapter.isActive()).thenCallRealMethod();
+        when(adapter.getGroupsForUser(Mockito.anyString())).thenCallRealMethod();
+        when(adapter.getUserName()).thenReturn(WRONG_USER_ID);
+        when(adapter.runAsPrincipalExists(USER_ID)).thenThrow(new RealmUnavailableException());
+        lenient().when(adapter.toPrincipalRoles(Mockito.anyString())).thenReturn(Arrays.asList(ROLE_1, ROLE_2, ROLE_3));
+        lenient().when(adapter.toRunAsPrincipalRoles(Mockito.anyString(), Mockito.eq(false))).thenReturn(Arrays.asList(ROLE_1, ROLE_2, ROLE_3));
+
+        List<String> roles = adapter.getGroupsForUser(USER_ID);
+
+        Assertions.assertThat(roles)
+                .isNotNull()
+                .hasSize(0);
+    }
+
+    @Test
+    public void testSecurityOnAuthorizationFailure() throws AuthorizationFailureException, RealmUnavailableException {
+        setAuthorizationFailureExceptionClass();
+        when(adapter.isActive()).thenCallRealMethod();
+        when(adapter.getGroupsForUser(Mockito.anyString())).thenCallRealMethod();
+        when(adapter.getUserName()).thenReturn(WRONG_USER_ID);
+        when(adapter.runAsPrincipalExists(USER_ID)).thenThrow(AuthorizationFailureException.class);
+        when(adapter.toRunAsPrincipalRoles(Mockito.anyString(), Mockito.eq(false))).thenReturn(Arrays.asList(ROLE_1, ROLE_2, ROLE_3));
+
+        List<String> roles = adapter.getGroupsForUser(USER_ID);
+
+        Assertions.assertThat(roles)
+                .isNotNull()
+                .hasSize(3)
+                .contains(ROLE_1, ROLE_2, ROLE_3);
+    }
+
+    private void setAuthorizationFailureExceptionClass() {
+        Whitebox.setInternalState(adapter, Class.class, (Object) AuthorizationFailureException.class);
+    }
 }
+

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/test/java/org/kie/server/services/jbpm/security/ElytronUserGroupAdapterTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/test/java/org/kie/server/services/jbpm/security/ElytronUserGroupAdapterTest.java
@@ -46,6 +46,7 @@ public class ElytronUserGroupAdapterTest {
 
     @Test
     public void testNoSecurityContext() {
+        when(adapter.isActive()).thenReturn(true);
         when(adapter.getGroupsForUser(Mockito.anyObject())).thenCallRealMethod();
         when(adapter.getUserName()).thenReturn(null);
         List<String> roles = adapter.getGroupsForUser(USER_ID);
@@ -57,6 +58,7 @@ public class ElytronUserGroupAdapterTest {
 
     @Test
     public void testSecurityContextNoIdentity() {
+        when(adapter.isActive()).thenReturn(true);
         when(adapter.getGroupsForUser(Mockito.anyObject())).thenCallRealMethod();
         when(adapter.getUserName()).thenReturn(USER_ID);
 
@@ -69,6 +71,7 @@ public class ElytronUserGroupAdapterTest {
 
     @Test
     public void testSecurityForWrongUser() throws RealmUnavailableException {
+        when(adapter.isActive()).thenReturn(true);
         when(adapter.getGroupsForUser(Mockito.anyObject())).thenCallRealMethod();
         when(adapter.getUserName()).thenReturn(USER_ID);
         when(adapter.runAsPrincipalExists(WRONG_USER_ID)).thenReturn(true);
@@ -84,6 +87,7 @@ public class ElytronUserGroupAdapterTest {
 
     @Test
     public void testSecurityForLoggedUser() {
+        when(adapter.isActive()).thenReturn(true);
         when(adapter.getGroupsForUser(Mockito.anyObject())).thenCallRealMethod();
         when(adapter.getUserName()).thenReturn(USER_ID);
         when(adapter.toPrincipalRoles(Mockito.anyObject())).thenReturn(Arrays.asList(ROLE_1, ROLE_2, ROLE_3));

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/test/java/org/kie/server/services/jbpm/security/ElytronUserGroupAdapterTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/test/java/org/kie/server/services/jbpm/security/ElytronUserGroupAdapterTest.java
@@ -121,7 +121,7 @@ public class ElytronUserGroupAdapterTest {
 
         Assertions.assertThat(roles)
                 .isNotNull()
-                .hasSize(0);
+                .isEmpty();
     }
 
     @Test
@@ -139,6 +139,27 @@ public class ElytronUserGroupAdapterTest {
                 .isNotNull()
                 .hasSize(3)
                 .contains(ROLE_1, ROLE_2, ROLE_3);
+    }
+
+    @Test
+    public void testSecurityElytronDisabled() throws RealmUnavailableException {
+        when(adapter.isActive()).thenCallRealMethod();
+        when(adapter.getGroupsForUser(Mockito.anyString())).thenCallRealMethod();
+        when(adapter.getUserName()).thenReturn(USER_ID);
+
+        List<String> roles = adapter.getGroupsForUser(USER_ID);
+
+        Assertions.assertThat(roles)
+                .isNotNull()
+                .isEmpty();
+    }
+
+    @Test
+    public void testToRolesWithEmptySecurityIdentity() {
+        List<String> roles = adapter.toRoles(null);
+        Assertions.assertThat(roles)
+                .isNotNull()
+                .isEmpty();
     }
 
     private void setAuthorizationFailureExceptionClass() {


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: 

- https://issues.redhat.com/browse/RHPAM-4714

**referenced Pull Requests**: 
* https://github.com/kiegroup/droolsjbpm-integration/pull/2961

Changes performed https://github.com/kiegroup/droolsjbpm-integration/pull/2961 were not enough as kieServerMatrix tests are still failing while using `tomcat` server:

```
[INFO] [talledLocalContainer] SEVERE: Exception sending context initialized event to listener instance of class [org.kie.server.remote.rest.common.Bootstrap]
[INFO] [talledLocalContainer] java.lang.NoClassDefFoundError: org/wildfly/security/auth/server/SecurityDomain
[INFO] [talledLocalContainer] 	at org.kie.server.services.impl.security.ElytronIdentityProvider.available(ElytronIdentityProvider.java:33)
[INFO] [talledLocalContainer] 	at org.kie.server.services.impl.KieServerImpl.init(KieServerImpl.java:157)
[INFO] [talledLocalContainer] 	at org.kie.server.services.impl.KieServerImpl.init(KieServerImpl.java:142)
[INFO] [talledLocalContainer] 	at org.kie.server.services.impl.KieServerLocator$KieServerLocatorHelper.<clinit>(KieServerLocator.java:25)
[INFO] [talledLocalContainer] 	at org.kie.server.services.impl.KieServerLocator.getInstance(KieServerLocator.java:32)
[INFO] [talledLocalContainer] 	at org.kie.server.remote.rest.common.Bootstrap.contextInitialized(Bootstrap.java:51)
[INFO] [talledLocalContainer] 	at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4682)
[INFO] [talledLocalContainer] 	at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5143)
....
[INFO] [talledLocalContainer] Caused by: java.lang.ClassNotFoundException: org.wildfly.security.auth.server.SecurityDomain
[INFO] [talledLocalContainer] 	at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1365)
[INFO] [talledLocalContainer] 	at org.apache.catalina.loader.WebappClassLoaderBase.loadClass(WebappClassLoaderBase.java:1188)
[INFO] [talledLocalContainer] 	... 47 more
```

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
