### PR TITLE
[FIX] custom fix when xml adapter has names

### DIFF
--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/KieServerConstants.java
@@ -63,6 +63,7 @@ public class KieServerConstants {
     public static final String KIE_SERVER_MODE = "org.kie.server.mode";
     public static final String KIE_SERVER_INCLUDE_STACKTRACE = "org.kie.server.stacktrace.included";
     public static final String KIE_SERVER_STRICT_ID_FORMAT = "org.kie.server.strict.id.format";
+    public static final String JSON_HANDLE_XML_ANY_ELEMENTS_NAMES = "org.kie.server.strict.json.xmlanyelements";
     public static final String KIE_SERVER_STRICT_JAVABEANS_SERIALIZERS = "org.kie.server.strict.javaBeans.serializers";
     public static final String KIE_SERVER_STRICT_JAXB_FORMAT = "org.kie.server.strict.jaxb.format";
     public static final String KIE_SERVER_IMAGESERVICE_MAX_NODES = "org.kie.server.service.image.max_nodes";

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
@@ -39,9 +39,25 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapters;
+
+import org.drools.core.xml.jaxb.util.JaxbListAdapter;
+import org.drools.core.xml.jaxb.util.JaxbListWrapper;
+import org.drools.core.xml.jaxb.util.JaxbUnknownAdapter;
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.marshalling.Marshaller;
+import org.kie.server.api.marshalling.MarshallingException;
+import org.kie.server.api.marshalling.MarshallingFormat;
+import org.kie.server.api.marshalling.ModelWrapper;
+import org.kie.server.api.model.Wrapped;
+import org.kie.server.api.model.definition.QueryParam;
+import org.kie.server.api.model.type.JaxbByteArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -80,25 +96,13 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
-import org.drools.core.xml.jaxb.util.JaxbListAdapter;
-import org.drools.core.xml.jaxb.util.JaxbListWrapper;
-import org.drools.core.xml.jaxb.util.JaxbUnknownAdapter;
-import org.kie.server.api.KieServerConstants;
-import org.kie.server.api.marshalling.Marshaller;
-import org.kie.server.api.marshalling.MarshallingException;
-import org.kie.server.api.marshalling.MarshallingFormat;
-import org.kie.server.api.marshalling.ModelWrapper;
-import org.kie.server.api.model.Wrapped;
-import org.kie.server.api.model.definition.QueryParam;
-import org.kie.server.api.model.type.JaxbByteArray;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class JSONMarshaller implements Marshaller {
 
     private static final Logger logger = LoggerFactory.getLogger(JSONMarshaller.class);
 
     private static final boolean STRICT_ID_FORMAT = Boolean.getBoolean(KieServerConstants.KIE_SERVER_STRICT_ID_FORMAT);
+    private boolean jsonHandleXmlAnyElementsNames = Boolean.getBoolean(KieServerConstants.JSON_HANDLE_XML_ANY_ELEMENTS_NAMES);
     private final boolean STRICT_JAVABEANS_SERIALIZERS = Boolean.getBoolean(KieServerConstants.KIE_SERVER_STRICT_JAVABEANS_SERIALIZERS);
 
     private static final String FIELDS = "fields";
@@ -106,7 +110,6 @@ public class JSONMarshaller implements Marshaller {
 
     private boolean formatDate;
     private String dateFormatStr = System.getProperty("org.kie.server.json.date_format", "yyyy-MM-dd'T'hh:mm:ss.SSSZ");
-
 
     private boolean useStrictJavaBeans;
     private boolean fallbackClassLoaderEnabled = Boolean.parseBoolean(System.getProperty("org.kie.server.json.fallbackClassLoader.enabled", "false"));
@@ -129,7 +132,7 @@ public class JSONMarshaller implements Marshaller {
         private boolean stripped;
 
         private boolean wrap;
-        
+
         private boolean writeNull;
 
         public JSONContext() {
@@ -182,8 +185,6 @@ public class JSONMarshaller implements Marshaller {
     // Optional Marshaller Extension to handle new types
     private static final List<JSONMarshallerExtension> EXTENSIONS;
 
-    
-
     // Load Marshaller Extension
     static {
         logger.info("Marshaller extensions init");
@@ -224,7 +225,7 @@ public class JSONMarshaller implements Marshaller {
             return CNFEBehavior.valueOf(cnfeBehaviorValue);
         } catch (IllegalArgumentException iae) {
             throw new MarshallingException(cnfeBehaviorValue + " is not supported for " + KieServerConstants.JSON_CUSTOM_OBJECT_DESERIALIZER_CNFE_BEHAVIOR +
-                                           ". Please choose from " + Arrays.asList(CNFEBehavior.values()).toString(), iae);
+                    ". Please choose from " + Arrays.asList(CNFEBehavior.values()).toString(), iae);
         }
     }
 
@@ -301,6 +302,7 @@ public class JSONMarshaller implements Marshaller {
                     }
                     return false;
                 }
+
             };
             typer = typer.init(JsonTypeInfo.Id.CLASS, null);
             typer = typer.inclusion(JsonTypeInfo.As.WRAPPER_OBJECT);
@@ -403,8 +405,7 @@ public class JSONMarshaller implements Marshaller {
             if (parameters.containsKey(MARSHALLER_PARAMETER_STRICT)) {
                 jsonContext.get().setWrap(Boolean.parseBoolean((String) parameters.get(MARSHALLER_PARAMETER_STRICT)));
             }
-            if (NOT_NULL.equals(parameters.get(FIELDS)))
-            {
+            if (NOT_NULL.equals(parameters.get(FIELDS))) {
                 jsonContext.get().setWriteNull(false);
             }
             return marshall(input);
@@ -416,7 +417,7 @@ public class JSONMarshaller implements Marshaller {
     @Override
     public String marshall(Object objectInput) {
         try {
-            return getMapper(objectMapper,notNullObjectMapper).writeValueAsString(wrap(objectInput));
+            return getMapper(objectMapper, notNullObjectMapper).writeValueAsString(wrap(objectInput));
         } catch (IOException e) {
             throw new MarshallingException("Error marshalling input", e);
         }
@@ -431,7 +432,6 @@ public class JSONMarshaller implements Marshaller {
         }
 
     }
-
 
     @Override
     public <T> T unmarshall(String serializedInput, Class<T> type) {
@@ -503,18 +503,31 @@ public class JSONMarshaller implements Marshaller {
 
         @Override
         public List<NamedType> findSubtypes(Annotated a) {
-            List<NamedType> base = super.findSubtypes(a);
-
             List<NamedType> complete = new ArrayList<NamedType>();
-            if (base != null) {
-                complete.addAll(base);
-            }
             if (customClasses != null) {
-                for (NamedType namedType  : customClasses) {
+                for (NamedType namedType : customClasses) {
                     Class<?> clazz = namedType.getType();
                     if (!a.getRawType().equals(clazz) && a.getRawType().isAssignableFrom(clazz)) {
                         complete.add(namedType);
                     }
+                }
+            }
+
+            XmlElements elements = findAnnotation(XmlElements.class, a, false, false, false);
+            if (elements != null) {
+                for (XmlElement elem : elements.value()) {
+                    if (!jsonHandleXmlAnyElementsNames && customClasses.contains(new NamedType(elem.type(), elem.type().getSimpleName()))) {
+                        continue;
+                    }
+                    String name = elem.name();
+                    if (MARKER_FOR_DEFAULT.equals(name))
+                        name = null;
+                    complete.add(new NamedType(elem.type(), name));
+                }
+            } else {
+                List<NamedType> base = super.findSubtypes(a);
+                if (base != null) {
+                    complete.addAll(base);
                 }
             }
             return complete;
@@ -706,7 +719,7 @@ public class JSONMarshaller implements Marshaller {
 
         @Override
         public void serialize(Object value, JsonGenerator jgen, SerializerProvider provider) throws IOException, JsonProcessingException {
-            jgen.writeRawValue(getMapper(customObjectMapper,notNullObjectMapper).writeValueAsString(value));
+            jgen.writeRawValue(getMapper(customObjectMapper, notNullObjectMapper).writeValueAsString(value));
         }
     }
 
@@ -725,17 +738,17 @@ public class JSONMarshaller implements Marshaller {
             String className = value.getClass().getName();
 
             if (value instanceof Collection) {
-                String collectionJson = writeCollection((Collection) value, getMapper(customObjectMapper,notNullObjectMapper));
+                String collectionJson = writeCollection((Collection) value, getMapper(customObjectMapper, notNullObjectMapper));
                 jgen.writeRawValue(collectionJson);
             } else if (value instanceof Map) {
-                String mapJson = writeMap((Map) value, getMapper(customObjectMapper,notNullObjectMapper));
+                String mapJson = writeMap((Map) value, getMapper(customObjectMapper, notNullObjectMapper));
                 jgen.writeRawValue(mapJson);
             } else if (value instanceof Object[] || value.getClass().isArray()) {
-                String arrayJson = writeArray((Object[]) value, getMapper(customObjectMapper,notNullObjectMapper));
+                String arrayJson = writeArray((Object[]) value, getMapper(customObjectMapper, notNullObjectMapper));
                 jgen.writeRawValue(arrayJson);
             } else {
 
-                String json = getMapper(customObjectMapper,notNullObjectMapper).writeValueAsString(value);
+                String json = getMapper(customObjectMapper, notNullObjectMapper).writeValueAsString(value);
 
                 // don't wrap java and javax classes as they are always available, in addition avoid double wrapping
                 if (!className.startsWith("java.") && !className.startsWith("javax.") && !json.contains(className)) {
@@ -842,13 +855,10 @@ public class JSONMarshaller implements Marshaller {
             return builder.toString();
         }
     }
-    
-    private ObjectMapper getMapper(ObjectMapper alwaysMapper, ObjectMapper notNullMapper)
-    {
+
+    private ObjectMapper getMapper(ObjectMapper alwaysMapper, ObjectMapper notNullMapper) {
         return jsonContext.get().isWriteNull() ? alwaysMapper : notNullMapper;
     }
-
-    
 
     class CustomObjectDeserializer extends UntypedObjectDeserializer {
 
@@ -976,6 +986,7 @@ public class JSONMarshaller implements Marshaller {
             }
             return result;
         }
+
         private Object[] toArray(Object element) {
             if (element != null) {
 
@@ -1159,5 +1170,9 @@ public class JSONMarshaller implements Marshaller {
     @Override
     public ClassLoader getClassLoader() {
         return classLoader;
+    }
+
+    public void setXmlAnyElementsNames(boolean jsonHandleXmlAnyElementsNames) {
+        this.jsonHandleXmlAnyElementsNames = jsonHandleXmlAnyElementsNames;
     }
 }

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
@@ -104,8 +104,8 @@ public class JSONMarshaller implements Marshaller {
     private boolean jsonHandleXmlAnyElementsNames = Boolean.getBoolean(KieServerConstants.JSON_HANDLE_XML_ANY_ELEMENTS_NAMES);
     private final boolean STRICT_JAVABEANS_SERIALIZERS = Boolean.getBoolean(KieServerConstants.KIE_SERVER_STRICT_JAVABEANS_SERIALIZERS);
 
-    private static final String FIELDS = "fields";
-    private static final String NOT_NULL = "not_null";
+    public static final String FIELDS = "fields";
+    public static final String NOT_NULL = "not_null";
 
     private boolean formatDate;
     private String dateFormatStr = System.getProperty("org.kie.server.json.date_format", "yyyy-MM-dd'T'hh:mm:ss.SSSZ");

--- a/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
+++ b/kie-server-parent/kie-server-api/src/main/java/org/kie/server/api/marshalling/json/JSONMarshaller.java
@@ -45,20 +45,6 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapters;
 
-import org.drools.core.xml.jaxb.util.JaxbListAdapter;
-import org.drools.core.xml.jaxb.util.JaxbListWrapper;
-import org.drools.core.xml.jaxb.util.JaxbUnknownAdapter;
-import org.kie.server.api.KieServerConstants;
-import org.kie.server.api.marshalling.Marshaller;
-import org.kie.server.api.marshalling.MarshallingException;
-import org.kie.server.api.marshalling.MarshallingFormat;
-import org.kie.server.api.marshalling.ModelWrapper;
-import org.kie.server.api.model.Wrapped;
-import org.kie.server.api.model.definition.QueryParam;
-import org.kie.server.api.model.type.JaxbByteArray;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonGenerator;
@@ -96,6 +82,19 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.fasterxml.jackson.databind.util.ClassUtil;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.jaxb.JaxbAnnotationIntrospector;
+import org.drools.core.xml.jaxb.util.JaxbListAdapter;
+import org.drools.core.xml.jaxb.util.JaxbListWrapper;
+import org.drools.core.xml.jaxb.util.JaxbUnknownAdapter;
+import org.kie.server.api.KieServerConstants;
+import org.kie.server.api.marshalling.Marshaller;
+import org.kie.server.api.marshalling.MarshallingException;
+import org.kie.server.api.marshalling.MarshallingFormat;
+import org.kie.server.api.marshalling.ModelWrapper;
+import org.kie.server.api.model.Wrapped;
+import org.kie.server.api.model.definition.QueryParam;
+import org.kie.server.api.model.type.JaxbByteArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JSONMarshaller implements Marshaller {
 
@@ -520,8 +519,9 @@ public class JSONMarshaller implements Marshaller {
                         continue;
                     }
                     String name = elem.name();
-                    if (MARKER_FOR_DEFAULT.equals(name))
+                    if (MARKER_FOR_DEFAULT.equals(name)) {
                         name = null;
+                    }   
                     complete.add(new NamedType(elem.type(), name));
                 }
             } else {

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/json/JSONMarshallerExtensionTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/json/JSONMarshallerExtensionTest.java
@@ -26,8 +26,9 @@ import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import org.assertj.core.api.Assertions;
 import org.drools.core.command.runtime.BatchExecutionCommandImpl;
 import org.drools.core.command.runtime.rule.InsertObjectCommand;
@@ -112,10 +113,15 @@ public class JSONMarshallerExtensionTest {
             marshall = marshaller.marshall(command);
         }
 
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode input = mapper.readTree(content);
-        JsonNode output = mapper.readTree(marshall);
-        assertThat(input.toPrettyString()).isEqualTo(output.toPrettyString());
+        BatchExecutionCommandImpl input = marshaller.unmarshall(content, BatchExecutionCommandImpl.class);
+        BatchExecutionCommandImpl output = marshaller.unmarshall(marshall, BatchExecutionCommandImpl.class);
+        
+        ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(Include.NON_NULL);
+        ObjectWriter writer = mapper.writerWithDefaultPrettyPrinter();
+
+        String inputStr = writer.writeValueAsString(input);
+        String outputStr = writer.writeValueAsString(output);
+        assertThat(inputStr).isEqualTo(outputStr);
     }
 
     @Test
@@ -136,9 +142,14 @@ public class JSONMarshallerExtensionTest {
             marshall = marshaller.marshall(command);
         }
 
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode input = mapper.readTree(content);
-        JsonNode output = mapper.readTree(marshall);
-        assertThat(input.toPrettyString()).isNotEqualTo(output.toPrettyString());
+        BatchExecutionCommandImpl input = marshaller.unmarshall(content, BatchExecutionCommandImpl.class);
+        BatchExecutionCommandImpl output = marshaller.unmarshall(marshall, BatchExecutionCommandImpl.class);
+        
+        ObjectMapper mapper = new ObjectMapper().setSerializationInclusion(Include.NON_NULL);
+        ObjectWriter writer = mapper.writerWithDefaultPrettyPrinter();
+
+        String inputStr = writer.writeValueAsString(input);
+        String outputStr = writer.writeValueAsString(output);
+        assertThat(inputStr).isEqualTo(outputStr);
     }
 }

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/json/JSONMarshallerExtensionTest.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/json/JSONMarshallerExtensionTest.java
@@ -18,7 +18,6 @@ package org.kie.server.api.marshalling.json;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
 import java.net.URL;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -27,6 +26,8 @@ import java.util.GregorianCalendar;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.assertj.core.api.Assertions;
 import org.drools.core.command.runtime.BatchExecutionCommandImpl;
 import org.drools.core.command.runtime.rule.InsertObjectCommand;
@@ -42,9 +43,6 @@ import org.kie.server.api.marshalling.objects.ItemsType;
 import org.kie.server.api.marshalling.objects.StandardItemType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/FreeFormItemType.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/FreeFormItemType.java
@@ -1,0 +1,46 @@
+package org.kie.server.api.marshalling.objects;
+
+import java.io.Serializable;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlType;
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "FreeFormItemType", propOrder = {
+    "itemValue"
+})
+public class FreeFormItemType implements Serializable, Cloneable
+{
+
+    private final static long serialVersionUID = 1L;
+
+    @XmlElement(required = true)
+    protected String itemValue;
+
+    /**
+     * Gets the value of the itemValue property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getItemValue() {
+        return itemValue;
+    }
+
+    /**
+     * Sets the value of the itemValue property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setItemValue(String value) {
+        this.itemValue = value;
+    }
+
+}

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/FreeFormItemType.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/FreeFormItemType.java
@@ -1,6 +1,22 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.kie.server.api.marshalling.objects;
 
 import java.io.Serializable;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/ItemsType.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/ItemsType.java
@@ -1,8 +1,24 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.kie.server.api.marshalling.objects;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/ItemsType.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/ItemsType.java
@@ -1,0 +1,35 @@
+package org.kie.server.api.marshalling.objects;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElements;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "ItemsType", propOrder = {
+    "standardItemsAndFreeformItems"
+})
+public class ItemsType
+    implements Serializable, Cloneable
+{
+
+    private final static long serialVersionUID = 1L;
+    @XmlElements({
+        @XmlElement(name = "standardItem", type = StandardItemType.class),
+        @XmlElement(name = "freeformItem", type = FreeFormItemType.class)
+    })
+    protected List<Serializable> standardItemsAndFreeformItems;
+
+    public List<Serializable> getStandardItemsAndFreeformItems() {
+        if (standardItemsAndFreeformItems == null) {
+            standardItemsAndFreeformItems = new ArrayList<Serializable>();
+        }
+        return this.standardItemsAndFreeformItems;
+    }
+
+
+}

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/StandardItemType.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/StandardItemType.java
@@ -1,6 +1,22 @@
+/*
+ * Copyright 2024 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.kie.server.api.marshalling.objects;
 
 import java.io.Serializable;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;

--- a/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/StandardItemType.java
+++ b/kie-server-parent/kie-server-api/src/test/java/org/kie/server/api/marshalling/objects/StandardItemType.java
@@ -1,0 +1,45 @@
+package org.kie.server.api.marshalling.objects;
+
+import java.io.Serializable;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.XmlValue;
+
+
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "StandardItemType", propOrder = {
+    "value"
+})
+public class StandardItemType implements Serializable, Cloneable
+{
+
+    private final static long serialVersionUID = 1L;
+    @XmlValue
+    protected String value;
+
+    /**
+     * Gets the value of the value property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link String }
+     *     
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Sets the value of the value property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link String }
+     *     
+     */
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/kie-server-parent/kie-server-api/src/test/resources/poly_payload.json
+++ b/kie-server-parent/kie-server-api/src/test/resources/poly_payload.json
@@ -1,0 +1,35 @@
+{
+  "commands": [
+    {
+      "insert": {
+                "object": {
+                        "org.kie.server.api.marshalling.objects.ItemsType": {
+                            "standardItemsAndFreeformItems": [
+                                {
+                                    "FreeFormItemType": {
+                                        "itemValue": "TEST 1"
+                                    }
+                                },
+                                {
+                                    "FreeFormItemType": {
+                                        "itemValue": "TEST 2"
+                                    }
+                                }
+                            ]
+                        }
+        },
+                "disconnected": false,
+                "out-identifier": "result",
+                "return-object": true,
+                "entry-point": "DEFAULT"
+      }
+    },
+    {
+      "fire-all-rules": {
+        "max": -1,
+        "agendaFilter": null,
+        "out-identifier" : "numberOfFiredRules"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The performance problem was related to the polymorphic feature of jackson. it computes the subtypes of a given types.
Before the patch we were saying that all classes contained in the kjar/project where subtypes of every class causing a huge impact in performance
That performance problem was causing another problem, it was overwriting the proper names for types
Every class when you are serializing you have the full qualified name and the name used for serialized and deserialized
So before the patch we were overwriting that information making this feature not working properly
Now because the subtypes are being computed properly we are not overwriting the names therefore now the name is being taken from the annotation like it should be
