### PR TITLE
Update JSONMarshaller.java

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
@@ -309,6 +309,8 @@ public class JSONMarshaller implements Marshaller {
             customObjectMapper.setConfig(customObjectMapper.getSerializationConfig().with(introspectorPair).with(SerializationFeature.INDENT_OUTPUT));
             customObjectMapper.configure(MapperFeature.USE_STD_BEAN_NAMING, this.useStrictJavaBeans);
 
+            customObjectMapper.registerModule(new JavaTimeModule());
+
             SimpleModule mod = new SimpleModule("custom-object-mapper", Version.unknownVersion());
             CustomObjectSerializer customObjectSerializer = new CustomObjectSerializer(customObjectMapper);
 


### PR DESCRIPTION
If customObjects contains java.time.* classes, serialization, will fail.
