### PR TITLE
Updating Tomcat to latest v9 CVE related

### DIFF
--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration/pom.xml
@@ -51,6 +51,12 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-annotations-api</artifactId>
+        </exclusion>
+      </exclusions>
       <scope>compile</scope>
     </dependency>
 

--- a/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-autoconfiguration/kie-server-spring-boot-autoconfiguration/pom.xml
@@ -27,10 +27,33 @@
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
 
+    <!-- Spring Boot v2 has no updates, but the tomcat version it uses has multiple CVEs -->
+    <!-- For this reason, we're going to include our own version of tomcat and exclude what it brings in -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-websocket</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-websocket</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>

--- a/kie-spring-boot/kie-spring-boot-samples/jbpm-spring-boot-sample-basic/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-samples/jbpm-spring-boot-sample-basic/pom.xml
@@ -74,6 +74,12 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-annotations-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
 

--- a/kie-spring-boot/kie-spring-boot-samples/jbpm-spring-boot-sample-basic/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-samples/jbpm-spring-boot-sample-basic/pom.xml
@@ -39,10 +39,20 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- Spring Boot v2 has no updates, but the tomcat version it uses has multiple CVEs -->
+    <!-- For this reason, we're going to include our own version of tomcat and exclude what it brings in -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
       <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-websocket</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.apache.tomcat.embed</groupId>
           <artifactId>tomcat-embed-el</artifactId>
@@ -57,6 +67,15 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-websocket</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+    </dependency>
+
 
     <!-- test dependencies -->
     <dependency>

--- a/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter-drools/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter-drools/pom.xml
@@ -34,6 +34,12 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-annotations-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter-drools/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter-drools/pom.xml
@@ -11,10 +11,31 @@
   <description>Drools and DMN - KIE Server SpringBoot Starter</description>
   
   <dependencies>
+    <!-- Spring Boot v2 has no updates, but the tomcat version it uses has multiple CVEs -->
+    <!-- For this reason, we're going to include our own version of tomcat and exclude what it brings in -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-websocket</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-websocket</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-spring-boot-starter-jaxrs</artifactId>

--- a/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter-jbpm/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter-jbpm/pom.xml
@@ -13,10 +13,20 @@
   <description>jBPM and Case management - KIE Server SpringBoot Starter</description>
 
   <dependencies>
+    <!-- Spring Boot v2 has no updates, but the tomcat version it uses has multiple CVEs -->
+    <!-- For this reason, we're going to include our own version of tomcat and exclude what it brings in -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
       <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-websocket</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.apache.tomcat</groupId>
           <artifactId>tomcat-annotations-api</artifactId>
@@ -27,6 +37,15 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-websocket</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-jdbc</artifactId>

--- a/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter-jbpm/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter-jbpm/pom.xml
@@ -44,6 +44,12 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-annotations-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter/pom.xml
@@ -45,6 +45,12 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat</groupId>
+          <artifactId>tomcat-annotations-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter/pom.xml
+++ b/kie-spring-boot/kie-spring-boot-starters/kie-server-spring-boot-starter/pom.xml
@@ -13,11 +13,21 @@
   <description>KIE Server SpringBoot Starter</description>
 
 
-  <dependencies>
+  <dependencies> 
+    <!-- Spring Boot v2 has no updates, but the tomcat version it uses has multiple CVEs -->
+    <!-- For this reason, we're going to include our own version of tomcat and exclude what it brings in -->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
       <exclusions>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-core</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.tomcat.embed</groupId>
+          <artifactId>tomcat-embed-websocket</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.apache.tomcat</groupId>
           <artifactId>tomcat-annotations-api</artifactId>
@@ -28,6 +38,15 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-websocket</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-jdbc</artifactId>

--- a/kie-spring-boot/pom.xml
+++ b/kie-spring-boot/pom.xml
@@ -120,6 +120,12 @@
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-core</artifactId>
         <version>${version.org.apache.tomcat}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-annotations-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.tomcat.embed</groupId>

--- a/kie-spring-boot/pom.xml
+++ b/kie-spring-boot/pom.xml
@@ -93,20 +93,32 @@
         </exclusions>
       </dependency>
 
+      
+      <!-- Spring Boot v2 has no updates, but the tomcat version it uses has multiple CVEs -->
+      <!-- For this reason, we're going to include our own version of tomcat and exclude what it brings in -->
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-web</artifactId>
         <version>${version.org.springframework.boot}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.tomcat.embed</groupId>
-        <artifactId>tomcat-embed-core</artifactId>
-        <version>${version.org.apache.tomcat}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-websocket</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${version.org.apache.tomcat}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
         <version>${version.org.apache.tomcat}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
We can't easily go to 10 or 11 because of javaee -> jakarta issues