### PR TITLE
Allow multiple implementations of KieServerController through the ServiceLoader

### DIFF
--- a/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/KieServerController.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-api/src/main/java/org/kie/server/controller/api/KieServerController.java
@@ -27,7 +27,7 @@ import org.kie.server.controller.api.model.KieServerSetup;
 public interface KieServerController {
 
     /**
-     * Entry point for for KieServer to connect(and register if done for the first time). At the same time, when given KieServerInstance
+     * Entry point for KieServer to connect(and register if done for the first time). At the same time, when given KieServerInstance
      * has been already added a KieServerSetup with data will be returned. Otherwise empty (or default) KieServerSetup will be provided.
      * @param serverInfo representation of minimal set of information about KieServer
      * @return KieServer configuration
@@ -35,8 +35,8 @@ public interface KieServerController {
     KieServerSetup connect(KieServerInfo serverInfo);
 
     /**
-     * Entry point for for KieServer to update its status information.
-     * @param serverInfo representation of minimal set of information about KieServer
+     * Entry point for KieServer to update its status information.
+     * @param containerSpec representation of minimal set of information about KieServer
      */
 
     default KieServerSetup update(KieServerStateInfo containerSpec) {

--- a/kie-server-parent/kie-server-controller/kie-server-controller-websocket-client/src/main/java/org/kie/server/controller/websocket/client/WebSocketKieServerControllerImpl.java
+++ b/kie-server-parent/kie-server-controller/kie-server-controller-websocket-client/src/main/java/org/kie/server/controller/websocket/client/WebSocketKieServerControllerImpl.java
@@ -51,10 +51,9 @@ public class WebSocketKieServerControllerImpl implements KieServerController, Ki
     private KieServerRegistry context;
     private final KieServerMessageHandlerWebSocketClient client;
     private final Marshaller marshaller;
-    
+    private final DefaultRestControllerImpl restController = new DefaultRestControllerImpl();
+
     private KieServerInfo serverInfo;
-    
-    private DefaultRestControllerImpl restController;
 
     public WebSocketKieServerControllerImpl() {
         this.marshaller = MarshallerFactory.getMarshaller(MarshallingFormat.JSON, this.getClass().getClassLoader());
@@ -67,6 +66,16 @@ public class WebSocketKieServerControllerImpl implements KieServerController, Ki
                 logger.warn("Error when trying to reconnect to Web Socket server - {}", e.getMessage());
             }
         });
+    }
+
+    @Override
+    public Integer getPriority() {
+        return 100;
+    }
+
+    @Override
+    public boolean supports(String url) {
+        return url != null && url.startsWith("ws");
     }
 
     @Override
@@ -170,15 +179,11 @@ public class WebSocketKieServerControllerImpl implements KieServerController, Ki
     @Override
     public void setRegistry(KieServerRegistry registry) {
         this.context = registry;
-        
-        this.restController = new DefaultRestControllerImpl(this.context);
+        this.restController.setRegistry(registry);
     }
 
     @Override
     public KieServerRegistry getRegistry() {
         return this.context;
     }
