### PR TITLE
[7.67.x-blue] Correcting parent to 7.67.2-SNAPSHOT in kie-maven-project-example pom.xml

### DIFF
--- a/kie-maven-project-example/pom.xml
+++ b/kie-maven-project-example/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.drools</groupId>
     <artifactId>droolsjbpm-integration</artifactId>
-    <version>7.68.0-SNAPSHOT</version>
+    <version>7.67.2-SNAPSHOT</version>
   </parent>
 
   <groupId>org.kie</groupId>


### PR DESCRIPTION
The current kie-maven-project-example pom.xml had parent as 7.68.0-SNAPSHOT.
Corrected it to the right one