### PR TITLE
feature/masked input field

### DIFF
--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/AbstractFormRenderer.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/AbstractFormRenderer.java
@@ -114,6 +114,7 @@ public abstract class AbstractFormRenderer implements FormRenderer {
         this.inputTypes.put("DocumentCollection", "documentCollection");
         this.inputTypes.put("MultipleSelector", "multipleSelector");
         this.inputTypes.put("MultipleInput", "multipleInput");
+        this.inputTypes.put("MaskedTextBox", "text");
 
         
         cfg = new Configuration(Configuration.VERSION_2_3_26);
@@ -414,6 +415,16 @@ public abstract class AbstractFormRenderer implements FormRenderer {
                             item.setPrecision(field.getPrecision());
                             item.setStep(field.getStep());
                             item.setShowTime(field.isShowTime());
+                            
+                            // Set MaskedTextBox specific properties if this is a MaskedTextBox field
+                            if ("MaskedTextBox".equals(field.getCode())) {
+                                item.setMinLength(field.getMinLength());
+                                item.setMaskingCharacter(field.getMaskingCharacter());
+                                item.setMaskingStartIndex(field.getMaskingStartIndex());
+                                item.setMaskingFromStartLength(field.getMaskingFromStartLength());
+                                item.setMaskingFromEndLength(field.getMaskingFromEndLength());
+                                item.setIsMaskedInDB(field.getIsMaskedInDB());
+                            }
 
                             Object value = "";
                             if (inputs.get(field.getBinding()) != null) {

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/AbstractFormRenderer.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/AbstractFormRenderer.java
@@ -419,6 +419,7 @@ public abstract class AbstractFormRenderer implements FormRenderer {
                             // Set MaskedTextBox specific properties if this is a MaskedTextBox field
                             if ("MaskedTextBox".equals(field.getCode())) {
                                 item.setMinLength(field.getMinLength());
+                                item.setMaxLength(field.getMaxLength());
                                 item.setMaskingCharacter(field.getMaskingCharacter());
                                 item.setMaskingStartIndex(field.getMaskingStartIndex());
                                 item.setMaskingFromStartLength(field.getMaskingFromStartLength());

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/model/FormField.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/model/FormField.java
@@ -66,6 +66,14 @@ public class FormField {
     private String editionForm;
 
     private boolean showTime;
+    
+    // MaskedTextBox specific properties
+    private Integer minLength;
+    private String maskingCharacter;
+    private Integer maskingStartIndex;
+    private Integer maskingFromStartLength;
+    private Integer maskingFromEndLength;
+    private Boolean isMaskedInDB;
 
     public boolean isShowTime() {
         return showTime;
@@ -243,4 +251,52 @@ public class FormField {
         return tags;
     }
 
+    // MaskedTextBox getters and setters
+    public Integer getMinLength() {
+        return minLength;
+    }
+
+    public void setMinLength(Integer minLength) {
+        this.minLength = minLength;
+    }
+
+    public String getMaskingCharacter() {
+        return maskingCharacter;
+    }
+
+    public void setMaskingCharacter(String maskingCharacter) {
+        this.maskingCharacter = maskingCharacter;
+    }
+
+    public Integer getMaskingStartIndex() {
+        return maskingStartIndex;
+    }
+
+    public void setMaskingStartIndex(Integer maskingStartIndex) {
+        this.maskingStartIndex = maskingStartIndex;
+    }
+
+    public Integer getMaskingFromStartLength() {
+        return maskingFromStartLength;
+    }
+
+    public void setMaskingFromStartLength(Integer maskingFromStartLength) {
+        this.maskingFromStartLength = maskingFromStartLength;
+    }
+
+    public Integer getMaskingFromEndLength() {
+        return maskingFromEndLength;
+    }
+
+    public void setMaskingFromEndLength(Integer maskingFromEndLength) {
+        this.maskingFromEndLength = maskingFromEndLength;
+    }
+
+    public Boolean getIsMaskedInDB() {
+        return isMaskedInDB;
+    }
+
+    public void setIsMaskedInDB(Boolean isMaskedInDB) {
+        this.isMaskedInDB = isMaskedInDB;
+    }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/model/LayoutItem.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/model/LayoutItem.java
@@ -44,6 +44,14 @@ public class LayoutItem {
     private String pattern;
 
     private List<ItemOption> options;
+    
+    // MaskedTextBox specific properties
+    private Integer minLength;
+    private String maskingCharacter;
+    private Integer maskingStartIndex;
+    private Integer maskingFromStartLength;
+    private Integer maskingFromEndLength;
+    private Boolean isMaskedInDB;
 
     public boolean isShowTime() {
         return showTime;
@@ -181,4 +189,52 @@ public class LayoutItem {
         this.pattern = pattern;
     }
 
+    // MaskedTextBox getters and setters
+    public Integer getMinLength() {
+        return minLength;
+    }
+
+    public void setMinLength(Integer minLength) {
+        this.minLength = minLength;
+    }
+
+    public String getMaskingCharacter() {
+        return maskingCharacter;
+    }
+
+    public void setMaskingCharacter(String maskingCharacter) {
+        this.maskingCharacter = maskingCharacter;
+    }
+
+    public Integer getMaskingStartIndex() {
+        return maskingStartIndex;
+    }
+
+    public void setMaskingStartIndex(Integer maskingStartIndex) {
+        this.maskingStartIndex = maskingStartIndex;
+    }
+
+    public Integer getMaskingFromStartLength() {
+        return maskingFromStartLength;
+    }
+
+    public void setMaskingFromStartLength(Integer maskingFromStartLength) {
+        this.maskingFromStartLength = maskingFromStartLength;
+    }
+
+    public Integer getMaskingFromEndLength() {
+        return maskingFromEndLength;
+    }
+
+    public void setMaskingFromEndLength(Integer maskingFromEndLength) {
+        this.maskingFromEndLength = maskingFromEndLength;
+    }
+
+    public Boolean getIsMaskedInDB() {
+        return isMaskedInDB;
+    }
+
+    public void setIsMaskedInDB(Boolean isMaskedInDB) {
+        this.isMaskedInDB = isMaskedInDB;
+    }
 }

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/model/LayoutItem.java
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/java/org/kie/server/services/jbpm/ui/form/render/model/LayoutItem.java
@@ -47,6 +47,7 @@ public class LayoutItem {
     
     // MaskedTextBox specific properties
     private Integer minLength;
+    private Long maxLength;
     private String maskingCharacter;
     private Integer maskingStartIndex;
     private Integer maskingFromStartLength;
@@ -196,6 +197,14 @@ public class LayoutItem {
 
     public void setMinLength(Integer minLength) {
         this.minLength = minLength;
+    }
+
+    public Long getMaxLength() {
+        return maxLength;
+    }
+
+    public void setMaxLength(Long maxLength) {
+        this.maxLength = maxLength;
     }
 
     public String getMaskingCharacter() {

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/resources/form-templates-providers/patternfly/input-form-group-template.html
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/resources/form-templates-providers/patternfly/input-form-group-template.html
@@ -168,6 +168,7 @@
 	       placeholder="${item.placeHolder}" value="${item.value}" pattern="${item.pattern}" 
 	       data-field-type="MaskedTextBox"
 	       <#if item.minLength??>minlength="${item.minLength}"</#if>
+	       <#if item.maxLength??>maxlength="${item.maxLength}"</#if>
 	       <#if item.maskingCharacter??>data-masking-character="${item.maskingCharacter}"</#if>
 	       <#if item.maskingStartIndex??>data-masking-start-index="${item.maskingStartIndex}"</#if>
 	       <#if item.maskingFromStartLength??>data-masking-from-start-length="${item.maskingFromStartLength}"</#if>

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/resources/form-templates-providers/patternfly/input-form-group-template.html
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/resources/form-templates-providers/patternfly/input-form-group-template.html
@@ -158,6 +158,23 @@
 	</#if>
     <input id="${item.id}" data-slider-id='${item.id}Slider' data-slider-value="${item.value}" name="${item.name}" data-slider-min="${item.min}" data-slider-max="${item.max}" data-slider-step="${item.step}" type="text" class="form-control" value="${item.value}" ${(item.required)?string('required', '')} data-slider-tooltip="hide" data-slider-handle="triangle" style="width: 100%;"/>    
 </div>
+<#elseif item.type == "text" && item.maskingCharacter??>
+<div class="form-group">
+	<label for="${item.id}">${item.label}</label> 
+	<#if item.required>
+	<strong style="color: red">*</strong>
+	</#if>
+	<input name="${item.name}" type="text" class="form-control masked-input-text-field" id="${item.id}" 
+	       placeholder="${item.placeHolder}" value="${item.value}" pattern="${item.pattern}" 
+	       data-field-type="MaskedTextBox"
+	       <#if item.minLength??>minlength="${item.minLength}"</#if>
+	       <#if item.maskingCharacter??>data-masking-character="${item.maskingCharacter}"</#if>
+	       <#if item.maskingStartIndex??>data-masking-start-index="${item.maskingStartIndex}"</#if>
+	       <#if item.maskingFromStartLength??>data-masking-from-start-length="${item.maskingFromStartLength}"</#if>
+	       <#if item.maskingFromEndLength??>data-masking-from-end-length="${item.maskingFromEndLength}"</#if>
+	       <#if item.isMaskedInDB??>data-is-masked-in-db="${item.isMaskedInDB?c}"</#if>
+	       ${(item.readOnly)?string('readonly', '')} ${(item.required)?string('required', '')}>
+</div>
 <#else>
 <div class="form-group">
 	<label for="${item.id}">${item.label}</label> 

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/resources/form-templates-providers/patternfly/js/masked-textbox.js
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/resources/form-templates-providers/patternfly/js/masked-textbox.js
@@ -1,0 +1,161 @@
+/**
+ * MaskedTextBox functionality for jBPM forms
+ * Based on Business Central masked-input.js implementation
+ * Handles client-side masking of text input values
+ */
+(function() {
+    'use strict';
+
+    // Initialize masked input fields when the page loads
+    document.addEventListener('DOMContentLoaded', function() {
+        initializeMaskedInputFields();
+    });
+
+    // Also initialize when new content is added dynamically
+    if (typeof MutationObserver !== 'undefined') {
+        var observer = new MutationObserver(function(mutations) {
+            mutations.forEach(function(mutation) {
+                if (mutation.type === 'childList') {
+                    mutation.addedNodes.forEach(function(node) {
+                        if (node.nodeType === 1) { // Element node
+                            initializeMaskedInputFields(node);
+                        }
+                    });
+                }
+            });
+        });
+        
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+    }
+
+    function initializeMaskedInputFields(container) {
+        container = container || document;
+        
+        // Find all input fields that should be masked
+        var inputs = container.querySelectorAll('input[data-field-type="MaskedTextBox"], input.masked-input-text-field, input.masked-textbox');
+        
+        inputs.forEach(function(input) {
+            if (!input.hasAttribute('data-masked-initialized')) {
+                setupMaskedInput(input);
+                input.setAttribute('data-masked-initialized', 'true');
+            }
+        });
+    }
+
+    function setupMaskedInput(input) {
+        var originalValue = input.value || '';
+        var isMasked = false;
+        
+        // Get masking configuration from data attributes
+        var maskingCharacter = input.getAttribute('data-masking-character') || input.getAttribute('data-masking-char') || '*';
+        var maskingStartIndexAttr = input.getAttribute('data-masking-start-index');
+        var maskingStartIndex = maskingStartIndexAttr !== null ? parseInt(maskingStartIndexAttr) : null;
+        var maskingFromStartLengthAttr = input.getAttribute('data-masking-from-start-length');
+        var maskingFromStartLength = maskingFromStartLengthAttr !== null ? parseInt(maskingFromStartLengthAttr) : null;
+        var maskingFromEndLengthAttr = input.getAttribute('data-masking-from-end-length');
+        var maskingFromEndLength = maskingFromEndLengthAttr !== null ? parseInt(maskingFromEndLengthAttr) : null;
+        var isMaskedInDB = input.getAttribute('data-is-masked-in-db') === 'true' || input.getAttribute('data-masked-in-db') === 'true';
+        
+        // Apply initial masking if configured
+        if (originalValue && (isMaskedInDB || input.readOnly)) {
+            input.value = applyMasking(originalValue, maskingCharacter, maskingStartIndex, maskingFromStartLength, maskingFromEndLength);
+            isMasked = true;
+            input.classList.add('masked');
+        }
+        
+        // Store original value
+        input.setAttribute('data-original-value', originalValue);
+        
+        // Add event listeners
+        input.addEventListener('focus', function() {
+            if (!input.readOnly) {
+                showOriginalValue();
+            }
+        });
+        
+        input.addEventListener('blur', function() {
+            if (!input.readOnly) {
+                applyMaskingToInput();
+            }
+        });
+        
+        input.addEventListener('input', function() {
+            if (!input.readOnly) {
+                // Update stored original value
+                input.setAttribute('data-original-value', input.value);
+            }
+        });
+        
+        // Handle form submission to send original value if needed
+        var form = input.closest('form');
+        if (form) {
+            form.addEventListener('submit', function() {
+                if (!isMaskedInDB) {
+                    // Send unmasked value to server
+                    input.value = input.getAttribute('data-original-value') || '';
+                }
+            });
+        }
+        
+        function showOriginalValue() {
+            var original = input.getAttribute('data-original-value');
+            if (original) {
+                input.value = original;
+                isMasked = false;
+                input.classList.remove('masked');
+                input.classList.add('unmasked');
+            }
+        }
+        
+        function applyMaskingToInput() {
+            var original = input.getAttribute('data-original-value');
+            if (original) {
+                input.value = applyMasking(original, maskingCharacter, maskingStartIndex, maskingFromStartLength, maskingFromEndLength);
+                isMasked = true;
+                input.classList.add('masked');
+                input.classList.remove('unmasked');
+            }
+        }
+    }
+
+    function applyMasking(value, maskingCharacter, maskingStartIndex, maskingFromStartLength, maskingFromEndLength) {
+        if (!value) {
+            return value;
+        }
+        
+        var maskedValue = value;
+        
+        // Apply masking from start index
+        if (maskingStartIndex !== null && maskingStartIndex !== undefined && maskingFromStartLength !== null && maskingFromStartLength !== undefined) {
+            var startIndex = Math.min(maskingStartIndex, value.length);
+            var endIndex = Math.min(startIndex + maskingFromStartLength, value.length);
+            
+            maskedValue = value.substring(0, startIndex) + 
+                         maskingCharacter.repeat(endIndex - startIndex) + 
+                         value.substring(endIndex);
+        }
+        
+        // Apply masking from end
+        if (maskingFromEndLength !== null && maskingFromEndLength !== undefined && maskingFromEndLength > 0) {
+            var startIndex = Math.max(0, maskedValue.length - maskingFromEndLength);
+            maskedValue = maskedValue.substring(0, startIndex) + 
+                         maskingCharacter.repeat(maskedValue.length - startIndex);
+        }
+        
+        return maskedValue;
+    }
+
+    // Expose functions globally for manual initialization
+    window.initializeMaskedInputFields = initializeMaskedInputFields;
+    window.MaskedTextBox = {
+        applyMasking: applyMasking,
+        initializeMaskedInputFields: initializeMaskedInputFields,
+        reinitialize: function() {
+            initializeMaskedInputFields();
+        }
+    };
+
+})();

--- a/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/resources/form-templates-providers/patternfly/main-template.html
+++ b/kie-server-parent/kie-server-services/kie-server-services-jbpm-ui/src/main/resources/form-templates-providers/patternfly/main-template.html
@@ -32,6 +32,7 @@
 	<script src="${serverPath}/bootstrap/js/bootstrap-tagsinput.js"></script>
 	<script src="${serverPath}/js/forms.js"></script>
 	<script src="${serverPath}/js/kieserver-ui.js"></script>
+	<script src="${serverPath}/patternfly/js/masked-textbox.js"></script>
 	<script>
 		${scriptData}
 	</script>


### PR DESCRIPTION
## Description

This PR adds comprehensive support for custom MaskedTextBox form fields in KIE Server REST API responses, enabling full feature parity with Business Central UI.

### New Functionality Added

#### 1. JSON API Support for MaskedTextBox Fields
- MaskedTextBox fields now appear in JSON responses from KIE Server REST API endpoints
- Full property support including `minLength`, `maxLength`, `maskingCharacter`, `maskingStartIndex`, `maskingFromStartLength`, `maskingFromEndLength`, `isMaskedInDB`

#### 2. HTML API Support for MaskedTextBox Fields  
- MaskedTextBox fields render correctly in HTML responses from KIE Server REST API endpoints
- Interactive masking behavior matching Business Central UI functionality
- Proper HTML attributes and client-side JavaScript for masking operations

#### 3. Complete Property Support
- All MaskedTextBox properties are now supported in KIE Server responses
- Proper data flow from form definitions to both JSON and HTML outputs
- Consistent behavior between Business Central UI and KIE Server APIs

### Technical Implementation

#### Backend Enhancements
- **FormField.java**: Extended with MaskedTextBox-specific properties
- **LayoutItem.java**: Added MaskedTextBox property support for HTML rendering
- **AbstractFormRenderer.java**: 
  - Added MaskedTextBox field type mapping
  - Implemented property extraction and assignment logic
- **Service Provider**: Configured proper field provider discovery

#### Frontend Enhancements
- **input-form-group-template.html**: Specialized MaskedTextBox rendering with HTML attributes
- **masked-textbox.js**: Client-side masking implementation with focus/blur/input event handling
- **main-template.html**: Script integration for masking functionality

### Benefits
- Complete feature parity between Business Central UI and KIE Server APIs
- Consistent MaskedTextBox behavior across all jBPM interfaces
- Enhanced data privacy protection in REST API responses
- Improved developer experience with unified form field support

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.74.1.Final` to backport the original PR to the `7.74.1.Final` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>