### PR TITLE
[JBPM-10214] Fix regression for immutable KIE container with auto scan

### DIFF
--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration/src/main/java/org/kie/server/springboot/autoconfiguration/KieServerAutoConfiguration.java
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration/src/main/java/org/kie/server/springboot/autoconfiguration/KieServerAutoConfiguration.java
@@ -173,7 +173,8 @@ public class KieServerAutoConfiguration extends AbstractJaxrsClassesScanServer {
     public List<KieContainerResource> buildAutoScanDeployments(KieServerProperties kieServerProperties) throws IOException {
         ApplicationHome appHome = new ApplicationHome();
         final String folder = "BOOT-INF/classes/KIE-INF/lib/";
-        return (explodedJarFolder == null) ? discoverDeployments(folder, new FileInputStream(appHome.getSource())) :  discoverDeployments(folder, new File(explodedJarFolder));
+        List<KieContainerResource> containerResources = discoverDeployments(folder, new File(explodedJarFolder));
+        return (containerResources.isEmpty()) ? discoverDeployments(folder, new FileInputStream(appHome.getSource())) : containerResources;
     }
 
     public List<KieContainerResource> discoverDeployments(String folder, File root) {

--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration/src/main/java/org/kie/server/springboot/autoconfiguration/KieServerAutoConfiguration.java
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration/src/main/java/org/kie/server/springboot/autoconfiguration/KieServerAutoConfiguration.java
@@ -174,7 +174,7 @@ public class KieServerAutoConfiguration extends AbstractJaxrsClassesScanServer {
         ApplicationHome appHome = new ApplicationHome();
         final String folder = "BOOT-INF/classes/KIE-INF/lib/";
         List<KieContainerResource> containerResources = discoverDeployments(folder, new File(explodedJarFolder));
-        return (containerResources.isEmpty()) ? discoverDeployments(folder, new FileInputStream(appHome.getSource())) : containerResources;
+        return containerResources.isEmpty() ? discoverDeployments(folder, new FileInputStream(appHome.getSource())) : containerResources;
     }
 
     public List<KieContainerResource> discoverDeployments(String folder, File root) {


### PR DESCRIPTION
**JIRA**: [JBPM-10214](https://issues.redhat.com/browse/JBPM-10214)

`explodedJarFolder` has a default value, i.e.,  it won't be null ever. As we want to keep the previous behavior, the best way IMHO without adding more configuration is to try the exploded option first and, if not present, try to autoscan the fat-jar.


<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>
