### PR TITLE
[FIX_TERMINATOR_TEST_VARIABLES] terminator is not counted in some decision tests

### DIFF
--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/DecisionTasksIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-all/src/test/java/org/kie/server/integrationtests/jbpm/DecisionTasksIntegrationTest.java
@@ -86,7 +86,7 @@ public class DecisionTasksIntegrationTest extends JbpmKieServerBaseIntegrationTe
 
             List<VariableInstance> variables = queryClient.findVariablesCurrentState(processInstanceId);
             assertNotNull(variables);
-            assertEquals(2, variables.size());
+            assertEquals(3, variables.size());
             Map<String, String> mappedVars = variables.stream().collect(Collectors.toMap(VariableInstance::getVariableName, VariableInstance::getValue));
             assertEquals("Person{name='john' age='35'}", mappedVars.get("person"));
             processInstanceId = null;
@@ -119,7 +119,7 @@ public class DecisionTasksIntegrationTest extends JbpmKieServerBaseIntegrationTe
 
             List<VariableInstance> variables = queryClient.findVariablesCurrentState(processInstanceId);
             assertNotNull(variables);
-            assertEquals(4, variables.size());
+            assertEquals(5, variables.size());
             Map<String, String> mappedVars = variables.stream().collect(Collectors.toMap(VariableInstance::getVariableName, VariableInstance::getValue));
             assertEquals("27", mappedVars.get("vacationDays"));
             processInstanceId = null;


### PR DESCRIPTION
Terminator value of the system is not accounted in some decision tests. Added.