### PR TITLE
Override dom4j library version in xstream-hibernate library

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm/pom.xml
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm/pom.xml
@@ -178,7 +178,15 @@
           <groupId>org.glassfish.jaxb</groupId>
           <artifactId>jaxb-runtime</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>dom4j</groupId>
+          <artifactId>dom4j</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.dom4j</groupId>
+      <artifactId>dom4j</artifactId>
     </dependency>
     <!-- TEST -->
     <dependency>


### PR DESCRIPTION
This PR overrides the version of dom4j library in xstream-hibernate library. It aligns the version with the version we use in global. 