-
-
-
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieServerRegistryAware.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/api/KieServerRegistryAware.java
@@ -6,4 +6,18 @@ public interface KieServerRegistryAware {
     void setRegistry(KieServerRegistry registry);
     
     KieServerRegistry getRegistry();
+
+
+    /**
+     * Determine the priority of the loaded KieServerController loaded through the ServiceLoader.
+     * @return A priority for the KieServerController. 0 being the highest, Integer.MAX_VALUE being the lowest. If null, then the lowest priority is assumed.
+     */
+    Integer getPriority();
+
+    /**
+     * Determine if a KieServerController supports a specific connection point.
+     * @param url The URL to check.
+     * @return true if the KieServerController supports the endpoint, false otherwise.
+     */
+    boolean supports(String url);
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/controller/DefaultRestControllerImpl.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/controller/DefaultRestControllerImpl.java
@@ -36,22 +36,41 @@ import org.kie.server.controller.api.model.KieServerSetup;
 import org.kie.server.services.api.KieControllerNotConnectedException;
 import org.kie.server.services.api.KieControllerNotDefinedException;
 import org.kie.server.services.api.KieServerRegistry;
+import org.kie.server.services.api.KieServerRegistryAware;
 import org.kie.server.services.impl.storage.KieServerState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.kie.server.common.KeyStoreHelperUtil.loadControllerPassword;
 
-public class DefaultRestControllerImpl implements KieServerController {
+public class DefaultRestControllerImpl implements KieServerController, KieServerRegistryAware {
 
     private static final Logger logger = LoggerFactory.getLogger(DefaultRestControllerImpl.class);
 
-    private final KieServerRegistry context;
+    private KieServerRegistry context;
 
-    public DefaultRestControllerImpl(KieServerRegistry context) {
-        this.context = context;
+    public DefaultRestControllerImpl() {
     }
 
+    @Override
+    public void setRegistry(KieServerRegistry registry) {
+        this.context = registry;
+    }
+
+    @Override
+    public KieServerRegistry getRegistry() {
+        return context;
+    }
+
+    @Override
+    public Integer getPriority() {
+        return 100;
+    }
+
+    @Override
+    public boolean supports(String url) {
+        return url != null && url.startsWith("http");
+    }
 
     protected <T> T makeHttpPutRequestAndCreateCustomResponse(String uri, String body, Class<T> resultType, String user, String password, String token) {
         logger.debug("About to send PUT request to '{}' with payload '{}' by thread {}", uri, body, Thread.currentThread().getId());
@@ -323,6 +342,4 @@ public class DefaultRestControllerImpl implements KieServerController {
             }
         }
     }
-
-
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/policy/KeepLatestContainerOnlyPolicy.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/java/org/kie/server/services/impl/policy/KeepLatestContainerOnlyPolicy.java
@@ -88,7 +88,8 @@ public class KeepLatestContainerOnlyPolicy implements Policy {
     @Override
     public void apply(KieServerRegistry kieServerRegistry, KieServer kieServer) {
 
-        DefaultRestControllerImpl controller = new DefaultRestControllerImpl(kieServerRegistry);
+        DefaultRestControllerImpl controller = new DefaultRestControllerImpl();
+        controller.setRegistry(kieServerRegistry);
 
         List<String> containerAliases = kieServerRegistry.getContainerAliases();
         if (containerAliases.isEmpty()) {

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/main/resources/META-INF/services/org.kie.server.controller.api.KieServerController
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/main/resources/META-INF/services/org.kie.server.controller.api.KieServerController
@@ -1,0 +1,1 @@
+org.kie.server.services.impl.controller.DefaultRestControllerImpl

--- a/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/AbstractKieServerImplTest.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-common/src/test/java/org/kie/server/services/impl/AbstractKieServerImplTest.java
@@ -62,11 +62,7 @@ import org.kie.server.api.model.ServiceResponsesList;
 import org.kie.server.api.model.Severity;
 import org.kie.server.controller.api.KieServerController;
 import org.kie.server.controller.api.model.KieServerSetup;
-import org.kie.server.services.api.KieContainerInstance;
-import org.kie.server.services.api.KieControllerNotConnectedException;
-import org.kie.server.services.api.KieServerExtension;
-import org.kie.server.services.api.KieServerRegistry;
-import org.kie.server.services.api.SupportedTransports;
+import org.kie.server.services.api.*;
 import org.kie.server.services.impl.controller.DefaultRestControllerImpl;
 import org.kie.server.services.impl.storage.KieServerState;
 import org.kie.server.services.impl.storage.KieServerStateRepository;
@@ -710,9 +706,10 @@ public abstract class AbstractKieServerImplTest {
 
             @Override
             public KieServerController getController() {
-                return new DefaultRestControllerImpl(getServerRegistry()) {
+                KieServerController controller = new DefaultRestControllerImpl() {
                     @Override
                     public KieServerSetup connect(KieServerInfo serverInfo) {
+                        setRegistry(getServerRegistry());
                         try {
                             if (latch.await(10, TimeUnit.MILLISECONDS)) {
                                 return new KieServerSetup();
@@ -722,8 +719,9 @@ public abstract class AbstractKieServerImplTest {
                             throw new KieControllerNotConnectedException("Unable to connect to any controller");
                         }
                     }
-
                 };
+                ((KieServerRegistryAware)controller).setRegistry(getServerRegistry());
+                return controller;
             }
 
         };

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerCrashIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerCrashIntegrationTest.java
@@ -96,7 +96,7 @@ public class KieControllerCrashIntegrationTest extends KieControllerManagementBa
         if (TestConfig.isLocalServer()) {
             controllerClient = KieServerControllerClientFactory.newWebSocketClient(TestConfig.getControllerWebSocketManagementUrl(),
                                                                               (String) null,
-                                                                              (String) null, 
+                                                                              (String) null,
                                                                               eventHandler);
         } else {
             controllerClient = KieServerControllerClientFactory.newWebSocketClient(TestConfig.getControllerWebSocketManagementUrl(),
@@ -162,7 +162,8 @@ public class KieControllerCrashIntegrationTest extends KieControllerManagementBa
 
         };
         registry.registerStateRepository(dummyKieServerStateRepository);
-        KieServerController controller =  new DefaultRestControllerImpl(registry);
+        DefaultRestControllerImpl controller =  new DefaultRestControllerImpl();
+        controller.setRegistry(registry);
         controller.connect(kieServerInfo);
         // Check that kie server is registered.
         serverUp.await(5, TimeUnit.SECONDS);

--- a/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerValidationIntegrationTest.java
+++ b/kie-server-parent/kie-server-tests/kie-server-integ-tests-controller/src/test/java/org/kie/server/integrationtests/controller/KieControllerValidationIntegrationTest.java
@@ -110,7 +110,8 @@ public class KieControllerValidationIntegrationTest extends KieControllerManagem
         kieServerInfo.setMode(KieServerMode.PRODUCTION);
         kieServerInfo.setName(SERVER_NAME);
 
-        KieServerController controller = new DefaultRestControllerImpl(registry);
+        DefaultRestControllerImpl controller = new DefaultRestControllerImpl();
+        controller.setRegistry(registry);
         assertThatThrownBy(() -> controller.connect(kieServerInfo)).isInstanceOf(KieControllerNotConnectedException.class);
 
         // Check that kie server is not registered.
@@ -151,7 +152,8 @@ public class KieControllerValidationIntegrationTest extends KieControllerManagem
         KieServerRegistry registry = new KieServerRegistryImpl();
 
         registry.registerStateRepository(dummyKieServerStateRepository);
-        KieServerController controller = new DefaultRestControllerImpl(registry);
+        DefaultRestControllerImpl controller = new DefaultRestControllerImpl();
+        controller.setRegistry(registry);
         KieServerSetup setup = controller.connect(kieServerInfo);
         Assert.assertTrue(setup.hasNoErrors());
 


### PR DESCRIPTION
Currently the implementation of KieServerController getController() in KieServerImpl uses the default, or the first class loaded through the ServiceLoader. This makes it difficult to override, especially as the WebSocket implementation is usually present.

This change allows multiple implementations to exist, and when they do, they are checked to see if they are supported, and are of a higher priority. The default is not instantiated automatically as this is always available to the ServiceLoader.

This change is designed to mirror the KieServicesClientProvider. However, the change could not be applied to the KieServerController interface as that is also used elsewhere in the kie-server (for example org.kie.server.controller.websocket.WebSocketKieServerControllerImpl)